### PR TITLE
Add External Service settings to the configuration page

### DIFF
--- a/db/initdb.d/fosslight_create.sql
+++ b/db/initdb.d/fosslight_create.sql
@@ -1796,6 +1796,7 @@ INSERT INTO `T2_CODE` (`CD_NO`, `CD_NM`, `CD_EXP`, `SYS_CD_YN`) VALUES
 	('924', 'Compliance Status Detail Setting', 'System Detail Setting Code', 'Y'),
 	('926', 'System Detail Setting', 'System Detail Setting Code', 'Y'),
 	('927', 'Notice Info', '', 'Y'),
+	('930', 'External Service Setting', 'System Detail Setting Code', 'Y'),
 	('990', 'System initialize flag', '', 'Y');
 /*!40000 ALTER TABLE `T2_CODE` ENABLE KEYS */;
 
@@ -2277,6 +2278,7 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('909', '911', 'SMTP Flag', '', 'N', 2, 'Y'),
 	('909', '912', 'Menu Auth Flag', '', 'Y', 3, 'Y'),
 	('909', '913', 'file Path Flag', '', 'Y', 4, 'Y'),
+	('909', '940', 'External Service Flag', '', 'N', 5, 'Y'),
 	('910', '100', 'Provider Url', '', '', 1, 'Y'),
 	('911', '100', 'Mail Server', '', '', 100, 'Y'),
 	('911', '101', 'Email Address', '', '', 101, 'Y'),
@@ -2315,6 +2317,7 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('927', '100', 'HTML', '', 'Y', 1, 'Y'),
 	('927', '101', 'TEXT', '', 'Y', 2, 'Y'),
 	('927', '102', 'SPDX', '', 'Y', 3, 'Y'),
+	('930', '100', 'Github Token', '', 'github token', 1, 'Y'),
 	('990', '100', 'N', '', 'NVD Data Feed initialize flag', 1, 'Y');
 /*!40000 ALTER TABLE `T2_CODE_DTL` ENABLE KEYS */;
 

--- a/src/main/java/oss/fosslight/common/CoConstDef.java
+++ b/src/main/java/oss/fosslight/common/CoConstDef.java
@@ -96,6 +96,7 @@ public class CoConstDef {
 	public static final String CD_LDAP_USED_FLAG				= "910";
 	public static final String CD_SMTP_USED_FLAG				= "911";
 //	public static final String CD_MENU_AUTH_FLAG				= "912";
+	public static final String CD_EXTERNAL_SERVICE_USED_FLAG	= "940";
 	
 	// Login Setting
 	public static final String CD_LOGIN_SETTING					= "910";
@@ -138,7 +139,10 @@ public class CoConstDef {
 	public static final String CD_DTL_NOTICE_HTML				= "100";
 	public static final String CD_DTL_NOTICE_TEXT				= "101";
 	public static final String CD_DTL_NOTICE_SPDX				= "102";	
-	
+
+	// External Service Setting
+	public static final String CD_EXTERNAL_SERVICE_SETTING		= "930";
+	public static final String CD_DTL_GITHUB_TOKEN  			= "100";
 	
 	/** System Setting Code List End */
 	

--- a/src/main/webapp/WEB-INF/views/admin/system/configuration-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/system/configuration-js.jsp
@@ -79,6 +79,22 @@
 			} else {
 				params["smtpFlag"] = "N";
 			}
+
+			// External Service Setting
+			var externalServiceFlag = $("#externalServiceFlag").prop("checked");
+
+			if(externalServiceFlag){
+				params["externalServiceFlag"] = "Y";
+
+				var externalServiceDetail = {};
+			<c:forEach var="code" items="${ct:getCodeValues(ct:getConstDef('CD_EXTERNAL_SERVICE_SETTING'))}" varStatus="status">
+				externalServiceDetail["${code[0]}"] = $("#external${code[0]}").val();
+			</c:forEach>
+				params["externalServiceDetail"] = externalServiceDetail;
+
+			} else {
+				params["externalServiceFlag"] = "N";
+			}
 			
 			// Menu Detail
 				// ㄴ DashBoard

--- a/src/main/webapp/WEB-INF/views/admin/system/configuration.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/system/configuration.jsp
@@ -43,6 +43,24 @@
 							</dl>
 						</div>
 					</dd>
+					<dd>
+						<span class="checkSet"><input type="checkbox" id="externalServiceFlag" name="externalServiceFlag" class="mainCategory" <c:if test="${ct:getCodeExpString(ct:getConstDef('CD_SYSTEM_SETTING'), ct:getConstDef('CD_EXTERNAL_SERVICE_USED_FLAG')) eq 'Y'}">checked</c:if> /><label>External Service Setting</label></span>
+						<div class="detailArea">
+							<dl class="col1">
+								<dt>detail Area</dt>
+								<c:forEach var="code" items="${ct:getCodeValues(ct:getConstDef('CD_EXTERNAL_SERVICE_SETTING'))}" varStatus="status">
+									<c:choose>
+										<c:when test="${fn:contains(code[1], 'Flag')}">
+											<dd><label>${code[1]}</label><span class="checkSet"><input type="checkbox" id="external${code[0]}" <c:if test="${code[3] eq 'Y'}">checked</c:if> /></dd>
+										</c:when>
+										<c:otherwise>
+											<dd><label>${code[1]}</label><input type="text" id="external${code[0]}" value="${code[0] eq '100' ? '' : code[3]}"/></dd>
+										</c:otherwise>
+									</c:choose>
+								</c:forEach>
+							</dl>
+						</div>
+					</dd>
 					<dd id="projectConfig">
 						<span class="checkSet"><label>Notice Setting</label></span>
 						<div class="detailArea">


### PR DESCRIPTION
## Description
* add External System related code
	* CD_EXTERNAL_SERVICE_SERVICE_USED_FLAG (914)
	* CD_EXTERNAL_SERVICE_SETTING (930)
	* CD_DTL_GITHUB_TOKEN (100)
* encrypt the token value and store it in the db
* add External Service Settings tab to Configuration page
* set the token value to not be visible on the Configuration page

### preview
![sep-26-2021_12-42-06](https://user-images.githubusercontent.com/32615702/134793100-8228c287-eeea-4946-ad11-c446b95a1cb8.gif)

### encrypt token (token value : test)
![_______________________________2021-09-26______________12 42 38](https://user-images.githubusercontent.com/32615702/134793105-2c92b4d5-2c92-4727-bf58-4a2c8bfe9d1a.png)


## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
