### PR TITLE
Add to show docker-compose log in github-actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,8 +21,14 @@ jobs:
           time: '30s'
       - name: Check running containers
         run: docker-compose ps
+      - name: Save docker-compose logs
+        run: docker-compose logs --no-color web > docker-compose-web.log && docker-compose logs --no-color db > docker-compose-db.log
       - name: Check the site
         run: docker run --network container:fosslight_web appropriate/curl -s --retry 3 --retry-connrefused http://localhost:8180/session/login
       - name: Stop containers
         if: always()
         run: docker-compose down
+      - name: Show db container log
+        run: cat docker-compose-db.log
+      - name: Show web container log
+        run: cat docker-compose-web.log


### PR DESCRIPTION
## Description
* Save docker-compose log as docker-compose-web.log and docker-compose-db.log respectively.
* It shows the saved log file in the final step of github actions.

### before

![스크린샷 2021-08-12 오후 5 49 45](https://user-images.githubusercontent.com/32615702/129167790-37a47619-8d33-43ba-bee0-151840b3d446.png)


### after
* add Save docker-compose logs sequence
* add Show db container log sequence
* add Show web container log sequence

![스크린샷 2021-08-12 오후 8 31 08](https://user-images.githubusercontent.com/32615702/129189722-03ed93b0-35cc-485b-8ebe-769a309822a1.png)

### Reference
* https://github.com/fosslight/fosslight/runs/3309800143?check_suite_focus=true
* https://stackoverflow.com/questions/35414495/save-docker-compose-logs-to-a-file

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
