### PR TITLE
Delete "Need check" in the Obligation Type from the search box in the License List

### DIFF
--- a/db/initdb.d/fosslight_create.sql
+++ b/db/initdb.d/fosslight_create.sql
@@ -2132,7 +2132,6 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('216', '#ffe7e', '#ffe7e7', NULL, NULL, 2, 'Y'),
 	('217', '10', 'Notice', NULL, '<span class="iconSet ops" title="Notice"></span>', 1, 'Y'),
 	('217', '11', 'Notice & Distribute', NULL, '<span class="iconSet ops" title="Notice"></span><span class="iconSet man" title="Source Code"></span>', 2, 'Y'),
-	('217', '90', 'Needs check', NULL, '', 3, 'Y'),
 	('218', 'NA', 'N/A', '', '', 3, 'Y'),
 	('219', '1', 'Company Full Name', 'FOSSLight', '', 1, 'Y'),
 	('219', '2', 'Company Short Name', '', '', 2, 'Y'),


### PR DESCRIPTION
## Description
- Delete Need check in the Obligation Type from the search box in the License List.
- Need Checks's option number is 90. so I hide option with a value of 90 after rendering.  

##ScreenShot
![After](https://user-images.githubusercontent.com/60414900/131218151-c016a22f-c8e8-4ed4-a114-dbc4982bc0f0.png)


## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
