### PR TITLE
In default state, add one declared license in new_opensource tab, Change to cotent of the email from License Name to License

### DIFF
--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -1823,7 +1823,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					CommentsHistory commentInfo = null;
 					
 					if(isEmpty(commentId)) {
-						checkOssNameComment  = "<p><b>The following open source and license names will be changed to names registered on the system for efficient management.</b></p>";
+						checkOssNameComment  = "<p><b>The following open source and license will be changed to names registered on the system for efficient management.</b></p>";
 						checkOssNameComment += "<p><b>Opensource Names</b></p>";
 						checkOssNameComment += changeOssNameInfo;
 						CommentsHistory commHisBean = new CommentsHistory();

--- a/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
@@ -789,13 +789,13 @@
 				hidePageNav('_licenseChoicePager');
 
 				// 생성된 grid가 있는지 확인하기
-                if($('#_licenseChoice > tbody tr').length == 1) {
-                    var ids = $("#_licenseChoice").jqGrid("getDataIDs");
-                    var newId = ids.length ? Number(ids[ids.length - 1]) + 1 : 1;
-                    var row = {no: newId, ossLicenseIdx: newId};
-                    $("#_licenseChoice").jqGrid("addRowData", newId, row, "last");
-                    $("#_licenseChoice").jqGrid("setSelection", newId);
-                }
+				if($('#_licenseChoice > tbody tr').length == 1) {
+				    var ids = $("#_licenseChoice").jqGrid("getDataIDs");
+				    var newId = ids.length ? Number(ids[ids.length - 1]) + 1 : 1;
+				    var row = {no: newId, ossLicenseIdx: newId};
+				    $("#_licenseChoice").jqGrid("addRowData", newId, row, "last");
+				    $("#_licenseChoice").jqGrid("setSelection", newId);
+				}
 
 				// 첫 로우 ossLicenseComb 설정
 				setFristComb();

--- a/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
@@ -787,6 +787,16 @@
 				lastsel = -1;
 				// 페이징 UI 설정
 				hidePageNav('_licenseChoicePager');
+
+				// 생성된 grid가 있는지 확인하기
+                if($('#_licenseChoice > tbody tr').length == 1) {
+                    var ids = $("#_licenseChoice").jqGrid("getDataIDs");
+                    var newId = ids.length ? Number(ids[ids.length - 1]) + 1 : 1;
+                    var row = {no: newId, ossLicenseIdx: newId};
+                    $("#_licenseChoice").jqGrid("addRowData", newId, row, "last");
+                    $("#_licenseChoice").jqGrid("setSelection", newId);
+                }
+
 				// 첫 로우 ossLicenseComb 설정
 				setFristComb();
 				// 라이센스 묶음 텍스트 출력


### PR DESCRIPTION
## Description
1. Change the default setting of declared license in oss list to the state where one license row is added.
2. Change to content of the email from 'License Name' to 'License' If edit OSS information.

### Before
![image](https://user-images.githubusercontent.com/21255149/130364378-917dd1c7-65e8-40cd-a6b8-0931bd5acd7c.png)

### After
![image](https://user-images.githubusercontent.com/21255149/130364384-6c56c3d8-4a77-4a9e-b80c-b618d77987e9.png)

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
