### PR TITLE
Add Line Separator Between Notice Intro And OSS Lists

### DIFF
--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -3687,7 +3687,9 @@ public class CommonFunction extends CoTopComponent {
 	    props.put("input.encoding", "UTF-8");
 	    
 		ve.init(props);
-		
+
+		// Core Logic: Velocity engine decides which template should be loaded according to the model's template URL
+		// Refer to the 'template' directory for further information.
 		try {
 			Template template = ve.getTemplate((String) model.get("templateURL"));
 			template.merge(context, writer);

--- a/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
@@ -392,7 +392,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				return "binAndroid"; 
 			} else {
 				ossNotice.setNetworkServerFlag(prjInfo.getNetworkServerType());
-				
+
+				// Convert Map to Apache Velocity Template
 				return CommonFunction.VelocityTemplateToString(getNoticeHtmlInfo(ossNotice));
 			}
 		}

--- a/src/main/resources/template/notice/notice.txt
+++ b/src/main/resources/template/notice/notice.txt
@@ -1,8 +1,10 @@
 #set($hash = "#")
 $hash$hash$hash Open Source Software Notice $hash$hash$hash
 
-#if($!{editCompanyYn} == "Y")This product from $!{companyNameFull} contains the open source software detailed below. Please refer to the indicated open source licenses (as are included following this notice) for the terms and conditions of their use.#end
-#if($!{editCompanyYn} != "Y")This product contains the open source software detailed below. Please refer to the indicated open source licenses (as are included following this notice) for the terms and conditions of their use.#end
+#if($!{editCompanyYn} == "Y")This product from $!{companyNameFull} contains the open source software detailed below. Please refer to the indicated open source licenses (as are included following this notice) for the terms and conditions of their use.
+#end
+#if($!{editCompanyYn} != "Y")This product contains the open source software detailed below. Please refer to the indicated open source licenses (as are included following this notice) for the terms and conditions of their use.
+#end
 
 #if($!{disclosureObligationSize} != "0")	
 #foreach( $!{closeSource} in $!{disclosureObligationList} ) 

--- a/src/main/resources/template/notice/notice_sks.txt
+++ b/src/main/resources/template/notice/notice_sks.txt
@@ -1,8 +1,10 @@
 #set($hash = "#")
 $hash$hash$hash $!{companyNameShot} Open Source Software Notice $hash$hash$hash
 
-#if($!{editCompanyYn} == "Y")This product from $!{companyNameFull} contains the open source software detailed below. Please refer to the indicated open source licenses (as are included following this notice) for the terms and conditions of their use.#end
-#if($!{editCompanyYn} != "Y")This product contains the open source software detailed below. Please refer to the indicated open source licenses (as are included following this notice) for the terms and conditions of their use.#end
+#if($!{editCompanyYn} == "Y")This product from $!{companyNameFull} contains the open source software detailed below. Please refer to the indicated open source licenses (as are included following this notice) for the terms and conditions of their use.
+#end
+#if($!{editCompanyYn} != "Y")This product contains the open source software detailed below. Please refer to the indicated open source licenses (as are included following this notice) for the terms and conditions of their use.
+#end
 
 #if($!{disclosureObligationSize} != "0")
 #foreach( $!{closeSource} in $!{disclosureObligationList} ) 


### PR DESCRIPTION
Signed-off-by: mhjang <mhjang@miridih.com>

## Description
When you download an OSS Notice file in a .txt type, this adds a line separator between the notice introduction and the OSS list that will be packaged.


## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
