### PR TITLE
Update .gitignore to ignore personal data folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ out/
 .vscode/
 /bin/
 /logs/
+
+### Ignore personal data folders ###
+/web-data/
+/db/data/


### PR DESCRIPTION
## Description
docker-compose automatically generate db/data folder(for mariadb) and web-data folder(for web).
That folders are unreleated to project because They are personal data.
So add folders name to .gitignore
- Issue number #30 
## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)