### PR TITLE
Fix a bug to create directories

### DIFF
--- a/src/main/java/oss/fosslight/util/FileUtil.java
+++ b/src/main/java/oss/fosslight/util/FileUtil.java
@@ -320,7 +320,11 @@ public class FileUtil {
             // opens input stream from the HTTP connection
             InputStream inputStream = httpConn.getInputStream();
             String saveFilePath = saveDir + File.separator + fileName;
-             
+
+            if(!Files.exists(Paths.get(saveDir))) {
+                Files.createDirectories(Paths.get(saveDir));
+            }
+
             // opens an output stream to save into file
             FileOutputStream outputStream = new FileOutputStream(saveFilePath);
  
@@ -416,7 +420,7 @@ public class FileUtil {
 			Path movePath = Paths.get(destPath);
 			
 			if(!Files.exists(movePath)) {
-				Files.createDirectory(movePath);
+				Files.createDirectories(movePath);
 			}
 			
 			if(Files.exists(zipPath)) {


### PR DESCRIPTION
## Description
Fix a bug to create nvd directories.

## About a bug
- An error occurs when creating related folders during NVD Data Sync.
 ```
ERROR [NvdDataService.java, executeNvdDataSync():64] - /data/fosslight/nvd/cve/nvdcpematch-1.0.json.zip (No such file or directory)
java.io.FileNotFoundException: /data/fosslight/nvd/cve/nvdcpematch-1.0.json.zip (No such file or directory)
	at java.io.FileOutputStream.open0(Native Method)
	at java.io.FileOutputStream.open(FileOutputStream.java:270)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:101)
	at oss.fosslight.util.FileUtil.downloadFile(FileUtil.java:325)
	at oss.fosslight.service.NvdDataService.nvdFeedDataDownloadJob(NvdDataService.java:437)
	at oss.fosslight.service.NvdDataService.executeNvdDataSync(NvdDataService.java:60)
	at oss.fosslight.scheduler.SchedulerWorkerTask.nvdDataIfJob(SchedulerWorkerTask.java:93)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	at org.springframework.scheduling.concurrent.ReschedulingRunnable.run(ReschedulingRunnable.java:93)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
2021-07-31 08:30:02.747 129944 [taskScheduler-1] ERROR [SchedulerWorkerTask.java, nvdDataIfJob():99] - executeNvdDataSync - resCd : 91

```


## Type of change
Please insert 'x' one of the type of change.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
