### PR TITLE
Add License Type option for OSS List search

### DIFF
--- a/src/main/resources/oss/fosslight/repository/OssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/OssMapper.xml
@@ -592,6 +592,9 @@
         <if test="@oss.fosslight.util.StringUtil@equalsIgnoreCase(deactivateFlag,'Y')">
 			AND T1.DEACTIVATE_FLAG = #{deactivateFlag}
 		</if>
+		<if test="!@oss.fosslight.util.StringUtil@isEmpty(licenseType)">
+			AND T1.LICENSE_TYPE = #{licenseType}
+		</if>
 		<if test="@oss.fosslight.util.StringUtil@notEquals(versionCheck,'N')">
 		GROUP BY T1.OSS_NAME
 		</if>

--- a/src/main/webapp/WEB-INF/views/admin/oss/list.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/list.jsp
@@ -43,7 +43,7 @@
 				</dl>
 				<c:if test="${ct:isAdmin()}">
 				<input type="button" value="Admin Expand apply" class="btnExpand" />
-				<dl class="adminSearch" style="display:none;">
+				<dl class="adminSearch" style="display:none; height: 70px;">
 					<dt style="width:20px;"></dt>
 					<dd>
 						<label>Creator</label>
@@ -74,6 +74,17 @@
 						<label>Modified Date</label>
 						<input name="mStartDate" id="mStartDate" type="text" class="cal" title="Search Start Date" value="${searchBean.mStartDate}" maxlength="8"/> ~ 
 						<input name="mEndDate" id="mEndDate" type="text" class="cal" title="Search End Date" value="${searchBean.mEndDate}" maxlength="8"/> 
+					</dd>
+					<dt style="width:20px;"></dt>
+					<dd style="padding-top: 6px;">
+						<label>License Type</label>
+						<span class="selectSet" style="width: 257px;">
+							<strong for="licenseType" title="selected value"></strong>
+							<select id="licenseType" name="licenseType">
+								<option></option>
+								${ct:genOption(ct:getConstDef("CD_LICENSE_TYPE"))}
+							</select>
+						</span>
 					</dd>
 				</dl>
 				</c:if>


### PR DESCRIPTION
## Description
Add License Type option for OSS List search
1. Add License Type select box in list.jsp
2.  Add AND operator clause for License Type in OssMapper.xml
<img width="1059" alt="스크린샷 2021-08-17 오후 9 25 15" src="https://user-images.githubusercontent.com/80666066/129725308-c7d41413-a194-4947-a90d-e363a853f80a.png">


## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
