### PR TITLE
FIx typo 'website' in UI

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/license/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/license/list-js.jsp
@@ -165,7 +165,7 @@
 					total:function(obj){return obj.total;},
 					records:function(obj){return obj.records;}
 				},
-				colNames: ['ID','License Name', 'Identifier', 'License Type', 'Restriction', 'Obligation', 'Web site', 'User Guide'<c:if test="${ct:isAdmin()}">, 'Creator', 'Created Date', 'Modifier', 'Modified Date'</c:if>],
+				colNames: ['ID','License Name', 'Identifier', 'License Type', 'Restriction', 'Obligation', 'Website', 'User Guide'<c:if test="${ct:isAdmin()}">, 'Creator', 'Created Date', 'Modifier', 'Modified Date'</c:if>],
 				colModel: [
 					  {name: 'licenseId', index: 'licenseId', width: 40, align: 'center', sorttype: 'int'}
 					, {name: 'licenseName', index: 'licenseName', width: 200, align: 'left', formatter: 'linkLicenseName'}

--- a/src/main/webapp/WEB-INF/views/admin/license/list.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/license/list.jsp
@@ -42,7 +42,7 @@
 						<textarea name="description" >${searchBean.description}</textarea>
 					</dd>
 					<dd>
-						<label>WebSite</label>
+						<label>Website</label>
 						<input name="webpage" type="text" value="${searchBean.webpage}"/>
 					</dd>
 					<dd>

--- a/src/main/webapp/WEB-INF/views/admin/oss/list.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/list.jsp
@@ -32,7 +32,7 @@
 						<textarea name="summaryDescription">${searchBean.summaryDescription}</textarea>
 					</dd>
 					<dd>
-						<label>WebSite</label>
+						<label>Website</label>
 						<input name="homepage" type="text" value="${searchBean.homepage}"/>
 					</dd>
 					<dd>

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/viewpopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/viewpopup.jsp
@@ -98,7 +98,7 @@
 									repeatitems: false,
 									id: 'licenseId',
 								},
-								colNames: ['ID','License Name','Identifier','License Type','Obligation','Restriction','Web site','Nick Name','License Text'],
+								colNames: ['ID','License Name','Identifier','License Type','Obligation','Restriction','Website','Nick Name','License Text'],
 								colModel: [
 									{name: 'licenseId', index: 'licenseId', key:true, hidden:true},
 									{name: 'licenseName', index: 'licenseName', width: 200, align: 'left'},


### PR DESCRIPTION
## Description
- Fix Typo 'WebSite' to 'Website' in listSearch field.
- Fix Typo 'Web site' to 'Website' in list column name.

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
