### PR TITLE
Update OSS Table > view comment info of oss popup

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
@@ -1307,7 +1307,11 @@
 					fn_grid_com.setWarningClass(srcList,rowid,["ossName","licenseName"]);
 					return true;
 				},
-				onCellSelect: function(rowid,iCol,cellcontent,e) {},
+				onCellSelect: function(rowid,iCol,cellcontent,e) {
+					if(iCol=="1") {
+						fn_grid_com.showOssViewPage(srcList, rowid, true, srcValidMsgData, srcDiffMsgData, null, com_fn.getLicenseName);
+					}
+				},
 				ondblClickRow: function(rowid,iRow,iCol,e) {
 					// 체크 박스 영역 제외
 					if(iCol!="22") {


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- In the OSS version-specific information popup that appears when you click a cell in the ID column of the OSS Table, if you are an admin, show a list of comments.
- Like a project or 3rd party, even for self-check, open a popup of OSS version-specific information that appears when you click a cell in the ID column of the OSS table.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
