### PR TITLE
Load and save all sheets with sheet names starting with Self-check, SRC, BIN

### DIFF
--- a/src/main/java/oss/fosslight/api/controller/v1/ApiSelfCheckController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiSelfCheckController.java
@@ -119,7 +119,7 @@ public class ApiSelfCheckController extends CoTopComponent {
     public CommonResult ossReportSelfCheck(
     		@RequestHeader String _token,
     		@ApiParam(value = "Project id", required = true) @RequestParam(required = true) String prjId,
-    		@ApiParam(value = "OSS Report > sheetName : 'Self-Check'", required = false) @RequestPart(required = false) MultipartFile ossReport){
+    		@ApiParam(value = "OSS Report > sheetName : 'Start with Self-Check, SRC or BIN '", required = false) @RequestPart(required = false) MultipartFile ossReport){
 		
 		T2Users userInfo = userService.checkApiUserAuth(_token);
 		Map<String, Object> resultMap = new HashMap<String, Object>(); // 성공, 실패에 대한 정보를 return하기 위한 map;

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -548,8 +548,31 @@ public class ExcelUtil extends CoTopComponent {
 			try {
 				Sheet sheet = wb.getSheetAt(Integer.parseInt(targetSheetNums[0]));
 			} catch (Exception e) {
-				int sheetIdx = wb.getSheetIndex(readType);
-				targetSheetNums[0] = Integer.toString(sheetIdx);
+				
+				String [] types = {"Self-Check", "SRC", "BIN"};
+
+				List<String> sheetNames = new ArrayList<String>();
+				for (int i=0; i<wb.getNumberOfSheets(); i++) {
+					sheetNames.add( wb.getSheetName(i) );
+				}
+
+				List<String> targetSheetNumsArrayList = new ArrayList<String>();
+
+				int idx = 0;
+				for(String sheetName : sheetNames){
+					for(String type : types){
+						if(sheetName.startsWith(type)){
+							targetSheetNumsArrayList.add(Integer.toString(idx));
+						}
+					}
+					idx++;
+				}
+				if(targetSheetNumsArrayList.isEmpty()){
+					targetSheetNums[0] = "-1";
+				}else{
+					targetSheetNums = targetSheetNumsArrayList.toArray(new String[0]);
+				}
+
 			}
 			
 			if(hasFileListSheet(targetSheetNums, wb)) {


### PR DESCRIPTION
## Description
For "/api/v1/oss_report_selfcheck" api, The sheet is loaded and saved only when the sheet name is Self-check.
It should be possible to load and save all sheets with sheet names starting with Self-check, SRC and BIN for future service expansion.

So, When you load file like below,
![image](https://user-images.githubusercontent.com/53862866/138673531-262d53ee-dc2b-45a2-ac4e-af8a875053d2.png)

![image](https://user-images.githubusercontent.com/53862866/138673460-66dc111f-f2ae-49ab-820f-e26133181576.png)
The result is
![image](https://user-images.githubusercontent.com/53862866/138673558-06b4fee4-7308-45f8-9d20-e1901f12a172.png)


- Issue number
-- #191  

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
