### PR TITLE
Change spdx/tools-java dependency to previous version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
 	
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 
-	implementation group: 'org.spdx', name: 'tools-java', version: '1.0.3'
+	implementation group: 'org.spdx', name: 'tools-java', version: '1.0.2'
 
 	runtime group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.10.7'
 	runtime group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.10.7'


### PR DESCRIPTION
## Description
* change spdx/tools-java dependency to previous version
* spdx/tools-java 1.0.3 -> 1.0.2 (Reason: spdx rdf download error in 1.0.3)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
