### PR TITLE
Change Self-Check in Obligation Warning message

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
@@ -705,8 +705,9 @@
 				if(!_obligationMsg || _obligationMsg == "") {
 					_obligationMsg = "unknown obligation";
 				}
-				
-				display = "<div class=\"tcenter\"><a class='iconSet help'>"+_obligationMsg+"</a></div>";
+
+				display= "<span class=\"iconSet help\">Obligation is unclear</span>";
+
 			} else if(obligationType == 10){
 				display="<span class=\"iconSet ops\">Notice</span>";
 			} else if(obligationType == 11) {


### PR DESCRIPTION
## Description
The existing warning phrase was changed to "Obligation is unclear".


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
