### PR TITLE
Remove warning message

### DIFF
--- a/src/main/java/oss/fosslight/scheduler/SchedulerWorkerTask.java
+++ b/src/main/java/oss/fosslight/scheduler/SchedulerWorkerTask.java
@@ -21,7 +21,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.scheduling.annotation.Scheduled;
 
-import lombok.extern.slf4j.Slf4j;
 import oss.fosslight.CoTopComponent;
 import oss.fosslight.common.CoConstDef;
 import oss.fosslight.common.CommonFunction;
@@ -32,7 +31,6 @@ import oss.fosslight.service.OssService;
 import oss.fosslight.service.impl.VulnerabilityServiceImpl;
 import oss.fosslight.util.FileUtil;
 
-@Slf4j
 public class SchedulerWorkerTask extends CoTopComponent {
 	final static Logger log = LoggerFactory.getLogger("SCHEDULER_LOG");
 	

--- a/src/main/java/oss/fosslight/service/NvdDataService.java
+++ b/src/main/java/oss/fosslight/service/NvdDataService.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import lombok.extern.slf4j.Slf4j;
 import oss.fosslight.common.CommonFunction;
 import oss.fosslight.repository.NvdDataMapper;
 import oss.fosslight.util.DateUtil;
@@ -37,7 +36,6 @@ import oss.fosslight.util.FileUtil;
 import oss.fosslight.util.StringUtil;
 
 @Service("NvdDataService")
-@Slf4j
 public class NvdDataService {
 	final static Logger log = LoggerFactory.getLogger("SCHEDULER_LOG");
 	


### PR DESCRIPTION
## Description
* Remove the warning message "Field 'log' already exists."
* Delete ```@slf4j``` Annotation in SchedulerWorkerTask.java, NvdDataService.java
* Delete ```import lombok.extern.slf4j.slf4j;```

## Type of change
Please insert 'x' one of the type of change.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
