### PR TITLE
Add SPDX json and yaml types for pakaging notice download

### DIFF
--- a/src/main/java/oss/fosslight/controller/SPDXDownloadController.java
+++ b/src/main/java/oss/fosslight/controller/SPDXDownloadController.java
@@ -147,6 +147,89 @@ public class SPDXDownloadController extends CoTopComponent {
 						log.error(e.getMessage(), e);
 					}
 				}
+			} else if("spdxJson".equals(spdxType)) {
+				if (!isEmpty(prjBean.getSpdxTagFileId())) {
+					downloadId = prjBean.getSpdxTagFileId();
+				} else {
+					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
+					T2File sheetFile = fileService.selectFileInfo(sheetFileId);
+					String sheetFullPath = sheetFile.getLogiPath();
+
+					if (!sheetFullPath.endsWith("/")) {
+						sheetFullPath += "/";
+					}
+
+					sheetFullPath += sheetFile.getLogiNm();
+					String tagFullPath = sheetFile.getLogiPath();
+
+					if (!tagFullPath.endsWith("/")) {
+						tagFullPath += "/";
+					}
+
+					tagFullPath += FilenameUtils.getBaseName(sheetFile.getLogiNm()) + ".json";
+
+					SPDXUtil2.convert(prjId, sheetFullPath, tagFullPath);
+
+					downloadId = fileService.registFileDownload(sheetFile.getLogiPath(), FilenameUtils.getBaseName(sheetFile.getOrigNm()) + ".json",
+							FilenameUtils.getBaseName(sheetFile.getLogiNm()) + ".json");
+
+					try {
+						File spdxTafFile = new File(tagFullPath);
+
+						if (spdxTafFile.exists() && spdxTafFile.length() <= 0) {
+							CommentsHistory commHisBean = new CommentsHistory();
+							commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS);
+							commHisBean.setReferenceId(prjId);
+							commHisBean.setContents(getMessage("spdx.tag.failure"));
+							commHisBean.setStatus(null); // 일반적인 comment에는 status를 넣지 않음.
+							commentService.registComment(commHisBean);
+						}
+					} catch (Exception e) {
+						log.error(e.getMessage(), e);
+					}
+				}
+			} else if("spdxYaml".equals(spdxType)) {
+				if (!isEmpty(prjBean.getSpdxTagFileId())) {
+					downloadId = prjBean.getSpdxTagFileId();
+				} else {
+					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
+					T2File sheetFile = fileService.selectFileInfo(sheetFileId);
+					String sheetFullPath = sheetFile.getLogiPath();
+
+					if (!sheetFullPath.endsWith("/")) {
+						sheetFullPath += "/";
+					}
+
+					sheetFullPath += sheetFile.getLogiNm();
+
+					String tagFullPath = sheetFile.getLogiPath();
+
+					if (!tagFullPath.endsWith("/")) {
+						tagFullPath += "/";
+					}
+
+					tagFullPath += FilenameUtils.getBaseName(sheetFile.getLogiNm()) + ".yaml";
+
+					SPDXUtil2.convert(prjId, sheetFullPath, tagFullPath);
+
+					downloadId = fileService.registFileDownload(sheetFile.getLogiPath(), FilenameUtils.getBaseName(sheetFile.getOrigNm()) + ".yaml",
+							FilenameUtils.getBaseName(sheetFile.getLogiNm()) + ".yaml");
+
+					try {
+						File spdxTafFile = new File(tagFullPath);
+
+						if (spdxTafFile.exists() && spdxTafFile.length() <= 0) {
+							CommentsHistory commHisBean = new CommentsHistory();
+							commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS);
+							commHisBean.setReferenceId(prjId);
+							commHisBean.setContents(getMessage("spdx.tag.failure"));
+							commHisBean.setStatus(null); // 일반적인 comment에는 status를 넣지 않음.
+							commentService.registComment(commHisBean);
+						}
+					} catch (Exception e) {
+						log.error(e.getMessage(), e);
+					}
+				}
 			} else if("spdx".equals(spdxType)){
 				if(!isEmpty(prjBean.getSpdxSheetFileId())) {
 					downloadId = prjBean.getSpdxSheetFileId();

--- a/src/main/webapp/WEB-INF/views/admin/project/verification-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/verification-js.jsp
@@ -877,6 +877,10 @@
 					fn.downloadSpdxRdf();
 				} else if(type == 'spdxTag') {
 					fn.downloadSpdxTag();
+				} else if(type == 'spdxJson') {
+					fn.downloadSpdxJson();
+				} else if(type == 'spdxYaml') {
+					fn.downloadSpdxYaml();
 				}
 			});
 			
@@ -1849,6 +1853,48 @@
 					alertify.error('<spring:message code="msg.common.valid2" />', 0);
 				}
 			});
+		},
+
+		downloadSpdxJson : function() {
+			$.ajax({
+				type: "POST",
+				url: '<c:url value="/spdxdownload/getSPDXPost"/>',
+				data: JSON.stringify({"type":"spdxJson", "parameter":'${project.prjId}'}),
+				dataType : 'json',
+				cache : false,
+				contentType : 'application/json',
+				success: function (data) {
+					if("false" == data.isValid) {
+						alertify.error('<spring:message code="msg.common.valid2" />', 0);
+					} else {
+						window.location =  '<c:url value="/spdxdownload/getFile?id='+data.validMsg+'"/>';
+					}
+				},
+				error: function(data){
+					alertify.error('<spring:message code="msg.common.valid2" />', 0);
+				}
+			})
+		},
+
+		downloadSpdxYaml : function() {
+			$.ajax({
+				type: "POST",
+				url: '<c:url value="/spdxdownload/getSPDXPost"/>',
+				data: JSON.stringify({"type":"spdxYaml", "parameter":'${project.prjId}'}),
+				dataType : 'json',
+				cache : false,
+				contentType : 'application/json',
+				success: function (data) {
+					if("false" == data.isValid) {
+						alertify.error('<spring:message code="msg.common.valid2" />', 0);
+					} else {
+						window.location =  '<c:url value="/spdxdownload/getFile?id='+data.validMsg+'"/>';
+					}
+				},
+				error: function(data){
+					alertify.error('<spring:message code="msg.common.valid2" />', 0);
+				}
+			})
 		},
 		appendEditVisible : function(target){
 			var checked = $(target).prop("checked");

--- a/src/main/webapp/WEB-INF/views/admin/project/verification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/verification.jsp
@@ -423,19 +423,21 @@
 						<strong for="docType" title="selected value"></strong>
 						<select id="docType" name="docType">
 							<!-- <option value="noticePreview">Notice Preview</option> -->
-						    <option value="noticeDownload">Default (html)</option>
+							<option value="noticeDownload">Default (html)</option>
 							<c:if test="${ct:getCodeExpString(ct:getConstDef('CD_NOTICE_INFO'), ct:getConstDef('CD_DTL_NOTICE_TEXT')) eq 'Y'}">
-						    	<option value="noticeTextDownload">Default (text)</option>
-					    	</c:if>
-						    <option value="noticeSimpleDownload">Simple (html)</option>
-						    <c:if test="${ct:getCodeExpString(ct:getConstDef('CD_NOTICE_INFO'), ct:getConstDef('CD_DTL_NOTICE_TEXT')) eq 'Y'}">
-						    	<option value="noticeTextSimpleDownload">Simple (text)</option>
-						    </c:if>
-						    <c:if test="${ct:getCodeExpString(ct:getConstDef('CD_NOTICE_INFO'), ct:getConstDef('CD_DTL_NOTICE_SPDX')) eq 'Y'}">
-							    <option value="spdxSpreadSheet">SPDX (spreadsheet)</option>
-			  			    	<option value="spdxRdf">SPDX (RDF)</option>
-						    	<option value="spdxTag">SPDX (TAG)</option>
-					    	</c:if>
+								<option value="noticeTextDownload">Default (text)</option>
+							</c:if>
+							<option value="noticeSimpleDownload">Simple (html)</option>
+							<c:if test="${ct:getCodeExpString(ct:getConstDef('CD_NOTICE_INFO'), ct:getConstDef('CD_DTL_NOTICE_TEXT')) eq 'Y'}">
+								<option value="noticeTextSimpleDownload">Simple (text)</option>
+							</c:if>
+							<c:if test="${ct:getCodeExpString(ct:getConstDef('CD_NOTICE_INFO'), ct:getConstDef('CD_DTL_NOTICE_SPDX')) eq 'Y'}">
+								<option value="spdxSpreadSheet">SPDX (spreadsheet)</option>
+								<option value="spdxRdf">SPDX (RDF)</option>
+								<option value="spdxTag">SPDX (TAG)</option>
+								<option value="spdxJson">SPDX (JSON)</option>
+								<option value="spdxYaml">SPDX (YAML)</option>
+							</c:if>
 						</select>
 					</span>
 					<input type="button" id="packageDocDownload" value="download" class="btnColor" style="width: 100px;"/>


### PR DESCRIPTION
## Description
- add spdx json and spdx yaml formats in pakaging notice download
<img width="1070" alt="스크린샷 2021-10-07 오후 11 21 32" src="https://user-images.githubusercontent.com/80666066/136409507-69c1e8ee-5abb-412c-800a-691214d5a371.png">

### Output file examples  
downloaded spdx json file would started like ...
```json
{
  "SPDXID" : "SPDXRef-DOCUMENT",
  "spdxVersion" : "SPDX-2.2",
  "creationInfo" : {
    "created" : "2021-10-07T23:48:42Z",
    "creators" : [ "Person: choi (hyewoncc@gmail.com)", "Organization: FOSSLight (opensource@fosslight.org)", "Tool: SPDXTools-2.2.2" ],
    "licenseListVersion" : "3.10"
  },
```
and spdx yaml file...
```yaml
---
SPDXID: "SPDXRef-DOCUMENT"
spdxVersion: "SPDX-2.2"
creationInfo:
  created: "2021-10-07T23:48:49Z"
  creators:
  - "Person: choi (hyewoncc@gmail.com)"
  - "Organization: FOSSLight (opensource@fosslight.org)"
  - "Tool: SPDXTools-2.2.2"
  licenseListVersion: "3.10"
```

## Proposal  
After developing it, I noticed that SPDXDownloadController.java has many duplicated lines  
From line 66 to 232, where this controller convert file to specific formats, only an extension type is changed  
So when this request'd be passed, I hope I can work on refactoring it 

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
