### PR TITLE
Enhancement function : Recommend the OSS Name according to the OSS Naming Rule

### DIFF
--- a/db/initdb.d/fosslight_create.sql
+++ b/db/initdb.d/fosslight_create.sql
@@ -2247,6 +2247,8 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('903', '002', 'www.npmjs.com/package/', '', 'npm url', 2, 'Y'),
 	('903', '003', 'pypi.org/project/', '', 'pypi url', 3, 'Y'),
 	('903', '004', 'mvnrepository.com/artifact/', '', 'maven url', 4, 'Y'),
+	('903', '005', 'pub.dev/packages/', '', 'pub url', 5, 'Y'),
+	('903', '006', 'cocoapods.org/pods/', '', 'cocoapods url', 6, 'Y'),
 	('904', '100', 'server url', '', '180', 1, 'Y'),
 	('904', '200', 'download url', '', '180', 2, 'Y'),
 	('905', '100', 'idleTime', '', '180', 1, 'Y'),

--- a/src/main/java/oss/fosslight/domain/ProjectIdentification.java
+++ b/src/main/java/oss/fosslight/domain/ProjectIdentification.java
@@ -311,6 +311,9 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	
 	private String attribution;
 
+	/** Check whether the Object is included in the oss list */
+	private String checkOssList = "N";
+
 	public String getGuireportFlag() {
 		return guireportFlag;
 	}
@@ -335,6 +338,24 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 
 	public void setObligationMsg(String obligationMsg) {
 		this.obligationMsg = obligationMsg;
+	}
+
+	/**
+	 * Gets the check oss list.
+	 *
+	 * @return the check oss list
+	 */
+	public String getCheckOssList(){
+		return checkOssList;
+	}
+
+	/**
+	 * Sets the check oss list.
+	 *
+	 * @param checkOssList the new check oss list
+	 */
+	public void setCheckOssList(String checkOssList){
+		this.checkOssList = checkOssList;
 	}
 
 	/**

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -1643,7 +1643,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 							break;
 						case 3: // maven
 							p = Pattern.compile("((http|https)://mvnrepository.com/artifact/([^/]+)/([^/]+))");
-							
+
+							break;
+						case 4: // pub
+							p = Pattern.compile("((http|https)://pub.dev/packages/([^/]+))");
+
+							break;
+						case 5: // cocoapods
+							p = Pattern.compile("((http|https)://cocoapods.org/pods/([^/]+))");
+
 							break;
 						default:
 							break;
@@ -1794,6 +1802,14 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					case 3: // maven
 						p = Pattern.compile("((http|https)://mvnrepository.com/artifact/([^/]+)/([^/]+))");
 						
+						break;
+					case 4: // pub
+						p = Pattern.compile("((http|https)://pub.dev/packages/([^/]+))");
+
+						break;
+					case 5: // cocoapods
+						p = Pattern.compile("((http|https)://cocoapods.org/pods/([^/]+))");
+
 						break;
 					default:
 						break;

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -1678,10 +1678,50 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						}
 						
 						if(!isEmpty(checkName)) {
-							bean.setDownloadLocation(downloadlocationUrl);
-							bean.setCheckName(checkName);
-							result.add(bean);
+							bean.setCheckOssList("Y");
+						} else {
+
+							Matcher ossNameMatcher = p.matcher(downloadlocationUrl);
+
+							while(ossNameMatcher.find()){
+
+								switch(urlSearchSeq) {
+									case 0: // github
+										checkName = ossNameMatcher.group(3) + "-" + ossNameMatcher.group(4);
+										
+										break;
+									case 1: // npm
+										checkName = "npm:" + ossNameMatcher.group(3);
+										
+										break;
+									case 2: // pypi
+										checkName = "pypi:" + ossNameMatcher.group(3);
+										
+										break;
+									case 3: // maven
+										checkName = ossNameMatcher.group(3) + ":" + ossNameMatcher.group(4);
+			
+										break;
+									case 4: // pub
+										checkName = "pub:" + ossNameMatcher.group(3);
+			
+										break;
+									case 5: // cocoapods
+										checkName = "cocoapods:" + ossNameMatcher.group(3);
+			
+										break;
+									default:
+										break;
+								}
+
+							}
+							
 						}
+
+						bean.setDownloadLocation(downloadlocationUrl);
+						bean.setCheckName(checkName);
+						if(!bean.getOssName().equals(bean.getCheckName())) result.add(bean);
+
 					}
 				} else if(semicolonFlag) {
 					String downloadlocationUrl = bean.getDownloadLocation().split(";")[0];
@@ -1719,9 +1759,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						}
 						
 						if(!isEmpty(checkName)) {
+							bean.setCheckOssList("Y");
 							bean.setDownloadLocation(downloadlocationUrl);
 							bean.setCheckName(checkName);
-							result.add(bean);
+							if(!bean.getOssName().equals(bean.getCheckName())) result.add(bean);
 						}
 					}
 				} else {
@@ -1731,8 +1772,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						String checkName = ossMapper.checkOssName(bean);
 						
 						if(!isEmpty(checkName)) {
+							bean.setCheckOssList("Y");
 							bean.setCheckName(checkName);
-							result.add(bean);
+							if(!bean.getOssName().equals(bean.getCheckName())) result.add(bean);
 						}
 					}
 				}

--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
@@ -139,7 +139,6 @@
 								
 								var rowdata = target.getRowData(rowId);
 								rowdata["checkName"] = rowdata["checkName"].replace(/(<([^>]+)>)/ig,"");
-
 								<c:if test="${projectInfo.targetName eq 'identification'}">
 								rowdata["refPrjId"] = rowdata["referenceId"];
 								rowdata["referenceId"] = commentId;
@@ -166,7 +165,6 @@
 										}
 										
 										result.push(resultData);
-
 										<c:if test="${projectInfo.targetName eq 'identification'}">
 										commentId = resultData.commentId;
 										</c:if>
@@ -191,7 +189,7 @@
 							}
 						}, 0);
 					} else {
-						alertify.alert('Please select OSS to register');
+						alertify.alert('Please select OSS to register', function(){});
 						$('#loading_wrap_popup').hide();
 					}
 				},
@@ -202,11 +200,17 @@
 					var result = [];
 					var failFlag = false;
 					var idArry = grid_fn.getCheckedRow("ADD");
-					
-					if(idArry.length > 0){
+
+					var idArryOnlyInOssList = grid_fn.getCheckedRow("ADD").filter(i => {
+						let input = $("#ossList").getRowData(i)['checkName'];
+						let regexp = /^(<a).*(<\/a>)$/;
+						return regexp.test(input);
+					});
+
+					if(idArryOnlyInOssList.length > 0){
 						window.setTimeout(function(){
-							for(var i = 0 ; i < idArry.length ; i++){
-								var rowId = idArry[i];
+							for(var i = 0 ; i < idArryOnlyInOssList.length ; i++){
+								var rowId = idArryOnlyInOssList[i];
 
 								cleanErrMsg("ossList", rowId);
 								
@@ -223,21 +227,21 @@
 									contentType : 'application/json',
 									success: function(resultData){
 										if(resultData.isValid == "true"){
-											$("#ossList").jqGrid('setCell', idArry[i], 'addFlag', 'Y');
-											$("#ossList").jqGrid('setCell', idArry[i], 'result', 'Y');
+											$("#ossList").jqGrid('setCell', idArryOnlyInOssList[i], 'addFlag', 'Y');
+											$("#ossList").jqGrid('setCell', idArryOnlyInOssList[i], 'result', 'Y');
 										}
 										else {
-											$("#ossList").jqGrid('setCell', idArry[i], 'addFlag', 'N');
-											$("#ossList").jqGrid('setCell', idArry[i], 'result', 'N');
+											$("#ossList").jqGrid('setCell', idArryOnlyInOssList[i], 'addFlag', 'N');
+											$("#ossList").jqGrid('setCell', idArryOnlyInOssList[i], 'result', 'N');
 											alertify.error('<spring:message code="already.added.nickname" />', 0);
 											failFlag = true;
 										}
 										
 										result.push(resultData);
 																
-										if(result.length == idArry.length){
+										if(result.length == idArryOnlyInOssList.length){
 											if(!failFlag){
-												alertify.success('Successfully add NickName');
+												alertify.success('Successfully add NickName except for oss not registered in oss list');
 												opener.location.reload();
 											}
 											
@@ -248,8 +252,11 @@
 								});
 							}
 						}, 0);
+					} else if(idArry.length > 0){
+						alertify.error('Unregistred OSS cannot add Nickname');
+						$('#loading_wrap_popup').hide();
 					} else {
-						alertify.alert('Please select OSS to register');
+						alertify.alert('Please select OSS to register', function(){});
 						$('#loading_wrap_popup').hide();
 					}
 				},
@@ -320,11 +327,14 @@
 					displayCheckName : function(cellvalue, options, rowObject){
 						var display = "";
 						var checkName = rowObject["checkName"];
+						var checkOssList = rowObject["checkOssList"];
 						
 						display = checkName.split("|");
 
 						for(var i in display){
-							display[i] = "<a href='#' onclick='Ctrl_fn.showOssViewPage(\""+display[i]+"\")' style='color:#2883f3;text-decoration:underline;'>"+display[i]+"</a>";
+							display[i] = checkOssList == "Y" ? 
+								"<a href='#' onclick='Ctrl_fn.showOssViewPage(\""+display[i]+"\")' style='color:#2883f3;text-decoration:underline;'>"+display[i]+"</a>"
+								: display[i];
 						}
 						
 						return display.join("<br>");


### PR DESCRIPTION
## Description

1. Now fosslight supports 6 open source package repositories (GitHub, Maven, PyPI, npm). To support two additional open source package repositories (Pub, CocoaPods), Modified fosslight_create.sql, OssServiceImpl::checkOssName, and OssServiceImpl::saveOssCheckName as follows.


2. And fosslight recommends an oss name by checking the oss list.
If the download location is not stored in the OSS List only for the OSS Name that is an Unconfirmed Open Source Warning message, recommend the OSS Name according to the OSS Naming Rule.

So in Project List > SRC tab, As shown in the picture below, Suppose that there is an open source specified in the downloadlocation for a specific repository and 'Unconfirmed Open Source' warning message is appeared.
![image](https://user-images.githubusercontent.com/53862866/130319953-aaded7eb-35fa-4360-9348-d9ce80b3c802.png)
If opensource's download location is specified in 6 open source package repositories (GitHub, Maven, PyPI, npm, Pub, CocoaPods), The oss name is automatically recommended by the oss naming rule, and the oss name can be replaced with this name.
![image](https://user-images.githubusercontent.com/53862866/130319956-10fd5619-e74e-4aee-ae4f-3c523ae0c6ed.png)

- Issue number
-- #78 
-- #79 


## Type of change
Please insert 'x' one of the type of change.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
