### PR TITLE
Add send to everyone when sending comments

### DIFF
--- a/src/main/resources/messages/message.properties
+++ b/src/main/resources/messages/message.properties
@@ -22,7 +22,8 @@ msg.common.search.check.date=Please check the period again.
 # PROJECT
 msg.project.required.selectDivision=Please select a Division or User.
 msg.project.required.comments=Please input reason for cancelation of review.
-#2018-07-20 choye add 
+#2018-07-20 choye add
+msg.project.sent.comments.success=Your message has been sent.
 msg.project.required.comments.reject=Please input reason for reject.
 msg.project.required.comments.reject.ignore=Please enter a reject ignore reason.
 msg.project.required.comments.reject.ok=Please enter a reason for reject ok.

--- a/src/main/resources/messages/message_en_US.properties
+++ b/src/main/resources/messages/message_en_US.properties
@@ -23,6 +23,7 @@ msg.common.search.check.date=Please check the period again.
 msg.project.required.selectDivision=Please select a Division or User.
 msg.project.required.comments=Please input reason for cancelation of review.
 #2018-07-20 choye add 
+msg.project.sent.comments.success=Your message has been sent.
 msg.project.required.comments.reject=Please input reason for reject.
 msg.project.required.comments.reject.ignore=Please enter a reject ignore reason.
 msg.project.required.comments.reject.ok=Please enter a reason for reject ok.

--- a/src/main/resources/messages/message_ko_KR.properties
+++ b/src/main/resources/messages/message_ko_KR.properties
@@ -23,6 +23,7 @@ msg.common.search.check.date=Please check the period again.
 msg.project.required.selectDivision=Please select a Division or User.
 msg.project.required.comments=Please input reason for cancelation of review.
 #2018-07-20 choye add
+msg.project.sent.comments.success=Your message has been sent.
 msg.project.required.comments.reject=Please input reason for reject.
 msg.project.required.comments.reject.ignore=Please enter a reject ignore reason.
 msg.project.required.comments.reject.ok=Please enter a reason for reject ok.

--- a/src/main/webapp/WEB-INF/views/admin/project/common-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/common-js.jsp
@@ -581,7 +581,7 @@ var com_fn = {
 				} else {
 					$('.ajs-close').trigger("click");
 
-					alertify.success('<spring:message code="msg.common.success" />');
+					alertify.success('<spring:message code="msg.project.sent.comments.success" />');
 					resetEditor(CKEDITOR.instances.editor);
 
 					$(".commentBtn open").trigger( "click" );

--- a/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
@@ -66,7 +66,7 @@
 	</div>
 	<div class="commentEditor" style="display:none;">
 	<div class="cBtn">
-		<input type="button" value="Save & Send comment" class="btnCLight saveEditor" onclick="com_fn.editorDialog();"/>
+		<input type="button" value="Save & Send comment" class="btnCLight saveEditor" onclick="com_fn.sendEditor('WR');"/>
 		<input type="button" value="Save draft" class="btnCLight" onclick="com_fn.saveEditor();"/>
 	</div>
 	<div class="grid-container">


### PR DESCRIPTION
## Description
* before : When saving comments, a window appears to select the destination to send mail, and you send mail to the selected target.
* after : When saving comments, set the sending target to all and send an email when saving comments

### before
![GIF 2021-10-07 오후 10-42-23](https://user-images.githubusercontent.com/32615702/136396288-f5b38ec4-9580-498c-9731-0cbd39c537d8.gif)

### after
![GIF 2021-10-07 오후 10-39-59](https://user-images.githubusercontent.com/32615702/136395867-1b527b14-f1bd-48e2-becb-1503928227ff.gif)

### alert message
![image](https://user-images.githubusercontent.com/32615702/136396494-98ea15a4-2904-44b3-a2a8-50555259c88b.png)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
