### PR TITLE
Add alert when the number of OSS versions is 1

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
@@ -506,7 +506,9 @@
 						contentType : 'application/json',
 						success : function(data){
 							var length = data.ossList.length;
-							if (length > 1) {
+							if (length == 1) {
+								alertify.alert('At least two OSS versions are required.', function(){});
+							} else if (length > 1) {
 								$.ajax({
 									url : '<c:url value="/oss/checkExistsOssByname"/>',
 									type : 'GET',


### PR DESCRIPTION
## Description
* Add a condition when length == 1.
* When length == 1 "At least two OSS versions are required." alert

| oss.length == 1 | oss.length > 1 |
|:--:|:--:|
|alert|popup|
|![스크린샷 2021-09-15 오후 12 47 21](https://user-images.githubusercontent.com/32615702/133367476-74db9ecc-bd7f-4b12-af8b-a491d15bbc85.png)|![스크린샷 2021-09-15 오후 12 28 08](https://user-images.githubusercontent.com/32615702/133365899-043740be-946f-4504-a421-3a0aa061e8f0.png)|

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
