### PR TITLE
Fix hide 'Check OSS Name' button from unrelated users

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
@@ -333,7 +333,7 @@
                     	<c:if test="${ct:isAdmin() and project.dropYn ne 'Y'}">
 	                        <input type="button" value="OSS bulk registration" onclick="fn_grid_com.ossBulkReg('${project.prjId}','11')" class="btnColor red" style="width: 145px;" />
                     	</c:if>
-                    	<c:if test="${project.dropYn ne 'Y'}">
+                    	<c:if test="${project.dropYn ne 'Y' and (ct:isAdmin() or project.viewOnlyFlag eq 'N')}">
                     		<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('SRC')" class="btnColor red srcBtn" style="width: 115px;" />
                     	</c:if>
                     </span>
@@ -516,7 +516,7 @@
                     	<c:if test="${ct:isAdmin() and project.dropYn ne 'Y'}">
 	                       <input type="button" value="OSS bulk registration" onclick="fn_grid_com.ossBulkReg('${project.prjId}','15')" class="btnColor red" style="width: 145px;" />
                     	</c:if>
-                    	<c:if test="${project.dropYn ne 'Y'}">
+                    	<c:if test="${project.dropYn ne 'Y' and (ct:isAdmin() or project.viewOnlyFlag eq 'N')}">
                     		<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('BIN')" class="btnColor red binBtn" style="width: 115px;" />
                    		</c:if>
                     </span>


### PR DESCRIPTION
Signed-off-by: hyewoncc <hyewoncc@gmail.com>

## Description
In Project - SRC/BIN tabs, 'Check OSS Name' button is only shown to Admin, Watcher and Creator.
Other unrelated users couldn't see it now. 

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
