### PR TITLE
Show a failed message in Self-check.

### DIFF
--- a/src/main/java/oss/fosslight/controller/SelfCheckController.java
+++ b/src/main/java/oss/fosslight/controller/SelfCheckController.java
@@ -321,6 +321,8 @@ public class SelfCheckController extends CoTopComponent {
 		// default 00:java error check code, 10:success code
 		String resCd = "00";
 
+		String resLicense="10";
+
 		String prjId = (String) map.get("prjId");
 		String csvFileId = (String) map.get("csvFileId");
 		String delFileString = (String) map.get("csvDelFileIds");
@@ -385,6 +387,8 @@ public class SelfCheckController extends CoTopComponent {
 			Map<String, Object> remakeComponentsMap = CommonFunction.remakeMutiLicenseComponents(ossComponents, ossComponentsLicense);
 			ossComponents = (List<ProjectIdentification>) remakeComponentsMap.get("mainList");
 			ossComponentsLicense = (List<List<ProjectIdentification>>) remakeComponentsMap.get("subList");
+
+			resLicense=selfCheckService.checkLicense(ossComponentsLicense);
 			
 			selfCheckService.registSrcOss(ossComponents, ossComponentsLicense, project);
 		}
@@ -397,6 +401,7 @@ public class SelfCheckController extends CoTopComponent {
 		resCd = "10";
 		resMap.put("isValid", String.valueOf(isValid));
 		resMap.put("resCd", resCd);
+		resMap.put("resLicense",resLicense);
 		
 		return makeJsonResponseHeader(resMap);
 	}

--- a/src/main/java/oss/fosslight/service/SelfCheckService.java
+++ b/src/main/java/oss/fosslight/service/SelfCheckService.java
@@ -135,4 +135,6 @@ public interface SelfCheckService extends HistoryConfig{
 	List<Project> copyWatcher(Project project);
 	
 	boolean existsWatcher(Project project);
+
+	String checkLicense(List<List<ProjectIdentification>> ossComponentLicense);
 }

--- a/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
@@ -1008,4 +1008,28 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 
 	@Override
 	public void updateWithoutVerifyYn(OssNotice ossNotice) {}
+
+	@Override
+	public String checkLicense(List<List<ProjectIdentification>> ossComponentLicense){
+		String result = "10";
+		boolean flag=false;
+		for (List<ProjectIdentification> comLicenseList : ossComponentLicense) {
+			for (ProjectIdentification comLicense : comLicenseList) {
+				//warning message
+				String msg = comLicense.getObligationMsg();
+
+				// warning message가 없을 경우 null이므로 "null"으로 변경
+				msg = msg != null ? msg : "null";
+
+				// 라이센스 기입 안되어 있거나 등록이 안된 경우
+				if(!(msg.equals("Unconfirmed open source")||msg.equals("Unconfirmed version")||msg.equals("null"))){
+					result="00";
+					flag=true;
+					break;
+				}
+			}
+			if(flag)	break;
+		}
+		return result;
+	}
 }

--- a/src/main/resources/messages/message_en_US.properties
+++ b/src/main/resources/messages/message_en_US.properties
@@ -173,6 +173,7 @@ msg.selfcheck.info.unconfirmed.oss=Unconfirmed open source
 msg.selfcheck.info.unconfirmed.license=Unconfirmed license
 msg.selfcheck.nickname.success=Successfully add Nickname except for OSS not registered in OSS list
 msg.selfcheck.confirm.remove.project=Are you sure you want to remove this project?<br>This will permanently delete all datas.
+msg.selfCheck.license=Please check licenese
 
 #msg.regist.duplicate=Registered users.
 msg.id.duplicate=This ID already exists.

--- a/src/main/resources/messages/message_ko_KR.properties
+++ b/src/main/resources/messages/message_ko_KR.properties
@@ -173,6 +173,7 @@ msg.selfcheck.info.unconfirmed.oss=확인되지 않은 오픈소스 입니다.
 msg.selfcheck.info.unconfirmed.license=확인되지 않은 라이선스 입니다.
 msg.selfcheck.nickname.success=OSS 목록에 등록되지 않은 OSS를 제외하고 닉네임을 추가했습니다.
 msg.selfcheck.confirm.remove.project=해당 프로젝트를 제거하시겠습니까?<br>모든 데이터가 영구적으로 삭제됩니다.
+msg.selfCheck.license=라이센스를 확인해주세요.
 
 #msg.regist.duplicate=이미 가입한 사용자입니다.
 msg.id.duplicate=이미 중복된 ID가 있습니다.

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
@@ -456,10 +456,15 @@
 							src_evt.csvDelFileSeq = [];
 							src_evt.csvFileSeq = [];
 							reloadTabInframe('/selfCheck/list');
-							
-							saveFlag = true;
-							
-							alertify.success('<spring:message code="msg.common.success" />');
+
+                            // 라이센스 기입 안되어 있거나 등록이 안된 경우
+                            if("00"==data.resLicense){
+                                alertify.error('<spring:message code="msg.selfCheck.license" />', 0);
+                            }
+                            else{
+                                saveFlag = true;
+                                alertify.success('<spring:message code="msg.common.success" />');
+                            }
 						} else {
 							alertify.error('<spring:message code="msg.common.valid2" />', 0);
 						}
@@ -986,7 +991,18 @@
 					return false;
 				}
 			});
-		}
+		},
+        createNoticeTab : function () {
+            if(saveFlag) {
+                alertify.alert('<spring:message code="msg.common.success" />', function(){
+                    createTabInFrame('Notice', '#<c:url value="/selfCheck/verification/${project.prjId}"/>');
+                });
+            } else {
+                alertify.error('<spring:message code="msg.project.required.checkOssName" />', 0);
+
+                return false;
+            }
+        }
 	};
 
 	//SRC 그리드

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
@@ -126,6 +126,7 @@
             <input id="delete" type="button" value="Delete" class="btnColor left selfCheckDelete" /><!-- 2018-07-19 choye 추가 class에  selfCheckDelete -->
             <span class="right">
             <a class="iconSet help left" id="helpLink_vulerabiityExport" style="display: none; position:relative; cursor: pointer; right:10px;"></a>
+				<input type="button" value="OSS Notice" onclick="src_fn.createNoticeTab()" class="btnColor red btnExpor srcBtn" class="btnColor red btnExpor srcBtn" style="width: 115px;" />
                 <input type="button" value="Export" onclick="src_fn.downloadExcel()" class="btnColor red btnExpor srcBtn" />
                 <input type="button" value="Check OSS Name" onclick="src_fn.CheckOssViewPage()" class="btnColor red btnExpor srcBtn" style="width: 115px;" />
                 <input id="srcResetUp" type="button" value="Reset" class="btnColor btnReset srcBtn idenReset" />
@@ -140,6 +141,7 @@
 		<div class="btnLayout">
 			<input id="delete" type="button" value="Delete" class="btnColor left selfCheckDelete" /><!-- 2018-07-19 choye 추가 class에  selfCheckDelete -->
 			<span class="right">
+				<input type="button" value="OSS Notice" onclick="src_fn.createNoticeTab()" class="btnColor red btnExpor srcBtn" class="btnColor red btnExpor srcBtn" style="width: 115px;" />
 				<input type="button" value="Export" onclick="src_fn.downloadExcel()" class="btnColor red btnExpor srcBtn" />
 				<input type="button" value="Check OSS Name" onclick="src_fn.CheckOssViewPage()" class="btnColor red btnExpor srcBtn" style="width: 115px;" />
 				<input id="srcReset" type="button" value="Reset" class="btnColor btnReset srcBtn idenReset" />


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
This is the PR related to the button in the self-check tab of task7.

1. when you click the OSS Notice button before clicking the save button in Self-Check, show a failed message.

1-1. This is when you click the "notice" button first.
![image](https://user-images.githubusercontent.com/47858282/140909810-42403165-6c7e-4840-86e2-a4a9e0649692.png)

1-2. This is when you save button before clicking the OSS Notice button.
![image](https://user-images.githubusercontent.com/47858282/140909978-942aedeb-0f72-43f6-b676-905ad435f427.png)
![image](https://user-images.githubusercontent.com/47858282/140910003-03a4231a-5065-41cd-a4aa-951cdc7d3eca.png)


2. When you click the save button in Self-Check, show a check message for unconfirmed license.
2-1. there is unconfirmed license.
![image](https://user-images.githubusercontent.com/47858282/140910554-0beb5bac-f724-4e49-ba43-4acca5370e36.png)

2-2. it’s all confirmed
![image](https://user-images.githubusercontent.com/47858282/140910751-dda9a5a0-2d19-4d95-a358-28eb64feb2f9.png)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
