### PR TITLE
Change the SPDX Spreadsheet output method for OSS Name is -

### DIFF
--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -486,11 +486,7 @@ public class CommonFunction extends CoTopComponent {
 					} else {
 						if(spdxConvert) {
 							// identifier가 없는 경우 라이선스 이름을 spdx 연동 용으로 변경한다.
-							if(CoCodeManager.LICENSE_INFO.containsKey(s) && isEmpty(CoCodeManager.LICENSE_INFO.get(s).getShortIdentifier())) {
-								s = "LicenseRef-" + s;
-							}
-							
-							s = s.replaceAll("\\(", "-").replaceAll("\\)", "").replaceAll(" ", "-").replaceAll("--", "-");
+							s = licenseStrToSPDXLicenseFormat(s);
 						}
 						andStr += s;
 					}
@@ -502,7 +498,16 @@ public class CommonFunction extends CoTopComponent {
 		
 		return rtnVal;
 	}
-	
+
+	public static String licenseStrToSPDXLicenseFormat(String licenseStr) {
+		if(CoCodeManager.LICENSE_INFO.containsKey(licenseStr) && isEmpty(CoCodeManager.LICENSE_INFO.get(licenseStr).getShortIdentifier())) {
+			licenseStr = "LicenseRef-" + licenseStr;
+		}
+
+		licenseStr = licenseStr.replaceAll("\\(", "-").replaceAll("\\)", "").replaceAll(" ", "-").replaceAll("--", "-");
+		return licenseStr;
+	}
+
 	public static String makeLicenseFromFiles(OssMaster _ossBean, boolean booleanflag) {
 		List<String> resultList = new ArrayList<>(); // declared License
 		List<String> detectedLicenseList = _ossBean.getDetectedLicenses(); // detected License


### PR DESCRIPTION
## Description
When outputting SPDX spreadsheet, if OSS Name : -, it was printed in Per file info sheet, but now it is printed in Package info sheet.
* Package Info sheet
    *  SPDX Identifier
        * if ossname is "-" : SPDXRef-File-{BOM's row id}
        * if ossname is not "-" : SPDXRef-Package-{oss id}
    * Licensed Declared : If ossname is "-", output license written to bom
    * License Concluded :  If ossname is "-", output license written to bom
    * License Info from files : If ossname is "-", output license written to bom

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
