### PR TITLE
Shorten the time required to save during OSS sync

### DIFF
--- a/src/main/java/oss/fosslight/domain/BinaryMaster.java
+++ b/src/main/java/oss/fosslight/domain/BinaryMaster.java
@@ -199,13 +199,15 @@ public class BinaryMaster extends ComBean implements Serializable{
 		return watcherDivision != null ? watcherDivision.clone() : null;
 	}
 	public void setWatcherDivision(String[] watcherDivision) {
-		this.watcherDivision = watcherDivision;
+		this.watcherDivision = watcherDivision != null ?
+			watcherDivision.clone() : null;
 	}
 	public String[] getWatcherUserId() {
 		return watcherUserId != null ? watcherUserId.clone() : null;
 	}
 	public void setWatcherUserId(String[] watcherUserId) {
-		this.watcherUserId = watcherUserId;
+		this.watcherUserId = watcherUserId != null ?
+			watcherUserId.clone() : null;
 	}
 	public String getBinaryFileName() {
 		return binaryFileName;
@@ -266,7 +268,7 @@ public class BinaryMaster extends ComBean implements Serializable{
 	}
 
 	public void setWatchers(String[] watchers) {
-		this.watchers = watchers;
+		this.watchers = watchers != null ? watchers.clone() : null;
 	}
 
 	public List<BinaryMaster> getWatcherList() {

--- a/src/main/java/oss/fosslight/domain/CodeBean.java
+++ b/src/main/java/oss/fosslight/domain/CodeBean.java
@@ -135,7 +135,7 @@ public class CodeBean extends ComBean implements Serializable{
      * @param cdDtlNo the new 코드상세번호
      */
     public void setCdDtlNo(String[] cdDtlNo) {
-        this.cdDtlNo = cdDtlNo;
+        this.cdDtlNo = cdDtlNo != null ? cdDtlNo.clone() : null;
     }
 
     /**
@@ -153,7 +153,7 @@ public class CodeBean extends ComBean implements Serializable{
      * @param cdDtlNm the new 코드상세명
      */
     public void setCdDtlNm(String[] cdDtlNm) {
-        this.cdDtlNm = cdDtlNm;
+        this.cdDtlNm = cdDtlNm != null ? cdDtlNm.clone() : null;
     }
     
     /**
@@ -171,7 +171,7 @@ public class CodeBean extends ComBean implements Serializable{
      * @param cdDtlNm the new 코드상세명2
      */
 	public void setCdDtlNm2(String[] cdDtlNm2) {
-		this.cdDtlNm2 = cdDtlNm2;
+        this.cdDtlNm2 = cdDtlNm2 != null ? cdDtlNm2.clone() : null;
 	}
 
 	/**
@@ -189,7 +189,7 @@ public class CodeBean extends ComBean implements Serializable{
      * @param cdDtlExp the new 코드상세설명
      */
     public void setCdDtlExp(String[] cdDtlExp) {
-        this.cdDtlExp = cdDtlExp;
+        this.cdDtlExp = cdDtlExp != null ? cdDtlExp.clone() : null;
     }
 
     /**
@@ -207,7 +207,7 @@ public class CodeBean extends ComBean implements Serializable{
      * @param cdOrder the new 코드우선순위
      */
     public void setCdOrder(String[] cdOrder) {
-        this.cdOrder = cdOrder;
+        this.cdOrder = cdOrder != null ? cdOrder.clone() : null;
     }
 
     public String[] getUseYn() {
@@ -215,7 +215,7 @@ public class CodeBean extends ComBean implements Serializable{
 	}
 
 	public void setUseYn(String[] useYn) {
-		this.useYn = useYn;
+        this.useYn = useYn != null ? useYn.clone() : null;
 	}
 
 	

--- a/src/main/java/oss/fosslight/domain/ComBean.java
+++ b/src/main/java/oss/fosslight/domain/ComBean.java
@@ -136,7 +136,7 @@ public class ComBean extends CoTopComponent implements Serializable {
 	 * @param ids the new ids
 	 */
 	public void setIds(String[] ids) {
-		this.ids = ids;
+		this.ids = ids != null ? ids.clone() : null;
 	}
 
 

--- a/src/main/java/oss/fosslight/domain/File.java
+++ b/src/main/java/oss/fosslight/domain/File.java
@@ -147,7 +147,7 @@ public class File extends ComBean implements Serializable{
         return fileSeqs != null ? fileSeqs.clone() : null;
 	}
 	public void setFileSeqs(String[] fileSeqs) {
-		this.fileSeqs = fileSeqs;
+		this.fileSeqs = fileSeqs != null ? fileSeqs.clone() : null;
 	}
 	public String getEtpId() {
 		return etpId;

--- a/src/main/java/oss/fosslight/domain/LicenseMaster.java
+++ b/src/main/java/oss/fosslight/domain/LicenseMaster.java
@@ -562,7 +562,8 @@ public class LicenseMaster extends ComBean implements Serializable {
 	 * @param licenseNicknames the new license nicknames
 	 */
 	public void setLicenseNicknames(String[] licenseNicknames) {
-		this.licenseNicknames = licenseNicknames;
+		this.licenseNicknames = licenseNicknames != null ?
+			licenseNicknames.clone() : null;
 	}
 	
 	/**
@@ -788,7 +789,8 @@ public class LicenseMaster extends ComBean implements Serializable {
 	}
 
 	public void setArrRestriction(String[] arrRestriction) {
-		this.arrRestriction = arrRestriction;
+		this.arrRestriction = arrRestriction != null ?
+			arrRestriction.clone() : null;
 	}
 	
 	public String getRestrictionList() {

--- a/src/main/java/oss/fosslight/domain/OssMaster.java
+++ b/src/main/java/oss/fosslight/domain/OssMaster.java
@@ -495,7 +495,8 @@ public class OssMaster extends ComBean implements Serializable{
 	}
 
 	public void setDownloadLocations(String[] downloadLocations) {
-		this.downloadLocations = downloadLocations;
+		this.downloadLocations = downloadLocations != null ?
+			downloadLocations.clone() : null;
 	}
 	
 	/**
@@ -1026,7 +1027,7 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @param ossNames the new oss names
 	 */
 	public void setOssNames(String[] ossNames) {
-		this.ossNames = ossNames;
+		this.ossNames = ossNames != null ? ossNames.clone() : null;
 	}
 	
 	/**
@@ -1101,7 +1102,7 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @param ossNicknames the new oss nicknames
 	 */
 	public void setOssNicknames(String[] ossNicknames) {
-		this.ossNicknames = ossNicknames;
+		this.ossNicknames = ossNicknames != null ? ossNicknames.clone() : null;
 	}
 	
 	/**

--- a/src/main/java/oss/fosslight/domain/PartnerMaster.java
+++ b/src/main/java/oss/fosslight/domain/PartnerMaster.java
@@ -682,7 +682,8 @@ public class PartnerMaster extends ComBean implements Serializable{
 	 * @param watcherDivision the new watcher division
 	 */
 	public void setWatcherDivision(String[] watcherDivision) {
-		this.watcherDivision = watcherDivision;
+		this.watcherDivision = watcherDivision != null ? 
+			watcherDivision.clone() : null;
 	}
 	
 	/**
@@ -700,7 +701,8 @@ public class PartnerMaster extends ComBean implements Serializable{
 	 * @param watcherUserId the new watcher user id
 	 */
 	public void setWatcherUserId(String[] watcherUserId) {
-		this.watcherUserId = watcherUserId;
+		this.watcherUserId = watcherUserId != null ?
+			watcherUserId.clone() : null;
 	}
 	
 	/**
@@ -900,7 +902,7 @@ public class PartnerMaster extends ComBean implements Serializable{
 	 * @param watchers the new watchers
 	 */
 	public void setWatchers(String[] watchers) {
-		this.watchers = watchers;
+		this.watchers = watchers != null ? watchers.clone() : null;
 	}
 
 	/**
@@ -998,7 +1000,8 @@ public class PartnerMaster extends ComBean implements Serializable{
 	}
 
 	public void setArrStatuses(String[] arrStatuses) {
-		this.arrStatuses = arrStatuses;
+		this.arrStatuses = arrStatuses != null ?
+			arrStatuses.clone() : null;
 	}
 	
 	/**

--- a/src/main/java/oss/fosslight/domain/Project.java
+++ b/src/main/java/oss/fosslight/domain/Project.java
@@ -1289,7 +1289,7 @@ public class Project extends ComBean implements Serializable {
 	 * @param watchers the new watchers
 	 */
 	public void setWatchers(String[] watchers) {
-		this.watchers = watchers;
+		this.watchers = watchers != null ? watchers.clone() : null;
 	}
 
 	/**
@@ -1828,7 +1828,7 @@ public class Project extends ComBean implements Serializable {
 	 * @param prjIds the new prj ids
 	 */
 	public void setPrjIds(String[] prjIds) {
-		this.prjIds = prjIds;
+		this.prjIds = prjIds != null ? prjIds.clone() : null;
 	}
 
 	/**
@@ -2230,7 +2230,8 @@ public class Project extends ComBean implements Serializable {
 	 * @param androidSheetNum the new android sheet num
 	 */
 	public void setAndroidSheetNum(String[] androidSheetNum) {
-		this.androidSheetNum = androidSheetNum;
+		this.androidSheetNum = androidSheetNum != null ?
+			androidSheetNum.clone() : null;
 	}
 
 	/**
@@ -3707,7 +3708,8 @@ public class Project extends ComBean implements Serializable {
 	}
 
 	public void setOssNickNames(String[] ossNickNames) {
-		this.ossNickNames = ossNickNames;
+		this.ossNickNames = ossNickNames != null ?
+			ossNickNames.clone() : null;
 	}
 
 	public String getStatuses() {
@@ -3723,7 +3725,8 @@ public class Project extends ComBean implements Serializable {
 	}
 
 	public void setArrStatuses(String[] arrStatuses) {
-		this.arrStatuses = arrStatuses;
+		this.arrStatuses = arrStatuses != null ?
+			arrStatuses.clone() : null;
 	}
 	
 	public String getPublicYn() {

--- a/src/main/java/oss/fosslight/domain/ReportCombean.java
+++ b/src/main/java/oss/fosslight/domain/ReportCombean.java
@@ -32,7 +32,7 @@ public class ReportCombean implements Serializable{
 		return sheetNums != null ? sheetNums.clone() : null;
 	}
 	public void setSheetNums(String[] sheetNums) {
-		this.sheetNums = sheetNums;
+		this.sheetNums = sheetNums != null ? sheetNums.clone() : null;
 	}
 	public String getFileSeq() {
 		return fileSeq;

--- a/src/main/java/oss/fosslight/repository/OssMapper.java
+++ b/src/main/java/oss/fosslight/repository/OssMapper.java
@@ -211,4 +211,10 @@ public interface OssMapper {
 	List<PartnerMaster> getOssNameMergePartnerList(OssMaster ossMaster);
 
 	List<Project> getOssNameMergeProjectList(OssMaster ossMaster);
+
+	void updateOssMasterSync(OssMaster ossMaster);
+
+	void deleteOssLicenseDeclaredSync(OssMaster ossMaster);
+
+	void deleteOssLicenseDetectedSync(OssMaster ossMaster);
 }

--- a/src/main/java/oss/fosslight/service/OssService.java
+++ b/src/main/java/oss/fosslight/service/OssService.java
@@ -107,4 +107,8 @@ public interface OssService extends HistoryConfig{
 	List<OssMaster> getOssListBySync(OssMaster bean);
 
 	List<String> getOssListSyncCheck(List<OssMaster> selectOssList, List<OssMaster> standardOssList);
+
+	void syncOssMaster(OssMaster syncBean, boolean declaredLicenseCheckFlag, boolean detectedLicenseCheckFlag, boolean downloadLocationCheckFlag);
+
+	OssMaster makeEmailSendFormat(OssMaster beforeBean);
 }

--- a/src/main/resources/oss/fosslight/repository/OssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/OssMapper.xml
@@ -639,6 +639,8 @@
 			, T2.OSS_COPYRIGHT	
 			, SUB1.OSS_TYPE
 			, T1.DEACTIVATE_FLAG
+			, T1.MODIFIER
+			, T1.MODIFIED_DATE
 		FROM 
 			OSS_MASTER 									T1
 			LEFT OUTER JOIN OSS_LICENSE_DECLARED		T2	ON T1.OSS_ID = T2.OSS_ID AND T2.OSS_LICENSE_IDX  = 1
@@ -1981,4 +1983,32 @@
     			</otherwise>
     		</choose>
     </update>
+    
+    <update id="updateOssMasterSync" parameterType="oss.fosslight.domain.OssMaster">
+    	UPDATE OSS_MASTER
+		   SET LICENSE_DIV 			= #{licenseDiv},
+		       COPYRIGHT 			= #{copyright},
+		       DOWNLOAD_LOCATION 	= #{downloadLocation},
+		       HOMEPAGE 			= #{homepage},
+		       SUMMARY_DESCRIPTION 	= #{summaryDescription},
+		       ATTRIBUTION 			= #{attribution},
+		       MODIFIED_DATE 		= now(),
+		       MODIFIER 			= #{modifier},
+		       LICENSE_TYPE 		= #{licenseType},
+		       OBLIGATION_TYPE 		= #{obligationType},
+		       DEACTIVATE_FLAG 		= #{deactivateFlag}
+		 WHERE OSS_ID = #{ossId}
+    </update>
+    
+    <delete id="deleteOssLicenseDeclaredSync" parameterType="oss.fosslight.domain.OssMaster">
+    	DELETE ODC
+		  FROM OSS_LICENSE_DECLARED ODC
+		 WHERE ODC.OSS_ID = #{ossId}
+    </delete>
+    
+    <delete id="deleteOssLicenseDetectedSync" parameterType="oss.fosslight.domain.OssMaster">
+    	DELETE ODT
+		  FROM OSS_LICENSE_DETECTED ODT
+		 WHERE ODT.OSS_ID = #{ossId}
+    </delete>
 </mapper>


### PR DESCRIPTION
## Description
- Update OSS Sync Function to shorten the time to save during OSS sync.
    - In the part of OSS Sync processing, the part that retrieves OSS information does not refer to memory, but change it so that it is fetched directly from the DB.
    -  Delete all refreshOssInfo() calls in loop.
- Fix the vulnerability that public array is assigned to private variable.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
