### PR TITLE
Add template to docker environment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,13 @@
 ## Description
-(Please describe what this PR do.)
+<!-- 
+Please describe what this PR do.
+ -->
 
 
 ## Type of change
+<!--
 Please insert 'x' one of the type of change.
+ -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Documentation update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-#Copyright (C) Sameer1046
-#SPDX-License-Identifier: AGPL-3.0-only
-#Build the image from source
+# Copyright (c) Sameer1046
+# SPDX-License-Identifier: AGPL-3.0-only
+# Build the image from source
 FROM gradle:6.8.2-jdk8 AS build
 
 COPY --chown=gradle:gradle . /home/gradle/src
@@ -16,12 +16,13 @@ FROM openjdk:8-jre-alpine
 LABEL maintainer="FOSSLight <fosslight-dev@lge.com>"
 
 COPY --from=build /home/gradle/src/build/libs/*.war /app/FOSSLight.war
-
 COPY ./verify/verify /app/verify/verify
 COPY ./db/wait-for /app/wait-for
+
+ADD ./src/main/resources/template /app/template
+
 RUN chmod +x /app/wait-for
 RUN chmod +x /app/verify/verify
-
 RUN apk update && apk add bash
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,8 @@ services:
                --spring.datasource.username=fosslight
                --spring.datasource.password=fosslight
                --logging.path=/data/fosslight/logs
-               --verify.bin.path=./verify"
+               --verify.bin.path=./verify
+               --export.template.path=./template"
     mail:
       image: mailserver/docker-mailserver:10
       container_name: fosslight_mail


### PR DESCRIPTION
## Description
Add template to docker environment.
- When running with docker, an error related to export occurs. This is caused by not finding the template file.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
