### PR TITLE
Fix error where download location is not output when ossname is "-"

### DIFF
--- a/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
@@ -1754,11 +1754,6 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				bean.setOssName(StringUtil.replaceHtmlEscape(bean.getOssName()));
 			}
 			
-			// oss 없이 라이선스만 확인한 경우, 고지문구 oss tag가 link로 생성되지 않도록 downloadlocation을 초기화
-			if(isEmpty(bean.getOssName()) || "-".equals(bean.getOssName())) {
-				bean.setDownloadLocation("");
-			}
-			
 			noticeList.add(bean);
 		}
 		List<OssComponents> srcList = new ArrayList<>();
@@ -1781,11 +1776,6 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			if(!isEmpty(bean.getOssName())) {
 				bean.setOssName(StringUtil.replaceHtmlEscape(bean.getOssName()));
-			}
-			
-			// oss 없이 라이선스만 확인한 경우, 고지문구 oss tag가 link로 생성되지 않도록 downloadlocation을 초기화
-			if(isEmpty(bean.getOssName()) || "-".equals(bean.getOssName())) {
-				bean.setDownloadLocation("");
 			}
 			
 			srcList.add(bean);


### PR DESCRIPTION
## Description
* Fix error where download location is not output when ossname is "-"

### before
If ossname is "-", the download location is NONE.
![image](https://user-images.githubusercontent.com/32615702/136731100-1acdf724-3d91-4700-bb73-8f943e41fb66.png)


### after
![image](https://user-images.githubusercontent.com/32615702/136731073-efaebf01-2f53-44ff-8fe2-91e01a0e284b.png)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
