### PR TITLE
Change link format of vulnerability discovered mail (#168)

### DIFF
--- a/src/main/resources/template/email/vulnerabilityInfo.html
+++ b/src/main/resources/template/email/vulnerabilityInfo.html
@@ -49,8 +49,10 @@
 										<td style="padding:5px;">$!vulnerability.ossVersion</td>
 										<td style="padding:5px;">
 											#if ($vulnerability.cveId)
-											#set($cveUrl = "https://nvd.nist.gov/vuln/detail/" + $vulnerability.cveId)
-											<a href="$cveUrl" target="_blank">$!vulnerability.cveId</a>
+												#set($cveIdRegExp = "((cve|CVE)-[0-9]{4}-[0-9]{4,})")
+												#set($cveLink = $vulnerability.cveId.replaceAll($cveIdRegExp,
+													"<a href='https://nvd.nist.gov/vuln/detail/$1' target='_blank'>$1<a/>"))
+												$cveLink
 											#end
 										</td>
 										<td style="padding:5px;">$!vulnerability.cvssScore</td>


### PR DESCRIPTION
Signed-off-by: Youn-Sung Hwang <acafela91@gmail.com>

## Description
- issue : #168 
- as-is

  There was a problem with the link when the CVE ID was in the form of "CVE ID -> CVE ID" or "CVE ID -> NONE".

  <img width="80%" alt="오류1" src="https://user-images.githubusercontent.com/19302597/136356666-bee023c4-ac8b-4949-af67-62e64881049d.png">
  <img width="80%" alt="오류2" src="https://user-images.githubusercontent.com/19302597/136356680-5ed2124f-d6bb-439f-83f5-b0125e54971f.png">

- to-be

  Now the link works well regardless of format.  

  <img width="80%" alt="정상1" src="https://user-images.githubusercontent.com/19302597/136357447-68aa6f08-e97f-4a2f-9131-6e5990072077.png">
  <img width="80%" alt="정상2" src="https://user-images.githubusercontent.com/19302597/136357469-6f2fd7b9-87d5-4fe3-882a-a373981749be.png">

Thank you ☺️ 

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
