### PR TITLE
Fix Timezone to Asia/Seoul

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
          - 8180:8180
        volumes:
          - ./web-data:/data/fosslight
+       environment:
+         TZ: Asia/Seoul
        command: sh -c "./wait-for db:3306 -t 120 && java -jar FOSSLight.war --root.dir=/data/fosslight 
                --server.port=8180
                --spring.datasource.url=db:3306/fosslight


### PR DESCRIPTION
Signed-off-by: YoungHo Choi <0505zxc@gmail.com>

## Description
- Docker use default timezone from UTC. so I fixed timezone to Asia/Seoul like timezone of db container.

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
