### PR TITLE
Fix the vulnerability for SQL Injection

### DIFF
--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -2736,7 +2736,7 @@ public class CommonFunction extends CoTopComponent {
 		
 		return resultMap;
 	}
-
+	//TODO : Deprecated
 	public static String makeSearchQuery(String schKeyword, String field) {
 		StringBuffer sb = new StringBuffer();
 		

--- a/src/main/java/oss/fosslight/domain/CommentsHistory.java
+++ b/src/main/java/oss/fosslight/domain/CommentsHistory.java
@@ -265,6 +265,15 @@ public class CommentsHistory extends ComBean implements Serializable{
 	}
 
 	/**
+	 * Gets the sch keyword list.
+	 *
+	 * @return the sch keyword list
+	 */
+	public String[] getSchKeywordList() {
+		return this.schKeyword.split(" ");
+	}
+
+	/**
 	 * Gets the expansion 1.
 	 *
 	 * @return the expansion 1

--- a/src/main/resources/oss/fosslight/repository/BinaryDataHistoryMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/BinaryDataHistoryMapper.xml
@@ -7,7 +7,76 @@
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
     <sql id="orderby">
-        ORDER BY ${sidx} ${sord}
+		ORDER BY
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('ACTION_ID', sidx)">
+				ACTION_ID
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('ACTION_TYPE', sidx)">
+				ACTION_TYPE
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('BINARY_NAME', sidx)">
+				BINARY_NAME
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('FILE_PATH', sidx)">
+				FILE_PATH
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('SOURCE_PATH', sidx)">
+				SOURCE_PATH
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('CHECK_SUM', sidx)">
+				CHECK_SUM
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('ACTION_ID', sidx)">
+				ACTION_ID
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('TLSH', sidx)">
+				TLSH
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('OSS_NAME', sidx)">
+				OSS_NAME
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('OSS_VERSION', sidx)">
+				OSS_VERSION
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('LICENSE', sidx)">
+				LICENSE
+			</when>
+			<!--TODO : Change it to snake_case-->
+			<when test="@oss.fosslight.util.StringUtil@equals('PARENTNAME', sidx)">
+				PARENT_NAME
+			</when>
+			<!--TODO : Change it to snake_case-->
+			<when test="@oss.fosslight.util.StringUtil@equals('PLATFORMNAME', sidx)">
+				PLATFORM_NAME
+			</when>
+			<!--TODO : Change it to snake_case-->
+			<when test="@oss.fosslight.util.StringUtil@equals('PLATFORMVERSION', sidx)">
+				PLATFORM_VERSION
+			</when>
+			<!--TODO : Change it to snake_case-->
+			<when test="@oss.fosslight.util.StringUtil@equals('UPDATEDATE', sidx)">
+				UPDATE_DATE
+			</when>
+			<!--TODO : Change it to snake_case-->
+			<when test="@oss.fosslight.util.StringUtil@equals('CREATED_DATE', sidx)">
+				CREATED_DATE
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('MODIFIER', sidx)">
+				MODIFIER
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('COMMENT', sidx)">
+				COMMENT
+			</when>
+		</choose>
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+				ASC
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+				DESC
+			</when>
+		</choose>
     </sql>
     
     <select id="selectBinaryDataHistoryTotalCount" parameterType="oss.fosslight.domain.BinaryAnalysisResult" resultType="int">

--- a/src/main/resources/oss/fosslight/repository/CodeMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/CodeMapper.xml
@@ -9,7 +9,28 @@
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
     <sql id="orderby">
-        ORDER BY ${sidx} ${sord}
+		ORDER BY 
+    	<choose>
+			<!--TODO : CD_NO will be convert into CAST(CD_NO AS SIGNED) in the getter.
+			But It should be done in this file. Like equals('CD_NO', sidx)-->
+			<when test="@oss.fosslight.util.StringUtil@equals('CAST(CD_NO AS SIGNED)',sidx)">
+				CAST(CD_NO AS SIGNED)
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('CD_NM',sidx)">
+				CD_NM
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('CD_EXP',sidx)">
+				CD_EXP
+			</when>
+		</choose>
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+				ASC
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+				DESC
+			</when>
+		</choose>
     </sql>
     
     <select id="selectCodeTotalCount" parameterType="oss.fosslight.domain.T2Code" resultType="int">

--- a/src/main/resources/oss/fosslight/repository/CommentMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/CommentMapper.xml
@@ -166,7 +166,9 @@
 			AND REFERENCE_DIV = #{schReferenceDiv}
 		</if>
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(schKeyword)">
-			AND ${schKeywordSql}
+			<foreach item="item" index="index" collection="schKeywordList">
+        		AND CONTENTS LIKE CONCAT('%', #{item}, '%')
+  			</foreach>
 		</if>
 		AND USE_YN = 'Y'
 	ORDER BY 
@@ -233,7 +235,9 @@
 				AND T1.REFERENCE_DIV = #{schReferenceDiv}
 			</if>
 			<if test="!@oss.fosslight.util.StringUtil@isEmpty(schKeyword)">
-				AND ${schKeywordSql}
+				<foreach item="item" index="index" collection="schKeywordList">
+					AND CONTENTS LIKE CONCAT('%', #{item}, '%')
+				</foreach>
 			</if>
 			AND T1.USE_YN = 'Y'
 		ORDER BY 
@@ -275,7 +279,9 @@
 			AND REFERENCE_DIV = #{schReferenceDiv}
 		</if>
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(schKeyword)">
-			AND ${schKeywordSql}
+			<foreach item="item" index="index" collection="schKeywordList">
+				AND CONTENTS LIKE CONCAT('%', #{item}, '%')
+			</foreach>
 		</if>
 		AND USE_YN = 'Y'
 	</select>

--- a/src/main/resources/oss/fosslight/repository/DashboardMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/DashboardMapper.xml
@@ -447,7 +447,8 @@
             </if>
         <choose>
             <when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY T1.MODIFIED_DATE DESC</when>
-            <otherwise>ORDER BY ${sidx} ${sord}</otherwise>
+			<!--jQGrid uses "loadonce" option. So below line will have never been used.-->
+            <!--<otherwise>ORDER BY ${sidx} ${sord}</otherwise>-->
         </choose>
     </select>
    
@@ -496,7 +497,8 @@
 	        </if>
 	    <choose>
             <when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY T1.MODIFIED_DATE DESC</when>
-            <otherwise>ORDER BY ${sidx} ${sord}</otherwise>
+			<!--jQGrid uses "loadonce" option. So below line will have never been used.-->
+            <!--<otherwise>ORDER BY ${sidx} ${sord}</otherwise>-->
         </choose>
     </select>
    

--- a/src/main/resources/oss/fosslight/repository/HistoryMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/HistoryMapper.xml
@@ -87,8 +87,30 @@
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(endDate)">
 			AND MODIFIED_DATE <![CDATA[<=]]> #{endDate}
 		</if>
-		<bind name="field" value="@oss.fosslight.util.StringUtil@convertToUnderScore(sortField)"/>
-		ORDER BY ${field} ${sortOrder}
+		<if test="sortField eq 'idx'">
+			ORDER BY IDX
+		</if>
+		<if test="sortField eq 'hTitle'">
+			ORDER BY H_TITLE
+		</if>
+		<if test="sortField eq 'hTypeNm'">
+			ORDER BY H_TYPE_NM
+		</if>
+		<if test="sortField eq 'hAction'">
+			ORDER BY H_ACTION
+		</if>
+		<if test="sortField eq 'modifier'">
+			ORDER BY MODIFIER
+		</if>
+		<if test="sortField eq 'modifiedDate'">
+			ORDER BY MODIFIED_DATE
+		</if>
+		<if test="sortOrder eq 'asc'">
+			ASC
+		</if>
+		<if test="sortOrder eq 'desc'">
+			DESC
+		</if>
 		<include refid="limitPage"/>
 	</select>
 	

--- a/src/main/resources/oss/fosslight/repository/NoticeMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/NoticeMapper.xml
@@ -9,7 +9,36 @@
 	</sql>
 	
     <sql id="orderby">
-        ORDER BY ${sidx} ${sord}
+        ORDER BY
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('SEQ',sidx)">
+				SEQ
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('TITLE',sidx)">
+				TITLE
+			</when>
+			<!--Why do we need replaceNotice-->
+			<when test="@oss.fosslight.util.StringUtil@equals('REPLACE_NOTICE',sidx)">
+				NOTICE
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('S_DATE',sidx)">
+				S_DATE
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('E_DATE',sidx)">
+				E_DATE
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('PUBLISH_YN',sidx)">
+				PUBLISH_YN
+			</when>
+		</choose>
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+				ASC
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+				DESC
+			</when>
+		</choose>
     </sql>
 	
 	<select id="selectNoticeTotalCount" parameterType="oss.fosslight.domain.Notice" resultType="int">

--- a/src/main/resources/oss/fosslight/repository/OssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/OssMapper.xml
@@ -15,7 +15,63 @@
     	</if>
     	<choose>
     		<when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)"> OSS_ID desc</when>
-    		<otherwise> ${sidx} ${sord}</otherwise>
+    		<otherwise>
+				<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('OSS_ID',sidx)">
+						OSS_ID
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('OSS_TYPE',sidx)">
+						OSS_TYPE
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('OSS_NAME',sidx)">
+						OSS_NAME
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('OSS_VERSION',sidx)">
+						OSS_VERSION
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('LICENSE_NAME',sidx)">
+						LICENSE_NAME
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('LICENSE_TYPE',sidx)">
+						LICENSE_TYPE
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('OBLIGATION',sidx)">
+						OBLIGATION
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('DOWNLOAD_LOCATION',sidx)">
+						DOWNLOAD_LOCATION
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('HOMEPAGE',sidx)">
+						HOMEPAGE
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('SUMMARY_DESCRIPTION',sidx)">
+						SUMMARY_DESCRIPTION
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE',sidx)">
+						CVSS_SCORE
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('CREATOR',sidx)">
+						CREATOR
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('CREATED_DATE',sidx)">
+						CREATED_DATE
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('MODIFIER',sidx)">
+						MODIFIER
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('MODIFIED_DATE',sidx)">
+						MODIFIED_DATE
+					</when>
+				</choose>
+				<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+						ASC
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+						DESC
+					</when>
+				</choose>
+			</otherwise>
     	</choose>
     </sql>
     

--- a/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
@@ -11,27 +11,27 @@
     <sql id="orderby">
     	<choose>
     		<when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY PRJ_ID desc</when>
-    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('PRJ_NAME', sidx) and  @oss.fosslight.util.StringUtil@equals('asc', sord)">
+    		<when test="@oss.fosslight.util.StringUtil@equals('PRJ_NAME', sidx) and  @oss.fosslight.util.StringUtil@equals('asc', sord)">
     			ORDER BY (
     			  CASE 
-    				WHEN ${sidx} REGEXP '^[a-zA-Z].+$' then 1 
-					WHEN ${sidx} REGEXP '^[가-힣].+$' then 2 
-					WHEN ${sidx} REGEXP '^[0-9].+$' then 3 
+    				WHEN PRJ_NAME REGEXP '^[a-zA-Z].+$' then 1 
+					WHEN PRJ_NAME REGEXP '^[가-힣].+$' then 2 
+					WHEN PRJ_NAME REGEXP '^[0-9].+$' then 3 
 					ELSE 4 
-			      END), ${sidx} ${sord}
+			      END), PRJ_NAME
     		</when>
-    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('PRJ_NAME', sidx) and  @oss.fosslight.util.StringUtil@equals('desc', sord)">
+			<when test="@oss.fosslight.util.StringUtil@equals('PRJ_NAME', sidx) and  @oss.fosslight.util.StringUtil@equals('desc', sord)">
     			ORDER BY (
     			  CASE 
-    				WHEN ${sidx} REGEXP '^[a-zA-Z].+$' then 4 
-					WHEN ${sidx} REGEXP '^[가-힣].+$' then 3 
-					WHEN ${sidx} REGEXP '^[0-9].+$' then 2 
+    				WHEN PRJ_NAME REGEXP '^[a-zA-Z].+$' then 4 
+					WHEN PRJ_NAME REGEXP '^[가-힣].+$' then 3 
+					WHEN PRJ_NAME REGEXP '^[0-9].+$' then 2 
 					ELSE 1 
-			      END), ${sidx} ${sord}
+			      END), PRJ_NAME
     		</when>
-    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('IDENTIFICATION_STATUS', sidx)">
+    		<when test="@oss.fosslight.util.StringUtil@equals('IDENTIFICATION_STATUS', sidx)">
     			ORDER BY (
-    				CASE ${sidx}
+    				CASE IDENTIFICATION_STATUS
     					WHEN '' THEN 1
 	    				WHEN 'NA' THEN 2
 	    				WHEN 'PROG' THEN 3
@@ -39,44 +39,53 @@
 	    				WHEN 'REV' THEN 5
 	    				WHEN 'CONF' THEN 6
 	    			END
-    			) ${sord}
+    			)
     		</when>
-    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('VERIFICATION_STATUS', sidx)">
+    		<when test="@oss.fosslight.util.StringUtil@equals('VERIFICATION_STATUS', sidx)">
     			ORDER BY (
     				CASE 
     					WHEN IDENTIFICATION_STATUS != 'CONF' THEN 1
-    					WHEN ${sidx} = '' AND IDENTIFICATION_STATUS = 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
-    					WHEN ${sidx} = '' AND A.COMPLETE_YN = 'Y' THEN 3
-    					WHEN ${sidx} = 'NA' THEN 4
-	    				WHEN ${sidx} = 'PROG' THEN 5
-	    				WHEN ${sidx} = 'REQ' THEN 6
-	    				WHEN ${sidx} = 'REV' THEN 7
-	    				WHEN ${sidx} = 'CONF' THEN 8
+    					WHEN VERIFICATION_STATUS = '' AND IDENTIFICATION_STATUS = 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
+    					WHEN VERIFICATION_STATUS = '' AND A.COMPLETE_YN = 'Y' THEN 3
+    					WHEN VERIFICATION_STATUS = 'NA' THEN 4
+	    				WHEN VERIFICATION_STATUS = 'PROG' THEN 5
+	    				WHEN VERIFICATION_STATUS = 'REQ' THEN 6
+	    				WHEN VERIFICATION_STATUS = 'REV' THEN 7
+	    				WHEN VERIFICATION_STATUS = 'CONF' THEN 8
 	    			END
-    			) ${sord}
+    			)
     		</when>
-    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('DESTRIBUTION_STATUS', sidx)">
+			<!--TODO: What is destribution?-->
+    		<when test="@oss.fosslight.util.StringUtil@equals('DESTRIBUTION_STATUS', sidx)">
     			ORDER BY (
     				CASE
-						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'ERROR' THEN 7
-						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'DONE' THEN 6
-						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'RSV' THEN 5
-						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'PROG' THEN 4
-						WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'NA' AND ${sidx} = 'NA') OR (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DISTRIBUTE_TARGET = 'NA' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
-						WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND ${sidx} = 'NA')  OR (VERIFICATION_STATUS != '' AND VERIFICATION_STATUS != 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') OR (${sidx} = '' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
-						WHEN VERIFICATION_STATUS = 'CONF' AND IDENTIFICATION_STATUS = 'CONF' AND ${sidx} = '' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
+						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'ERROR' THEN 7
+						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'DONE' THEN 6
+						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'RSV' THEN 5
+						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'PROG' THEN 4
+						WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'NA' AND DESTRIBUTION_STATUS = 'NA') OR (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DISTRIBUTE_TARGET = 'NA' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
+						WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DESTRIBUTION_STATUS = 'NA')  OR (VERIFICATION_STATUS != '' AND VERIFICATION_STATUS != 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') OR (DESTRIBUTION_STATUS = '' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
+						WHEN VERIFICATION_STATUS = 'CONF' AND IDENTIFICATION_STATUS = 'CONF' AND DESTRIBUTION_STATUS = '' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
 						ELSE 1
 					END
-    			) ${sord}
+    			)
     		</when>
     		<when test="@oss.fosslight.util.StringUtil@equals('DIVISION', sidx)">
-    			ORDER BY (SELECT CD.CD_DTL_NM FROM T2_CODE_DTL CD WHERE CD.CD_NO = '200' AND CD.CD_DTL_NO =  DIVISION) ${sord}
+    			ORDER BY (SELECT CD.CD_DTL_NM FROM T2_CODE_DTL CD WHERE CD.CD_NO = '200' AND CD.CD_DTL_NO =  DIVISION)
     		</when>
     		<when test="@oss.fosslight.util.StringUtil@equals('REVIEWER', sidx)">
-    			ORDER BY (SELECT u.USER_NAME FROM T2_USERS u WHERE REVIEWER = u.USER_ID) ${sord}
+    			ORDER BY (SELECT u.USER_NAME FROM T2_USERS u WHERE REVIEWER = u.USER_ID)
     		</when>
-    		<otherwise>ORDER BY ${sidx} ${sord}</otherwise>
+    		<otherwise>ORDER BY ${sidx}</otherwise>
     	</choose>
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+				ASC
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+				DESC
+			</when>
+		</choose>
     </sql>
     	
 	<select id="selectProjectTotalCount" parameterType="oss.fosslight.domain.Project" resultType="int">
@@ -3686,26 +3695,35 @@
    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('DESTRIBUTION_STATUS', sidx)">
    			ORDER BY (
    				CASE
-					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'ERROR' THEN 7
-					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'DONE' THEN 6
-					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'RSV' THEN 5
-					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'PROG' THEN 4
-					WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'NA' AND ${sidx} = 'NA') OR (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DISTRIBUTE_TARGET = 'NA' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
-					WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND ${sidx} = 'NA')  OR (VERIFICATION_STATUS != '' AND VERIFICATION_STATUS != 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') OR (${sidx} = '' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
-					WHEN VERIFICATION_STATUS = 'CONF' AND IDENTIFICATION_STATUS = 'CONF' AND ${sidx} = '' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
+					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'ERROR' THEN 7
+					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'DONE' THEN 6
+					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'RSV' THEN 5
+					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'PROG' THEN 4
+					WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'NA' AND DESTRIBUTION_STATUS = 'NA') OR (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DISTRIBUTE_TARGET = 'NA' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
+					WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DESTRIBUTION_STATUS = 'NA')  OR (VERIFICATION_STATUS != '' AND VERIFICATION_STATUS != 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') OR (DESTRIBUTION_STATUS = '' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
+					WHEN VERIFICATION_STATUS = 'CONF' AND IDENTIFICATION_STATUS = 'CONF' AND DESTRIBUTION_STATUS = '' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
 					ELSE 1
 				END
-   			) ${sord}
+   			)
    		</when>
-   		<otherwise>ORDER BY ${sidx} ${sord}</otherwise>
+		<!--TODO : Chagne ${} to #{}-->
+   		<otherwise>ORDER BY ${sidx}</otherwise>
    	</choose>
-		 <include refid="limitPage"/>
+	<choose>
+		<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+			ASC
+		</when>
+		<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+			DESC
+		</when>
+	</choose>
+	<include refid="limitPage"/>
 	</select>
 	
 	<update id="updateProjectAllowDownloadBitFlag"  parameterType="oss.fosslight.domain.Project">
 		UPDATE PROJECT_MASTER
 		   SET ALLOW_DOWNLOAD_BIT_FLAG = #{allowDownloadBitFlag}
-		 WHERE PRJ_ID = ${prjId}
+		 WHERE PRJ_ID = #{prjId}
 	</update>
 	
 	<update id="updateProjectDistributionStatus"  parameterType="String">

--- a/src/main/resources/oss/fosslight/repository/SelfCheckMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/SelfCheckMapper.xml
@@ -12,16 +12,24 @@
     	<choose>
     		<when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY PRJ_ID desc</when>
     		<when test="@oss.fosslight.util.StringUtil@equals('OS_TYPE_ETC', sidx)">
-    		ORDER BY CASE WHEN OS_TYPE = '999' THEN OS_TYPE_ETC ELSE (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '213' AND SORTCD.CD_DTL_NO = OS_TYPE) END ${sord}
+    		ORDER BY CASE WHEN OS_TYPE = '999' THEN OS_TYPE_ETC ELSE (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '213' AND SORTCD.CD_DTL_NO = OS_TYPE) END
     		</when>
     		<when test="@oss.fosslight.util.StringUtil@equals('DESTRIBUTION_NAME', sidx)">
-    		ORDER BY (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '207' AND SORTCD.CD_DTL_NO = DISTRIBUTION_TYPE) ${sord}
+    		ORDER BY (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '207' AND SORTCD.CD_DTL_NO = DISTRIBUTION_TYPE)
     		</when>
     		<when test="@oss.fosslight.util.StringUtil@equals('DIVISION', sidx)">
-    		ORDER BY (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '200' AND SORTCD.CD_DTL_NO = DIVISION) ${sord}
+    		ORDER BY (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '200' AND SORTCD.CD_DTL_NO = DIVISION)
     		</when>
-    		<otherwise>ORDER BY ${sidx} ${sord}</otherwise>
+    		<otherwise>ORDER BY ${sidx}</otherwise>
     	</choose>
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+				ASC
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+				DESC
+			</when>
+		</choose>
     </sql>
     	
 	<select id="selectProjectTotalCount" parameterType="oss.fosslight.domain.Project" resultType="int">

--- a/src/main/resources/oss/fosslight/repository/SentMailMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/SentMailMapper.xml
@@ -7,7 +7,41 @@
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
     <sql id="orderby">
-        ORDER BY ${sidx} ${sord}
+        ORDER BY
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('MSG_TYPE', sidx)">
+				MSG_TYPE
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('SND_STATUS', sidx)">
+				SND_STATUS
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('EML_TITLE', sidx)">
+				EML_TITLE
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('CREATION_DATE', sidx)">
+				CREATION_DATE
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('CREATION_USER', sidx)">
+				CREATION_USER
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('ERROR_MSG', sidx)">
+				ERROR_MSG
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('EML_TO', sidx)">
+				EML_TO
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('EML_CC', sidx)">
+				EML_CC
+			</when>
+		</choose>
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+				ASC
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+				DESC
+			</when>
+		</choose>
     </sql>
     
     <select id="selectSentMailTotalCount" parameterType="oss.fosslight.domain.CoMail" resultType="int">

--- a/src/main/resources/oss/fosslight/repository/StatisticsMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/StatisticsMapper.xml
@@ -60,14 +60,14 @@
 							, IF(STAT.CD_DTL_NM IS NOT NULL AND STAT.CATEGORY IS NULL, COUNT(1), 0) AS CATEGORY${index}
 						</when>
     					<otherwise>
-    						, IF(STAT.CATEGORY = <![CDATA['${item}']]>, COUNT(1), 0) AS CATEGORY${index}
+    						, IF(STAT.CATEGORY = #{item}, COUNT(1), 0) AS CATEGORY${index}
     					</otherwise>
     				</choose>
 	  			  </foreach>
 	  			  <if test="@oss.fosslight.util.StringUtil@equals('REV', categoryType)">
 	  			  	  , IF(
 					  <foreach collection="noneUser" item="user" index="index" separator=" OR ">
-					  	   STAT.CATEGORY = <![CDATA['${user}']]>
+					  	   STAT.CATEGORY = #{user}
 					  </foreach>
 					  , COUNT(1), 0) AS CATEGORY${titleArray.size}
 	  			  </if>
@@ -97,7 +97,7 @@
 										   WHERE CD_NO = '200'
 										     AND USE_YN = 'Y') T2
 								 ON T1.DIVISION = T2.CD_DTL_NO
-							  WHERE PM.CREATED_DATE BETWEEN ${startDate} AND ${endDate} AND PM.USE_YN ='Y') STAT
+							  WHERE PM.CREATED_DATE BETWEEN #{startDate} AND #{endDate} AND PM.USE_YN ='Y') STAT
 				    ON A.CD_DTL_NM = STAT.CD_DTL_NM
 				 GROUP BY A.CD_DTL_NM, STAT.CATEGORY
 			</if>
@@ -121,7 +121,7 @@
 						 				  INNER JOIN T2_AUTHORITIES AUTH
 						    				 ON USR.USER_ID = AUTH.USER_ID AND AUTH.AUTHORITY='ROLE_ADMIN') ADMIN
 						        ON PM.REVIEWER = ADMIN.USER_ID
-						     WHERE PM.CREATED_DATE BETWEEN ${startDate} AND ${endDate} AND PM.USE_YN ='Y') STAT
+						     WHERE PM.CREATED_DATE BETWEEN #{startDate} AND #{endDate} AND PM.USE_YN ='Y') STAT
 		    	   ON A.CD_DTL_NM = STAT.CD_DTL_NM
 		 	    GROUP BY A.CD_DTL_NM, STAT.CATEGORY
 			</if>
@@ -281,14 +281,14 @@
 			 , MAX(RTN.CATEGORY${titleArray.size}) AS CATEGORY${titleArray.size}_CNT
 		  FROM (SELECT A.DATE
 			 	  <foreach collection="titleArray" item="item" index="index">
-	  			 	 , IF(STAT.CATEGORY = <![CDATA['${item}']]>, COUNT(1), 0) AS CATEGORY${index}
+	  			 	 , IF(STAT.CATEGORY = #{item}, COUNT(1), 0) AS CATEGORY${index}
 	  			  </foreach>
 	  			  	 , IF(
 				  <foreach collection="noneUser" item="user" index="index" separator=" OR ">
-				  	   STAT.CATEGORY = <![CDATA['${user}']]>
+				  	   STAT.CATEGORY = #{user}
 				  </foreach>
 				     , COUNT(1), 0) AS CATEGORY${titleArray.size}
-				  FROM (SELECT DATE_FORMAT(DATE_ADD('${startDate}', INTERVAL (@num := @num + 1)-1 MONTH), '%Y%m') AS DATE
+				  FROM (SELECT DATE_FORMAT(DATE_ADD(#{startDate}, INTERVAL (@num := @num + 1)-1 MONTH), '%Y%m') AS DATE
 					  	  FROM INFORMATION_SCHEMA.TABLES TAB
 					     	 , (select @num := 0) NUM
 					 	 LIMIT ${diffMonthCnt}) A
@@ -318,11 +318,11 @@
 					<choose>
 						<when test="@oss.fosslight.util.StringUtil@equals('ADD', updateType)">
 							  	 ON OM.CREATOR = ADMIN.USER_ID AND OM.USE_YN = 'Y'
-							  WHERE DATE_FORMAT(OM.CREATED_DATE, '%Y%m%d') BETWEEN ${startDate} AND ${endDate}) STAT
+							  WHERE DATE_FORMAT(OM.CREATED_DATE, '%Y%m%d') BETWEEN #{startDate} AND #{endDate}) STAT
 						</when>
 						<when test="@oss.fosslight.util.StringUtil@equals('MOD', updateType)">
 							  	 ON OM.MODIFIER = ADMIN.USER_ID AND OM.USE_YN = 'Y'
-							  WHERE DATE_FORMAT(OM.MODIFIED_DATE, '%Y%m%d') BETWEEN ${startDate} AND ${endDate} 
+							  WHERE DATE_FORMAT(OM.MODIFIED_DATE, '%Y%m%d') BETWEEN #{startDate} AND #{endDate} 
 								AND OM.CREATOR != OM.MODIFIER) STAT
 						</when>
 					</choose>    
@@ -341,14 +341,14 @@
 			 , MAX(RTN.CATEGORY${titleArray.size}) AS CATEGORY${titleArray.size}_CNT
 		  FROM (SELECT A.DATE
 			 	  <foreach collection="titleArray" item="item" index="index">
-	  			 	 , IF(STAT.CATEGORY = <![CDATA['${item}']]>, COUNT(1), 0) AS CATEGORY${index}
+	  			 	 , IF(STAT.CATEGORY = #{item}, COUNT(1), 0) AS CATEGORY${index}
 	  			  </foreach>
 	  			     , IF(
 				  <foreach collection="noneUser" item="user" index="index" separator=" OR ">
-				  	   STAT.CATEGORY = <![CDATA['${user}']]>
+				  	   STAT.CATEGORY = #{user}
 				  </foreach>
 				     , COUNT(1), 0) AS CATEGORY${titleArray.size}
-				  FROM (SELECT DATE_FORMAT(DATE_ADD('${startDate}', INTERVAL (@num := @num + 1)-1 MONTH), '%Y%m') AS DATE
+				  FROM (SELECT DATE_FORMAT(DATE_ADD(#{startDate}, INTERVAL (@num := @num + 1)-1 MONTH), '%Y%m') AS DATE
 					  	  FROM INFORMATION_SCHEMA.TABLES TAB
 					     	 , (select @num := 0) NUM
 					 	 LIMIT ${diffMonthCnt}) A
@@ -378,11 +378,11 @@
 					<choose>
 						<when test="@oss.fosslight.util.StringUtil@equals('ADD', updateType)">
 							  	 ON LM.CREATOR = ADMIN.USER_ID AND LM.USE_YN = 'Y'
-							  WHERE DATE_FORMAT(LM.CREATED_DATE, '%Y%m%d') BETWEEN ${startDate} AND ${endDate}) STAT
+							  WHERE DATE_FORMAT(LM.CREATED_DATE, '%Y%m%d') BETWEEN #{startDate} AND #{endDate}) STAT
 						</when>
 						<when test="@oss.fosslight.util.StringUtil@equals('MOD', updateType)">
 							  	 ON LM.MODIFIER = ADMIN.USER_ID AND LM.USE_YN = 'Y'
-							  WHERE DATE_FORMAT(LM.MODIFIED_DATE, '%Y%m%d') BETWEEN ${startDate} AND ${endDate} 
+							  WHERE DATE_FORMAT(LM.MODIFIED_DATE, '%Y%m%d') BETWEEN #{startDate} AND #{endDate} 
 							    AND LM.CREATOR != LM.MODIFIER) STAT
 						</when>
 					</choose>
@@ -409,14 +409,14 @@
 							, IF(STAT.CD_DTL_NM IS NOT NULL AND STAT.CATEGORY IS NULL, COUNT(1), 0) AS CATEGORY${index}
 						</when>
     					<otherwise>
-    						, IF(STAT.CATEGORY = <![CDATA['${item}']]>, COUNT(1), 0) AS CATEGORY${index}
+    						, IF(STAT.CATEGORY = #{item}, COUNT(1), 0) AS CATEGORY${index}
     					</otherwise>
     				</choose>
 	  			  </foreach>
 	  			  <if test="@oss.fosslight.util.StringUtil@equals('REV', categoryType)">
 	  			  	  , IF(
 					  <foreach collection="noneUser" item="user" index="index" separator=" OR ">
-					  	   STAT.CATEGORY = <![CDATA['${user}']]>
+					  	   STAT.CATEGORY = #{user}
 					  </foreach>
 					  , COUNT(1), 0) AS CATEGORY${titleArray.size}
 	  			  </if>
@@ -437,7 +437,7 @@
 										   WHERE CD_NO = '200'
 										     AND USE_YN = 'Y') T2
 								 ON T1.DIVISION = T2.CD_DTL_NO
-							  WHERE PM.CREATED_DATE BETWEEN ${startDate} AND ${endDate}) STAT
+							  WHERE PM.CREATED_DATE BETWEEN #{startDate} AND #{endDate}) STAT
 				    ON A.CD_DTL_NM = STAT.CD_DTL_NM
 				 GROUP BY A.CD_DTL_NM, STAT.CATEGORY
 			</if>
@@ -461,7 +461,7 @@
 						 				  INNER JOIN T2_AUTHORITIES AUTH
 						    				 ON USR.USER_ID = AUTH.USER_ID AND AUTH.AUTHORITY='ROLE_ADMIN') ADMIN
 						        ON PM.REVIEWER = ADMIN.USER_ID
-						     WHERE PM.CREATED_DATE BETWEEN ${startDate} AND ${endDate}) STAT
+						     WHERE PM.CREATED_DATE BETWEEN #{startDate} AND #{endDate}) STAT
 		    	   ON A.CD_DTL_NM = STAT.CD_DTL_NM
 		 	    GROUP BY A.CD_DTL_NM, STAT.CATEGORY
 			</if>
@@ -491,7 +491,7 @@
 						 ON USR.USER_ID = PM.CREATOR AND PM.USE_YN = 'Y'
 					  INNER JOIN (SELECT * FROM T2_CODE_DTL WHERE CD_NO = '200' AND USE_YN = 'Y') DIVISION
 					     ON USR.DIVISION = DIVISION.CD_DTL_NO
-						AND PM.CREATED_DATE BETWEEN ${startDate} AND ${endDate}
+						AND PM.CREATED_DATE BETWEEN #{startDate} AND #{endDate}
 					  GROUP BY USR.USER_ID) STAT
 		    ON A.CD_DTL_NM = STAT.CD_DTL_NM
 		 GROUP BY A.CD_DTL_NM

--- a/src/main/resources/oss/fosslight/repository/T2UserMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/T2UserMapper.xml
@@ -45,10 +45,16 @@
         <choose>
             <when test="!@oss.fosslight.util.StringUtil@isEmptyTrimmed(sortField) and !@oss.fosslight.util.StringUtil@isEmptyTrimmed(sortOrder) ">
                 <if test="@oss.fosslight.util.StringUtil@equals('userId', sortField)">
-                ORDER BY USER_ID ${sortOrder}
+                ORDER BY USER_ID
                 </if>
                 <if test="@oss.fosslight.util.StringUtil@equals('userName', sortField)">
-                ORDER BY USER_NAME ${sortOrder}
+                ORDER BY USER_NAME
+                </if>
+                <if test="@oss.fosslight.util.StringUtil@equals('asc', sortOrder)">
+                ASC
+                </if>
+                <if test="@oss.fosslight.util.StringUtil@equals('desc', sortOrder)">
+                DESC
                 </if>
             </when>
             <otherwise>

--- a/src/main/resources/oss/fosslight/repository/VulnerabilityHistoryMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/VulnerabilityHistoryMapper.xml
@@ -6,8 +6,42 @@
 	<sql id="limitPage">
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
+	<!--TODO : Why don't you change camel case to snake case like other files about sidx-->
     <sql id="orderby">
-        ORDER BY ${sidx} ${sord}
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('regDt', sidx)">
+				ORDER BY REG_DT
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('ossId', sidx)">
+				ORDER BY OSS_ID
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('ossName', sidx)">
+				ORDER BY OSS_NAME
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('ossVersion', sidx)">
+				ORDER BY OSS_VERSION
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('cveId', sidx)">
+				ORDER BY CVE_ID
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('cvssScore', sidx)">
+				ORDER BY CVSS_SCORE
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('cveIdTo', sidx)">
+				ORDER BY CVE_ID_TO
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('cvssScoreTo', sidx)">
+				ORDER BY CVSS_SCORE_TO
+			</when>
+		</choose>
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+				ASC
+			</when>
+			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+				DESC
+			</when>
+		</choose>
     </sql>
     
     <select id="selectVulnerabilityHistoryTotalCount" parameterType="oss.fosslight.domain.VulnerabilityHistory" resultType="int">

--- a/src/main/resources/oss/fosslight/repository/VulnerabilityMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/VulnerabilityMapper.xml
@@ -11,15 +11,49 @@
     <sql id="orderby">
     	<choose>
     		<when test="@oss.fosslight.util.StringUtil@equals('VERSION', sidx)">
-    			ORDER BY A.SEQ ${sord} 
-			 	    , A.MAJOR_VERSION ${sord} 
-			 	    , BINARY ( CASE WHEN A.VERSION REGEXP '^[a-zA-Z]+' THEN VERSION END ) ${sord}
-			 	    , A.ASCII ${sord}
-				    , A.MINOR_VERSION ${sord}
-				    , A.PATCH_VERSION ${sord}
-				    , A.VERSION_LEN ${sord}
+				<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+						ORDER BY A.SEQ asc 
+							, A.MAJOR_VERSION asc
+							, BINARY ( CASE WHEN A.VERSION REGEXP '^[a-zA-Z]+' THEN VERSION END ) asc
+							, A.ASCII asc
+							, A.MINOR_VERSION asc
+							, A.PATCH_VERSION asc
+							, A.VERSION_LEN asc
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+						ORDER BY A.SEQ desc
+							, A.MAJOR_VERSION desc
+							, BINARY ( CASE WHEN A.VERSION REGEXP '^[a-zA-Z]+' THEN VERSION END ) desc
+							, A.ASCII desc
+							, A.MINOR_VERSION desc
+							, A.PATCH_VERSION desc
+							, A.VERSION_LEN desc
+					</when>
+				</choose>
     		</when>
-    		<otherwise>ORDER BY ${sidx} ${sord}</otherwise>
+			<otherwise>
+				<choose>
+					<!--TODO: why is it "product" not "ossName". Need to check the domain of vulnerability.-->
+					<when test="@oss.fosslight.util.StringUtil@equals('PRODUCT', sidx)">
+						ORDER BY PRODUCT
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('OSS_NICKNAME', sidx)">
+						ORDER BY OSS_NICKNAME
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE', sidx)">
+						ORDER BY CVSS_SCORE
+					</when>
+				</choose>
+				<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+						ASC
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+						DESC
+					</when>
+				</choose>
+			</otherwise>
     	</choose>
     </sql>
 	


### PR DESCRIPTION
Change ${} to #{} for defending SQL Injection. There is remain work
because the things that can not be simply replaced into #{} exist.

Signed-off-by: yugeeklab <yugeeklab@gmail.com>

## Description
<!-- 
Please describe what this PR do.
 -->


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
