### PR TITLE
SPDX Spreadsheet License List parsing

### DIFF
--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -1061,8 +1061,7 @@ public class ExcelUtil extends CoTopComponent {
     				if(ossNameCol < 0) {
     					bean.setBinaryName(binaryNameCol < 0 ? "" : avoidNull(getCellData(row.getCell(binaryNameCol))).trim().replaceAll("\t", ""));
     					bean.setCopyrightText(copyrightTextCol < 0 ? "" : getCellData(row.getCell(copyrightTextCol)));
-//    					bean.setComments(commentCol < 0 ? getCellData(row.getCell(licenseCol)) : getCellData(row.getCell(licenseCol)) + ", " + getCellData(row.getCell(commentCol)));
-    					bean.setComments(commentCol < 0 ? "" : getCellData(row.getCell(commentCol)));
+    					bean.setComments(commentCol < 0 ? getCellData(row.getCell(licenseCol)) : getCellData(row.getCell(licenseCol)) + ", " + getCellData(row.getCell(commentCol)));
     					bean.setFilePath(pathOrFileCol < 0 ? "" : avoidNull(getCellData(row.getCell(pathOrFileCol))).trim().replaceAll("\t", ""));
     					if(bean.getCopyrightText() == ""){
     						bean.setCopyrightText(" ");
@@ -1096,7 +1095,7 @@ public class ExcelUtil extends CoTopComponent {
     					bean.setFilePath(pathOrFileCol < 0 ? "" : avoidNull(getCellData(row.getCell(pathOrFileCol))).trim().replaceAll("\t", ""));
     					bean.setBinaryName(binaryNameCol < 0 ? "" : avoidNull(getCellData(row.getCell(binaryNameCol))).trim().replaceAll("\t", ""));
     					bean.setCopyrightText(copyrightTextCol < 0 ? "" : getCellData(row.getCell(copyrightTextCol)));
-//    					bean.setComments(commentCol < 0 ? getCellData(row.getCell(licenseCol)) : getCellData(row.getCell(licenseCol)) + ", " + getCellData(row.getCell(commentCol)));
+//  					bean.setComments(commentCol < 0 ? getCellData(row.getCell(licenseCol)) : getCellData(row.getCell(licenseCol)) + ", " + getCellData(row.getCell(commentCol)));
     					bean.setComments(commentCol < 0 ? "" : getCellData(row.getCell(commentCol)));
     					bean.setOssNickName(nickNameCol < 0 ? "" : getCellData(row.getCell(nickNameCol)));
     					bean.setSpdxIdentifier(spdxIdentifierCol < 0 ? "" : getCellData(row.getCell(spdxIdentifierCol)));
@@ -1116,11 +1115,10 @@ public class ExcelUtil extends CoTopComponent {
     				// oss Name을 입력하지 않거나, 이전 row와 oss name, oss version이 동일한 경우, 멀티라이선스로 판단
     				OssComponentsLicense subBean = new OssComponentsLicense();
     				String licenseName = getCellData(row.getCell(licenseCol));
-//    				if(licenseName.contains("(")){
-//    					licenseName = StringUtil.join(Arrays.asList(licenseName.split("\\(|\\)| ")).stream().filter(l -> !isEmpty(l) && !l.equals("AND") && !l.equals("OR")).collect(Collectors.toList()), ",");
-//    				}
-//    				else 
-    				if(licenseName.contains(",")) {
+    				if(sheet.getSheetName().equals("Package Info") || sheet.getSheetName().equals("Per File Info")){
+    					licenseName = StringUtil.join(Arrays.asList(licenseName.split("\\(|\\)| ")).stream().filter(l -> !isEmpty(l) && !l.equals("AND") && !l.equals("OR")).collect(Collectors.toList()), ",");
+    				}
+    				else if (licenseName.contains(",")) {
     					licenseName = StringUtil.join(Arrays.asList(licenseName.split(",")).stream().filter(l -> !isEmpty(l)).collect(Collectors.toList()), ",");
     				}
     				subBean.setLicenseName(licenseCol < 0 ? "" : licenseName);


### PR DESCRIPTION
Signed-off-by: Taehyun <kimtaehyun98@naver.com>

## Description
### If Load FOSSLight Report(Excel), license parsing only by  ',' 

![image](https://user-images.githubusercontent.com/65909160/140880582-4a0c4bca-f3ad-45d0-9040-cd834141325a.png)

- test file : [FOSSLight-Report_test_License.xlsx](https://github.com/fosslight/fosslight/files/7502802/FOSSLight-Report_test_License.xlsx)

### If Load SPDX Spreadsheet, license parsing by "AND", "OR", "(", ")"

![image](https://user-images.githubusercontent.com/65909160/140880878-d4975d32-9e3c-46c8-af18-cc08b340c8ed.png)

- test file : [SPDX_test_License_comments.xls](https://github.com/fosslight/fosslight/files/7502809/SPDX_test_License_comments.xls)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
