### PR TITLE
Hide reject buttons on identification, package tab

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
@@ -50,7 +50,9 @@
 					</c:when>
 					<c:when test="${project.completeYn ne 'Y' and project.dropYn ne 'Y' and project.distributeDeployYn ne 'Y'}">
 						<a class="btnSet confirm"><span id="bomConfirm">Confirm</span></a>
-						<a class="btnSet reject"><span id="bomReject">Reject</span></a>
+						<c:if test="${ct:isAdmin() or project.viewOnlyFlag eq 'N'}">
+							<a class="btnSet reject"><span id="bomReject">Reject</span></a>
+						</c:if>
 						<a class="btnSet review"><span id="bomRequest">Request</span></a>
 						<a class="btnSet restart"><span id="bomReviewStart">Review Start</span></a>
 					</c:when>

--- a/src/main/webapp/WEB-INF/views/admin/project/verification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/verification.jsp
@@ -42,7 +42,9 @@
 					</c:when>
 					<c:when test="${project.completeYn ne 'Y' and project.dropYn ne 'Y' and project.verificationStatus ne 'NA' and project.distributeDeployYn ne 'Y'}">
 						<a class="btnSet confirm"><span id="verConfirm">Confirm</span></a>
-						<a class="btnSet reject"><span id="verReject">Reject</span></a>
+						<c:if test="${ct:isAdmin() or project.viewOnlyFlag eq 'N'}">
+							<a class="btnSet reject"><span id="verReject">Reject</span></a>
+						</c:if>
 						<a class="btnSet review"><span id="verRequest">Request</span></a>
 						<a class="btnSet restart"><span id="verReviewStart">Review Start</span></a>
 					</c:when>


### PR DESCRIPTION
Signed-off-by: jongun.chae <cha452jg@gmail.com>

## Description
Hello, @soimkim. I try to hide reject buttons on identification, package tab. Only admin, creatoer, and watcher can see the buttons. Others cannot see it.

See #102 

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
