### PR TITLE
Fix JSON parsing error in basic.js

### DIFF
--- a/src/main/resources/static/js/basic.js
+++ b/src/main/resources/static/js/basic.js
@@ -332,8 +332,12 @@ var loading = {
 
 /* iFrame에서 호출 (보안문제로 broadcast하여 호출) */
 function receiveMessage(event) {
-	var data = JSON.parse(event.data);
-	
+	var data = event.data;
+
+	if (typeof data === 'string') {
+		data = JSON.parse(event.data);
+	}
+
 	switch(data.action){
 		case 'create':
 			createTab(data.tabData[0], data.tabData[1]);


### PR DESCRIPTION
## Description
This is a PR to address the #133. If this PR is merged, we can be freed from the countless error messages shown below, unlike before. The JSON.parse method requires data of string type (text) as a parameter, but in our project, sometimes an object type was entered as a parameter and an error occurred. In this PR, by checking the data type, if it is already an object type, the JSON.parse method is not called, but if it is a string type, the error is solved by making it a JSON object.


![스크린샷 19-09-2021 15 23 04](https://user-images.githubusercontent.com/76172759/133918712-ab6748ba-45aa-4980-beee-69f2d873efec.png)



## Type of change
Please insert 'x' one of the type of change.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
