### PR TITLE
Expose a save button for a creator, watcher, and admin

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/project/verification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/verification.jsp
@@ -405,7 +405,7 @@
 									<dd class="mt10">
 										<div class="basicCase">
 											<span class="right">
-												<c:if test="${project.verificationStatus ne 'CONF' and project.dropYn ne 'Y'}">
+												<c:if test="${project.verificationStatus ne 'CONF' and project.dropYn ne 'Y' and (ct:isAdmin() or project.viewOnlyFlag eq 'N')}">
 													<input type="button" id="save" value="Save" class="btnColor red"/>
 												</c:if>
 											</span>


### PR DESCRIPTION
Signed-off-by: jongun.chae <cha452jg@gmail.com>

## Description
Hide a save button for a normal user in packaging tab. Admin, watcher, and creator only can see the button.
 
## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)