### PR TITLE
Change CVE-ID to a link (#212)

### DIFF
--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -4042,4 +4042,12 @@ public class CommonFunction extends CoTopComponent {
 		
 		return distributionDuplicateMsg;
 	}
+
+	public static String convertCveIdToLink(String cveId) {
+		if (StringUtil.isEmpty(cveId)) {
+			return "";
+		}
+		return cveId.replaceAll("((cve|CVE)-[0-9]{4}-[0-9]{4,})",
+				"<a href='https://nvd.nist.gov/vuln/detail/$1' target='_blank'>$1<a/>");
+	}
 }

--- a/src/main/java/oss/fosslight/domain/CoMailManager.java
+++ b/src/main/java/oss/fosslight/domain/CoMailManager.java
@@ -3143,6 +3143,7 @@ public class CoMailManager extends CoTopComponent {
 		}
 		
 		context.put("domain", CommonFunction.emptyCheckProperty("server.domain", "http://fosslight.org"));
+		context.put("commonFunction", CommonFunction.class);
 	    
 		props.put("resource.loader", "class");
 	    props.put("class.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");

--- a/src/main/resources/template/email/projectInfo.html
+++ b/src/main/resources/template/email/projectInfo.html
@@ -199,7 +199,9 @@ Guide for Packaging : <a href="$packaging_requested_url_info">$packaging_request
 									<tr>
 										<td style="padding:5px;">$!vulnerability.ossName</td>
 										<td style="padding:5px;">$!vulnerability.ossVersion</td>
-										<td style="padding:5px;">$!vulnerability.cveId</td>
+										<td style="padding:5px;">
+											$commonFunction.convertCveIdToLink($!vulnerability.cveId)
+										</td>
 										<td style="padding:5px;">$!vulnerability.cvssScore</td>
 										<td style="padding:5px;">$!vulnerability.vulnSummary</td>
 										<td style="padding:5px;">$!vulnerability.publishedDate</td>
@@ -229,8 +231,12 @@ Guide for Packaging : <a href="$packaging_requested_url_info">$packaging_request
 									</tr>
 									<tr>
 										<th align="left" style="padding:5px;background:#f0f0f0;">CVE ID</th>
-										<td style="padding:5px;">$!vulnerability_reCalc.cveId</td>
-										<td style="padding:5px;">$!vulnerability_reCalc.cveIdTo</td>
+										<td style="padding:5px;">
+											$commonFunction.convertCveIdToLink($!vulnerability_reCalc.cveId)
+										</td>
+										<td style="padding:5px;">
+											$commonFunction.convertCveIdToLink($$!vulnerability_reCalc.cveIdTo)
+										</td>
 									</tr>
 									<tr>
 										<th align="left" style="padding:5px;background:#f0f0f0;">Score</th>

--- a/src/main/resources/template/email/vulnerabilityInfo.html
+++ b/src/main/resources/template/email/vulnerabilityInfo.html
@@ -48,12 +48,7 @@
 										<td style="padding:5px;">$!vulnerability.ossName</td>
 										<td style="padding:5px;">$!vulnerability.ossVersion</td>
 										<td style="padding:5px;">
-											#if ($vulnerability.cveId)
-												#set($cveIdRegExp = "((cve|CVE)-[0-9]{4}-[0-9]{4,})")
-												#set($cveLink = $vulnerability.cveId.replaceAll($cveIdRegExp,
-													"<a href='https://nvd.nist.gov/vuln/detail/$1' target='_blank'>$1<a/>"))
-												$cveLink
-											#end
+											$commonFunction.convertCveIdToLink($!vulnerability.cveId)
 										</td>
 										<td style="padding:5px;">$!vulnerability.cvssScore</td>
 										<td style="padding:5px;">$!vulnerability.vulnSummary</td>


### PR DESCRIPTION
Signed-off-by: Youn-Sung Hwang <acafela91@gmail.com>

## Description
### issue : #212 

### as-is mail body
<img width="571" alt="스크린샷 2021-10-30 오후 4 01 07" src="https://user-images.githubusercontent.com/19302597/139523854-f3abb91c-413f-4854-ac22-5db4ba22a551.png">

### to-be mail body
<img width="562" alt="스크린샷 2021-10-30 오후 3 58 32" src="https://user-images.githubusercontent.com/19302597/139523866-9b8e1497-8048-4dc6-aca9-aaabaf6e837f.png">

### Reasons for modifying files (_CoMailManager.java, CommonFunction.java_)
- In the Velocity template, there was a code duplication that changed the CVE-ID to a link,
so i added the method to CommonFunction and put it to VelocityContext.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
