### PR TITLE
Add function to save NVD Feed Data from 2002

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v1.2.5 (09/09/2021)
+## Changes
+## 🚀 Features
+
+- Recommend the OSS Name according to the OSS Naming Rule @namkyu1999 (#82)
+
+## 🐛 Hotfixes
+
+- Update OSS Sync Function @FOSSLight-dev (#117)
+- Exclude from 'Check OSS Name' unless it is an 'Unconfirmed open source' @soimkim (#116)
+
+## 🔧 Maintenance
+
+- Delete "Need check" in the Obligation Type from the search box in the License List @Lee-JaeHyuk (#101)
+- Translate some korean comments to english @wkdalsgh192 (#60)
+
+---
+
 ## v1.2.4 (03/09/2021)
 ## Changes
 ## 🚀 Features

--- a/db/initdb.d/fosslight_create.sql
+++ b/db/initdb.d/fosslight_create.sql
@@ -2132,7 +2132,6 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('216', '#ffe7e', '#ffe7e7', NULL, NULL, 2, 'Y'),
 	('217', '10', 'Notice', NULL, '<span class="iconSet ops" title="Notice"></span>', 1, 'Y'),
 	('217', '11', 'Notice & Distribute', NULL, '<span class="iconSet ops" title="Notice"></span><span class="iconSet man" title="Source Code"></span>', 2, 'Y'),
-	('217', '90', 'Needs check', NULL, '', 3, 'Y'),
 	('218', 'NA', 'N/A', '', '', 3, 'Y'),
 	('219', '1', 'Company Full Name', 'FOSSLight', '', 1, 'Y'),
 	('219', '2', 'Company Short Name', '', '', 2, 'Y'),

--- a/db/initdb.d/fosslight_create.sql
+++ b/db/initdb.d/fosslight_create.sql
@@ -1795,7 +1795,8 @@ INSERT INTO `T2_CODE` (`CD_NO`, `CD_NM`, `CD_EXP`, `SYS_CD_YN`) VALUES
 	('923', 'Self-Check List Detail Setting', 'System Detail Setting Code', 'Y'),
 	('924', 'Compliance Status Detail Setting', 'System Detail Setting Code', 'Y'),
 	('926', 'System Detail Setting', 'System Detail Setting Code', 'Y'),
-	('927', 'Notice Info', '', 'Y');
+	('927', 'Notice Info', '', 'Y'),
+	('990', 'System initialize flag', '', 'Y');
 /*!40000 ALTER TABLE `T2_CODE` ENABLE KEYS */;
 
 -- 테이블 fosslight.T2_CODE_DTL 구조 내보내기
@@ -2311,7 +2312,8 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('918', '100', 'Distribution Flag', '', 'N', 2, 'Y'),
 	('927', '100', 'HTML', '', 'Y', 1, 'Y'),
 	('927', '101', 'TEXT', '', 'Y', 2, 'Y'),
-	('927', '102', 'SPDX', '', 'Y', 3, 'Y');
+	('927', '102', 'SPDX', '', 'Y', 3, 'Y'),
+	('990', '100', 'N', '', 'NVD Data Feed initialize flag', 1, 'Y');
 /*!40000 ALTER TABLE `T2_CODE_DTL` ENABLE KEYS */;
 
 -- 테이블 fosslight.T2_FILE 구조 내보내기

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -147,7 +147,15 @@ public class OssController extends CoTopComponent{
 		
 		ossMaster.setCurPage(page);
 		ossMaster.setPageListSize(rows);
-		
+
+		// download location check
+		List<String> values = Arrays.asList("https://", "http://", "www.");
+		String homepage =req.getParameter("homepage");
+		if(!values.contains(homepage)){
+			homepage = homepage.replaceFirst("^((http|https)://)?(www.)*", "");
+			ossMaster.setHomepage(homepage);
+		}
+
 		if("search".equals(req.getParameter("act"))) {
 			// 검색 조건 저장
 			putSessionObject(SESSION_KEY_SEARCH, ossMaster);

--- a/src/main/java/oss/fosslight/repository/CodeMapper.java
+++ b/src/main/java/oss/fosslight/repository/CodeMapper.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import oss.fosslight.domain.T2Code;
 import oss.fosslight.domain.T2CodeDtl;
@@ -44,4 +45,23 @@ public interface CodeMapper {
 	public List<String> getCategoryList(String categoryCd);
 	
 	public void saveConfiguration(T2Code code);
+
+	/**
+	 * Gets the Detail Code Name.
+	 *
+	 * @param cdNo the cd no
+	 * @param cdDtlNo the cd dtl no
+	 * @return the code dtl nm
+	 */
+	public String getCodeDtlNm(@Param("cdNo") String cdNo, @Param("cdDtlNo") String cdDtlNo);
+	
+	/**
+	 * Update Detail Code Name.
+	 *
+	 * @param cdNo the cd no
+	 * @param cdDtlNo the cd dtl no
+	 * @param cdDtlNm the cd dtl nm
+	 * @return update result int
+	 */
+	public int updateCodeDtlNm(@Param("cdNo") String cdNo, @Param("cdDtlNo") String cdDtlNo, @Param("cdDtlNm") String cdDtlNm);
 }

--- a/src/main/java/oss/fosslight/repository/NvdDataMapper.java
+++ b/src/main/java/oss/fosslight/repository/NvdDataMapper.java
@@ -50,4 +50,6 @@ public interface NvdDataMapper {
 	void nickNameToOssNameMgrtCvssScore();
 	void insertCpeMatchData(Map<String, Object> params);
 	void insertCpeMatchNameData(Map<String, Object> params);
+	void resetCveDataV3();
+	void resetNvdDataV3();
 }

--- a/src/main/java/oss/fosslight/service/NvdDataService.java
+++ b/src/main/java/oss/fosslight/service/NvdDataService.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import oss.fosslight.common.CommonFunction;
+import oss.fosslight.repository.CodeMapper;
 import oss.fosslight.repository.NvdDataMapper;
 import oss.fosslight.util.DateUtil;
 import oss.fosslight.util.FileUtil;
@@ -46,6 +47,7 @@ public class NvdDataService {
 	private final String NVD_CVE_URL = "https://nvd.nist.gov/feeds/json/cve/1.1/";
 	
 	@Autowired NvdDataMapper nvdDataMapper;
+	@Autowired CodeMapper codeMapper;
 	@Autowired Environment env;
 	@Autowired SqlSessionFactory sqlSessionFactory;
 	
@@ -62,6 +64,23 @@ public class NvdDataService {
 			log.error(e.getMessage(), e);
 			return "91";
 		}
+		
+		try {
+			// initialize NVD Data Feed
+			// check initialize flag
+			if("Y".equalsIgnoreCase(codeMapper.getCodeDtlNm("990", "100")) ) {
+				codeMapper.updateCodeDtlNm("990", "100", "N");
+
+				// delete all NVD Data and Max Score
+				resetNvdFeedData();
+				
+				// Put NVD Data feed from CPE2002 ~ current date year
+				initNvdDataFeed();
+				
+			}
+		} catch (Exception e) {
+			log.error("Failed to NVD Data initiallize", e);
+		}
 
 		try {
 			if(nvdMetaCheckJob(NVD_DATA_FILE_NAME_NVDCVE, "CVE")) {
@@ -77,7 +96,6 @@ public class NvdDataService {
 	}
 	
 
-	@SuppressWarnings("unchecked")
 	@Transactional
 	private String nvdCveDataSyncJob() throws JsonParseException, JsonMappingException, IOException {
 		String resCd = "00";
@@ -97,150 +115,13 @@ public class NvdDataService {
 			// JobStatus가 W인 대상이 작업이 들어갔다면 G로 변경을 하여 추후에 다시 loop 돌지 않도록 처리함.
 			nvdDataMapper.updateJobStatus(param);
 			
-			Map<String, Object> map = null;
 			String NVD_CVE_PATH = env.getProperty("root.dir");
 			if(StringUtil.isEmpty(NVD_CVE_PATH)) {
 				NVD_CVE_PATH = new FileSystemResource("").getFile().getAbsolutePath();
 			}
 			NVD_CVE_PATH = Paths.get(NVD_CVE_PATH, "nvd/cve").toString();
 
-			{
-				
-				ObjectMapper mapper = new ObjectMapper();
-				map = mapper.readValue(  new File(NVD_CVE_PATH + File.separator + (String) wMetaMap.get("fileNm") + ".json") , new TypeReference<Map<String, Object>>() { });
-				
-				if(map.containsKey("CVE_Items")) {
-					List<Map<String, Object>> cveItems = (List<Map<String, Object>>) map.get("CVE_Items");
-					for(Map<String, Object> cveItem : cveItems) {
-						
-						Map<String, Object> cveInfo = cveDatajsonReader(cveItem);
-						if(cveInfo == null || cveInfo.isEmpty()) {
-							continue;
-						}
-						
-						String cveId = (String) cveInfo.get("cveId");
-						Map<String, Object> comapare = nvdDataMapper.selectOneCveInfoV3(cveInfo);
-						
-						List<Map<String, String>> ossList = null;
-						
-						ossList = new ArrayList<>();
-						// 전체 cpe match 정보에서 vulnerable 가 false인 경우는 제외한다.
-						// 적용대상 cpe match list
-						List<Map<String, Object>> cpe_match_all = (List<Map<String, Object>>) cveInfo.get("cpe_match_all");
-						for (Map<String, Object> cpe_match_data : cpe_match_all) {
-							// 정보에서 Version Range 조건을 고려하여 Cpe match 정보로 부터 최종적요으로 적용할 모든 대상 cpe23uri를 취득한다.
-							// Version Range 조건 취득
-							// 검색 조건 설정
-							Map<String, String> _matchNameParams = new HashMap<>();
-							_matchNameParams.put("cpe23Uri", (String) cpe_match_data.get("cpe23Uri"));
-							if (cpe_match_data.containsKey("versionStartIncluding")) {
-								_matchNameParams.put("versionStartIncluding",
-										(String) cpe_match_data.get("versionStartIncluding"));
-							}
-							if (cpe_match_data.containsKey("versionEndIncluding")) {
-								_matchNameParams.put("versionEndIncluding",
-										(String) cpe_match_data.get("versionEndIncluding"));
-							}
-							if (cpe_match_data.containsKey("versionStartExcluding")) {
-								_matchNameParams.put("versionStartExcluding",
-										(String) cpe_match_data.get("versionStartExcluding"));
-							}
-							if (cpe_match_data.containsKey("versionEndExcluding")) {
-								_matchNameParams.put("versionEndExcluding",
-										(String) cpe_match_data.get("versionEndExcluding"));
-							}
-
-							List<String> matchNames = nvdDataMapper.selectNvdMatchList(_matchNameParams);
-
-							// 만약 cpe match에서 cpe23uri로 조회된 결과가 없을 경우 해당 cpe23uri 만 설정한다.
-							if (matchNames == null) {
-								matchNames = new ArrayList<>();
-							}
-
-							if (matchNames.isEmpty()) {
-								matchNames.add((String) cpe_match_data.get("cpe23Uri"));
-							}
-
-							// cpe23uri에서 product, version 정보를 추출한다.
-							for (String cpe23uri : matchNames) {
-								String[] cpeInfoArr = cpe23uri.split(":");
-
-								Map<String, String> _productInfo = new HashMap<>();
-								_productInfo.put("cveId", cveId);
-								_productInfo.put("product", cpeInfoArr[4].replaceAll("_", " "));
-								_productInfo.put("version", cpeInfoArr[5]);
-
-								ossList.add(_productInfo);
-							}
-						}
-						
-						// 신규등록
-						if(comapare == null){
-							nvdDataMapper.insertCveInfoV3(cveInfo);
-							
-							if(!ossList.isEmpty()) {
-								List<Map<String, String>> insertDataList = new ArrayList<>();
-								for(Map<String, String> item : ossList){
-									insertDataList.add(item);
-									if( (insertDataList.size() % 1000) == 0 ) {
-										nvdDataMapper.insertBulkNvdDataV3(insertDataList);
-										insertDataList = new ArrayList<>();
-									}
-								}
-								// 미등록 data가 존재하는 경우 나머지를 등록한다.
-								if( !insertDataList.isEmpty() ) {
-									nvdDataMapper.insertBulkNvdDataV3(insertDataList);
-								}
-							}
-							
-							updateFlag = true;
-						}
-						// 변경(delete > insert)
-						else if(!DateUtil.equals((Date)comapare.get("modiDate"), (Date) cveInfo.get("modiDate"))
-								|| !((Float)comapare.get("cvssScore")).equals(Float.valueOf((String)cveInfo.get("cvssScore"))) ){
-							// 기존 데이터 삭제
-							nvdDataMapper.deleteCveDataV3(cveInfo);
-							nvdDataMapper.deleteNvdDataV3(cveInfo);
-							// 변경 데이터 등록
-							nvdDataMapper.insertCveInfoV3(cveInfo);
-							if(!ossList.isEmpty()) {
-								List<Map<String, String>> insertDataList = new ArrayList<>();
-								for(Map<String, String> item : ossList){
-									insertDataList.add(item);
-									if( (insertDataList.size() % 1000) == 0 ) {
-										nvdDataMapper.insertBulkNvdDataV3(insertDataList);
-										insertDataList = new ArrayList<>();
-									}
-								}
-								// 미등록 data가 존재하는 경우 나머지를 등록한다.
-								if( !insertDataList.isEmpty() ) {
-									nvdDataMapper.insertBulkNvdDataV3(insertDataList);
-								}
-							}
-						} else if (DateUtil.equals((Date)comapare.get("modiDate"), (Date) cveInfo.get("modiDate"))
-								&& ((Float)comapare.get("cvssScore")).equals(Float.valueOf((String)cveInfo.get("cvssScore")))) {
-							// NVD_CVE_V3는 변경 대상이 아니지만 NVD_DATA_V3에 적용 될 대상이 존재 한 경우
-							
-							if(!ossList.isEmpty()) {
-								List<Map<String, String>> insertDataList = new ArrayList<>();
-								for(Map<String, String> item : ossList){
-									insertDataList.add(item);
-									if( (insertDataList.size() % 1000) == 0 ) {
-										nvdDataMapper.insertBulkNvdDataV3(insertDataList);
-										insertDataList = new ArrayList<>();
-									}
-								}
-								// 미등록 data가 존재하는 경우 나머지를 등록한다.
-								if( !insertDataList.isEmpty() ) {
-									nvdDataMapper.insertBulkNvdDataV3(insertDataList);
-								}
-							}
-						}
-						updateFlag = true;
-					}
-				}
-				
-			}
+			updateFlag = updateNvdData(NVD_CVE_PATH, (String) wMetaMap.get("fileNm"));
 			
 			param.put("jobStatus", "C");
 			nvdDataMapper.updateJobStatus(param);
@@ -301,6 +182,150 @@ public class NvdDataService {
 		}
 		
 		return resCd;
+	}
+	
+	
+	@SuppressWarnings("unchecked")
+	private boolean updateNvdData(String cpeFileRootPath, String cpeFileName) throws JsonParseException, JsonMappingException, IOException {
+
+		boolean updateFlag = false;
+		
+		ObjectMapper mapper = new ObjectMapper();
+		Map<String, Object> map = mapper.readValue(  new File(cpeFileRootPath + File.separator + cpeFileName + ".json") , new TypeReference<Map<String, Object>>() { });
+		
+		if(map.containsKey("CVE_Items")) {
+			List<Map<String, Object>> cveItems = (List<Map<String, Object>>) map.get("CVE_Items");
+			for(Map<String, Object> cveItem : cveItems) {
+				
+				Map<String, Object> cveInfo = cveDatajsonReader(cveItem);
+				if(cveInfo == null || cveInfo.isEmpty()) {
+					continue;
+				}
+				
+				String cveId = (String) cveInfo.get("cveId");
+				Map<String, Object> comapare = nvdDataMapper.selectOneCveInfoV3(cveInfo);
+				
+				List<Map<String, String>> ossList = null;
+				
+				ossList = new ArrayList<>();
+				// 전체 cpe match 정보에서 vulnerable 가 false인 경우는 제외한다.
+				// 적용대상 cpe match list
+				List<Map<String, Object>> cpe_match_all = (List<Map<String, Object>>) cveInfo.get("cpe_match_all");
+				for (Map<String, Object> cpe_match_data : cpe_match_all) {
+					// 정보에서 Version Range 조건을 고려하여 Cpe match 정보로 부터 최종적요으로 적용할 모든 대상 cpe23uri를 취득한다.
+					// Version Range 조건 취득
+					// 검색 조건 설정
+					Map<String, String> _matchNameParams = new HashMap<>();
+					_matchNameParams.put("cpe23Uri", (String) cpe_match_data.get("cpe23Uri"));
+					if (cpe_match_data.containsKey("versionStartIncluding")) {
+						_matchNameParams.put("versionStartIncluding",
+								(String) cpe_match_data.get("versionStartIncluding"));
+					}
+					if (cpe_match_data.containsKey("versionEndIncluding")) {
+						_matchNameParams.put("versionEndIncluding",
+								(String) cpe_match_data.get("versionEndIncluding"));
+					}
+					if (cpe_match_data.containsKey("versionStartExcluding")) {
+						_matchNameParams.put("versionStartExcluding",
+								(String) cpe_match_data.get("versionStartExcluding"));
+					}
+					if (cpe_match_data.containsKey("versionEndExcluding")) {
+						_matchNameParams.put("versionEndExcluding",
+								(String) cpe_match_data.get("versionEndExcluding"));
+					}
+
+					List<String> matchNames = nvdDataMapper.selectNvdMatchList(_matchNameParams);
+
+					// 만약 cpe match에서 cpe23uri로 조회된 결과가 없을 경우 해당 cpe23uri 만 설정한다.
+					if (matchNames == null) {
+						matchNames = new ArrayList<>();
+					}
+
+					if (matchNames.isEmpty()) {
+						matchNames.add((String) cpe_match_data.get("cpe23Uri"));
+					}
+
+					// cpe23uri에서 product, version 정보를 추출한다.
+					for (String cpe23uri : matchNames) {
+						String[] cpeInfoArr = cpe23uri.split(":");
+
+						Map<String, String> _productInfo = new HashMap<>();
+						_productInfo.put("cveId", cveId);
+						_productInfo.put("product", cpeInfoArr[4].replaceAll("_", " "));
+						_productInfo.put("version", cpeInfoArr[5]);
+
+						ossList.add(_productInfo);
+					}
+				}
+				
+				// 신규등록
+				if(comapare == null){
+					nvdDataMapper.insertCveInfoV3(cveInfo);
+					
+					if(!ossList.isEmpty()) {
+						List<Map<String, String>> insertDataList = new ArrayList<>();
+						for(Map<String, String> item : ossList){
+							insertDataList.add(item);
+							if( (insertDataList.size() % 1000) == 0 ) {
+								nvdDataMapper.insertBulkNvdDataV3(insertDataList);
+								insertDataList = new ArrayList<>();
+							}
+						}
+						// 미등록 data가 존재하는 경우 나머지를 등록한다.
+						if( !insertDataList.isEmpty() ) {
+							nvdDataMapper.insertBulkNvdDataV3(insertDataList);
+						}
+					}
+					
+					updateFlag = true;
+				}
+				// 변경(delete > insert)
+				else if(!DateUtil.equals((Date)comapare.get("modiDate"), (Date) cveInfo.get("modiDate"))
+						|| !((Float)comapare.get("cvssScore")).equals(Float.valueOf((String)cveInfo.get("cvssScore"))) ){
+					// 기존 데이터 삭제
+					nvdDataMapper.deleteCveDataV3(cveInfo);
+					nvdDataMapper.deleteNvdDataV3(cveInfo);
+					// 변경 데이터 등록
+					nvdDataMapper.insertCveInfoV3(cveInfo);
+					if(!ossList.isEmpty()) {
+						List<Map<String, String>> insertDataList = new ArrayList<>();
+						for(Map<String, String> item : ossList){
+							insertDataList.add(item);
+							if( (insertDataList.size() % 1000) == 0 ) {
+								nvdDataMapper.insertBulkNvdDataV3(insertDataList);
+								insertDataList = new ArrayList<>();
+							}
+						}
+						// 미등록 data가 존재하는 경우 나머지를 등록한다.
+						if( !insertDataList.isEmpty() ) {
+							nvdDataMapper.insertBulkNvdDataV3(insertDataList);
+						}
+					}
+				} else if (DateUtil.equals((Date)comapare.get("modiDate"), (Date) cveInfo.get("modiDate"))
+						&& ((Float)comapare.get("cvssScore")).equals(Float.valueOf((String)cveInfo.get("cvssScore")))) {
+					// NVD_CVE_V3는 변경 대상이 아니지만 NVD_DATA_V3에 적용 될 대상이 존재 한 경우
+					
+					if(!ossList.isEmpty()) {
+						List<Map<String, String>> insertDataList = new ArrayList<>();
+						for(Map<String, String> item : ossList){
+							insertDataList.add(item);
+							if( (insertDataList.size() % 1000) == 0 ) {
+								nvdDataMapper.insertBulkNvdDataV3(insertDataList);
+								insertDataList = new ArrayList<>();
+							}
+						}
+						// 미등록 data가 존재하는 경우 나머지를 등록한다.
+						if( !insertDataList.isEmpty() ) {
+							nvdDataMapper.insertBulkNvdDataV3(insertDataList);
+						}
+					}
+				}
+				updateFlag = true;
+			}
+		}
+		
+	
+		return updateFlag;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -631,5 +656,34 @@ public class NvdDataService {
 		}
 		
 		return metaInfo;
+	}
+	
+	@Transactional
+	private void initNvdDataFeed() throws Exception {
+
+		int nvdBeginDateYear = 2002;
+		int currentDateYear = StringUtil.string2integer(DateUtil.getCurrentDateAsString("yyyy")) ;
+		for(int year = nvdBeginDateYear; year <= currentDateYear; year ++) {
+			nvdFeedDataDownloadJob("nvdcve-1.1-" + year);
+		}
+		
+		String NVD_CVE_PATH = env.getProperty("root.dir");
+		if(StringUtil.isEmpty(NVD_CVE_PATH)) {
+			NVD_CVE_PATH = new FileSystemResource("").getFile().getAbsolutePath();
+		}
+		NVD_CVE_PATH = Paths.get(NVD_CVE_PATH, "nvd/cve").toString();
+		for(int year = nvdBeginDateYear; year <= currentDateYear; year ++) {
+			updateNvdData(NVD_CVE_PATH, "nvdcve-1.1-" + year);
+		}
+		
+	}
+
+
+	/**
+	 * Reset ALL NVD Feed Data 
+	 */
+	private void resetNvdFeedData() {
+		nvdDataMapper.resetCveDataV3();
+		nvdDataMapper.resetNvdDataV3();
 	}
 }

--- a/src/main/resources/oss/fosslight/repository/CodeMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/CodeMapper.xml
@@ -201,4 +201,11 @@
     	 WHERE CD_NO = #{cdNo}
     	  
     </update>
+    
+    <select id="getCodeDtlNm" resultType="string">
+    	SELECT CD_DTL_NM FROM T2_CODE_DTL WHERE CD_NO = #{cdNo} AND CD_DTL_NO = #{cdDtlNo}
+    </select>
+    <update id="updateCodeDtlNm">
+    	UPDATE T2_CODE_DTL SET CD_DTL_NM = #{cdDtlNm} WHERE CD_NO = #{cdNo} AND CD_DTL_NO = #{cdDtlNo}
+    </update>
 </mapper>

--- a/src/main/resources/oss/fosslight/repository/NvdDataMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/NvdDataMapper.xml
@@ -104,6 +104,13 @@
     	DELETE FROM NVD_VULN_SW WHERE CVE_ID = #{cveId}
     </delete>
     
+    <delete id="resetCveDataV3">
+    	TRUNCATE TABLE NVD_CVE_V3
+    </delete>
+    <delete id="resetNvdDataV3">
+    	TRUNCATE TABLE NVD_DATA_V3
+    </delete>
+    
     <!-- CPE 데이터 조회 -->
     <select id="selectOneCpeDicData" parameterType="HashMap" resultType="HashMap">
     	SELECT CPE_NM AS cpeNm, TITLE AS title, PART AS part, VENDOR AS vendor, PRODUCT AS product, VERSION AS version, REG_DATE AS regDate FROM NVD_CPE_DICTIONARY WHERE CPE_NM = #{cpeNm}


### PR DESCRIPTION
## Description
Add logic to register all data from 2002 to NVD Feed Data during initial setting.

1. How it works
    - When the value of common code System initialize flag (Code management Number: 990) > Detail Code No :100 (NVD Data Feed initialize flag) is “Y”, data initialization is performed.
    - The default value is set to "N", and if the user changes it to "Y", all NVD-related Data is cleaned during the next NVD schedule operation and registered sequentially from the 2002 data file.

2. How to apply
    - Add 990 code to fosslight_create.sql. In case of new configuration, 990 code is registered. ( Default "N" )
    - How to add initialization handling to a pre-configured system : 
        -  Add code 990 to DB and apply after merging source code (5 Files)
        -  Initialization is included when working with NVD Batch at 01:00 the next day.
    - How to change the NVD Data Feed initialize flag to Y: Execute the following query.
    `UPDATE T2_CODE_DTL SET CD_DTL_NM = 'Y' WHERE CD_NO = '990' AND CD_DTL_NO = '100'`
        - Reasons for not being able to modify in Code management (UI): Code 9** is intentionally hidden because there is a risk that problems may occur if the user directly changes it.

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)