### PR TITLE
Fix the nickname input width size to double

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/license/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/license/edit.jsp
@@ -75,7 +75,7 @@
 							<td class="dCase">
 								<div class="multiTxtSet">	
 									<div class="required">								
-										<span><input type="text" name="licenseNicknames" /><input type="button" value="Delete" class="smallDelete" /></span>
+										<span><input type="text" name="licenseNicknames" style="width: 356px;"/><input type="button" value="Delete" class="smallDelete" /></span>
 										<span class="retxt"></span>
 									</div>
 								</div>


### PR DESCRIPTION
## Description
- The nickname input width size to double

<!-- 
Please describe what this PR do.
 -->


| capture
| -- 
|  
![image](https://user-images.githubusercontent.com/17478634/135771807-73f68e4c-b99c-40f9-ba8b-7f93a167e151.png)
 | ![image](https://user-images.githubusercontent.com/17478634/135771832-5728bdeb-2fb9-4a9c-ade4-da9fcf19ecdd.png)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
