### PR TITLE
unquoted port mapping may be interpreted as a base-60 value

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       image: mariadb:10
       container_name: fosslight_db
       ports:
-        - 3306:3306
+        - "3306:3306"
       volumes:
         - ./db/conf.d:/etc/mysql/conf.d
         - ./db/data:/var/lib/mysql
@@ -17,14 +17,14 @@ services:
         TZ: Asia/Seoul
       restart: always
       expose:
-        - '3306'
+        - "3306"
     web:
        build: .
        container_name: fosslight_web
        depends_on:
          - db
        ports:
-         - 8180:8180
+         - "8180:8180"
        volumes:
          - ./web-data:/data/fosslight
        environment:
@@ -42,11 +42,11 @@ services:
       hostname: mail
       domainname: fosslight.org
       ports:
-        - 25:25
-        - 587:587
+        - "25:25"
+        - "587:587"
       expose:
-        - '25'
-        - '587'
+        - "25"
+        - "587"
       volumes:
         - ./mail/maildata/:/var/mail
         - ./mail/mailstate/:/var/mail-state


### PR DESCRIPTION
## Description
* docker-compose unquoted port mapping may be interpreted as a base-60 value
* 25:25 -> '25:25'

### Reference
> https://docs.docker.com/compose/compose-file/compose-file-v3/#ports

Note
When mapping ports in the HOST:CONTAINER format, you may experience erroneous results when using a container port lower than 60, because YAML parses numbers in the format xx:yy as a base-60 value. For this reason, **_we recommend always explicitly specifying your port mappings as strings._**

![스크린샷 2021-09-22 오후 3 30 58](https://user-images.githubusercontent.com/32615702/134293886-9f8889f8-bfe7-4a80-a0ba-68b6afb08d3e.png)


## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
