### PR TITLE
Add a function to copy 3rd party to Project

### DIFF
--- a/src/main/java/oss/fosslight/controller/PartnerController.java
+++ b/src/main/java/oss/fosslight/controller/PartnerController.java
@@ -46,12 +46,14 @@ import oss.fosslight.domain.CommentsHistory;
 import oss.fosslight.domain.History;
 import oss.fosslight.domain.OssMaster;
 import oss.fosslight.domain.PartnerMaster;
+import oss.fosslight.domain.Project;
 import oss.fosslight.domain.ProjectIdentification;
 import oss.fosslight.domain.T2File;
 import oss.fosslight.domain.T2Users;
 import oss.fosslight.domain.UploadFile;
 import oss.fosslight.repository.FileMapper;
 import oss.fosslight.repository.PartnerMapper;
+import oss.fosslight.repository.ProjectMapper;
 import oss.fosslight.service.CommentService;
 import oss.fosslight.service.FileService;
 import oss.fosslight.service.HistoryService;
@@ -76,6 +78,7 @@ public class PartnerController extends CoTopComponent{
 	
 	@Autowired PartnerMapper partnerMapper;
 	@Autowired FileMapper fileMapper;
+	@Autowired ProjectMapper projectMapper;
 	
 	/** The session key search. */
 	private final String SESSION_KEY_SEARCH = "SESSION_KEY_PARTNER_LIST";
@@ -171,6 +174,12 @@ public class PartnerController extends CoTopComponent{
 		partnerMaster.setUserComment(commentService.getUserComment(comHisBean));
 		partnerMaster.setDocumentsFile(partnerMapper.selectDocumentsFile(partnerMaster.getDocumentsFileId()));
 		partnerMaster.setDocumentsFileCnt(partnerMapper.selectDocumentsFileCnt(partnerMaster.getDocumentsFileId()));
+		
+		List<Project> prjList = projectMapper.selectPartnerRefPrjList(partnerMaster);
+		
+		if(prjList.size() > 0) {
+			model.addAttribute("prjList", toJson(prjList));
+		}
 		
 		model.addAttribute("detail", partnerMaster);
 		model.addAttribute("detailJson", toJson(partnerMaster));

--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -39,7 +39,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.gson.reflect.TypeToken;
 
@@ -131,6 +130,7 @@ public class ProjectController extends CoTopComponent {
 		
 		Project searchBean = null;
 		Object _param =  getSessionObject(CoConstDef.SESSION_KEY_PREFIX_DEFAULT_SEARCHVALUE + "OSSLISTMORE", true);
+		Object _param2 =  getSessionObject(CoConstDef.SESSION_KEY_PREFIX_DEFAULT_SEARCHVALUE + "PARTNERLISTMORE", true);
 		
 		if(_param != null) {
 			String defaultSearchOssId = (String) _param;
@@ -144,6 +144,15 @@ public class ProjectController extends CoTopComponent {
 					searchBean.setOssName(ossBean.getOssName());
 					searchBean.setOssVersion(ossBean.getOssVersion());
 				}
+			}
+		} else if(_param2 != null) {
+			String defaultSearchRefPartnerId = (String) _param2;
+			searchBean = new Project();
+			
+			if(!isEmpty(defaultSearchRefPartnerId)) {
+				deleteSession(SESSION_KEY_SEARCH);
+				
+				searchBean.setRefPartnerId(defaultSearchRefPartnerId);
 			}
 		} else {
 			if (!CoConstDef.FLAG_YES.equals(req.getParameter("gnbF"))) {
@@ -292,6 +301,26 @@ public class ProjectController extends CoTopComponent {
 		Project project = new Project();
 		project.setNoticeType(CoConstDef.CD_GENERAL_MODEL);
 		project.setPriority(CoConstDef.CD_PRIORITY_P2);
+		
+		Object _param =  getSessionObject(CoConstDef.SESSION_KEY_PREFIX_DEFAULT_SEARCHVALUE + "PARTNER", true);
+		
+		if(_param != null) {
+			String partnerKey = (String) _param;
+			
+			if(!isEmpty(partnerKey)) {
+				deleteSession(SESSION_KEY_SEARCH);
+				
+				String[] partnerArr = partnerKey.split("\\|\\|");
+				String refPartnerId = partnerArr[0];
+				String partnerName = partnerArr[1];
+				String softwareName = partnerArr[2];
+				
+				project.setRefPartnerId(refPartnerId); // refPartnerId
+				
+				String comment = "Copied from [3rd-" + refPartnerId + "] " + partnerName + " (" + softwareName + ")";
+				project.setComment(comment);
+			}
+		}
 		
 		model.addAttribute("project", project);
 		model.addAttribute("distributionFlag", CommonFunction.propertyFlagCheck("distribution.use.flag", CoConstDef.FLAG_YES));
@@ -1200,6 +1229,51 @@ public class ProjectController extends CoTopComponent {
 					}
 				}
 			}
+		}
+		
+		try {
+			// 1. 신규 생성 & partner id가 존재함. -> 이미 완료된 시점
+			if(isNew && !isEmpty(project.getRefPartnerId())) {
+				// 2. RefPartnerId 기준으로 OSS Component & OSS Component License Data -> Identification > 3rd Party에 copy함.
+				// 3. PROJECT_PARTNER_MAP 생성
+				// -> Identification > 3rd party save처리와 동일한 상태
+				projectService.addPartnerData(project);
+				
+				// 4. merge and save 처리
+				projectService.registBom(project.getPrjId(), CoConstDef.FLAG_YES, new ArrayList<>()); // 신규생성이기 때문에 default Data가 없음.
+				
+				// 5. validation check로 project status를 정리함.
+				ProjectIdentification identification = new ProjectIdentification();
+				identification.setReferenceId(project.getPrjId());
+				identification.setMerge(CoConstDef.FLAG_NO);
+				Map<String, Object> result = getOssComponentDataInfo(identification, CoConstDef.CD_DTL_COMPONENT_ID_BOM);
+				
+				// 6. mail & comment를 남김.(status가 정리된 내용까지 전부 포함.)
+				Project prjBean = new Project();
+				prjBean.setPrjId(project.getPrjId());
+				prjBean.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST);
+				try {
+					Map<String, Object> resultMap = projectService.updateProjectStatus(project);
+					updateProjectNotification(project, resultMap);
+				} catch (Exception e) {
+					log.error(e.getMessage(), e);
+				}
+				
+				if(!result.containsKey("validData")) {
+					// review Start에서는 status말고 변경되는 정보가 없어서 우선은 pass함.					
+					prjBean.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM);
+					prjBean.setIgnoreBinaryDbFlag(CoConstDef.FLAG_NO);
+					
+					try {
+						Map<String, Object> resultMap = projectService.updateProjectStatus(prjBean);
+						updateProjectNotification(prjBean, resultMap);
+					} catch (Exception e) {
+						log.error(e.getMessage(), e);
+					}
+				}
+			}
+		} catch (Exception e) {
+			log.error(e.getMessage(), e);
 		}
 		
 		return makeJsonResponseHeader(true, null, lastResult);
@@ -2125,395 +2199,28 @@ public class ProjectController extends CoTopComponent {
 				return makeJsonResponseHeader(false, resMsg, null);
 			}
 		}
-
-		String commentDiv = isEmpty(project.getReferenceDiv()) ? CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS
-				: project.getReferenceDiv();
-		CoMail mailBean = null;
-		boolean reDirectPackagingFlag = false;
-		String userComment = project.getUserComment();
-		String statusCode = project.getIdentificationStatus();
 		
-		if(isEmpty(statusCode)) {
-			statusCode = project.getVerificationStatus();
-		}
+		Map<String, Object> resultMap = new HashMap<>();
 		
-		String status = CoCodeManager.getCodeExpString(CoConstDef.CD_IDENTIFICATION_STATUS, statusCode);
-		log.info("statusCode : " + statusCode + "/  status : " + status);
-		
-		log.debug("PARAM: " + "identificationStatus="+project.getIdentificationStatus());
-		log.debug("PARAM: " + "completeYn="+project.getCompleteYn());
-		
-		// Identification confirm시 validation check 수행
-		if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(project.getIdentificationStatus())) {
-			boolean isAndroidModel = false;
-			boolean isNetworkRestriction = false;
-			boolean hasSourceOss = false;
-			boolean hasNotificationOss = false; 
-			
-			Map<String, Object> map = null;
-			
-			// confirm 시 다시 DB Data를 가져와서 체크한다.
-			ProjectIdentification param = new ProjectIdentification();
-			param.setReferenceId(project.getPrjId());
-			param.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_BOM);
-			param.setMerge(CoConstDef.FLAG_NO);
-			map = projectService.getIdentificationGridList(param);
-			
-			if (map != null && map.containsKey("rows") && !((List<ProjectIdentification>) map.get("rows")).isEmpty()) {
-				T2CoProjectValidator pv = new T2CoProjectValidator();
-				pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_BOM_MERGE);
-
-				pv.setAppendix("bomList", (List<ProjectIdentification>) map.get("rows"));
-
-				T2CoValidationResult vr = pv.validate(new HashMap<>());
-				
-				// return validator result
-				if (!vr.isValid() && !vr.isAdminCheck((List<String>) map.get("adminCheckList"))) {
-					return makeJsonResponseHeader(vr.getValidMessageMap());
-				}
-				
-				String networkRedistribution = CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, CoConstDef.CD_LICENSE_NETWORK_RESTRICTION);
-				
-				for(ProjectIdentification _projectBean : (List<ProjectIdentification>) map.get("rows")) {
-					if(hasSourceOss && hasNotificationOss && isNetworkRestriction) {
-						break;
-					}
-					
-					if(!hasNotificationOss) {
-						if(!CoConstDef.FLAG_YES.equals(_projectBean.getExcludeYn()) && ("10".equals(_projectBean.getObligationType()) || "11".equals(_projectBean.getObligationType()) )) {
-							hasNotificationOss = true;
-						}
-					}
-					
-					if(!hasSourceOss) {
-						if("11".equals(_projectBean.getObligationType())){
-							hasSourceOss = true;
-						}
-					}
-					
-					if(!isNetworkRestriction) {
-						if(_projectBean.getRestriction().toUpperCase().contains(networkRedistribution.toUpperCase())) {
-							isNetworkRestriction = true;
-						}
-					}
-				}
-			}
-
-			Project prjInfo = null;
-			
-			{
-				// ANDROID PROJECT인 경우
-				Project prjParam = new Project();
-				prjParam.setPrjId(project.getPrjId());
-				prjInfo = projectService.getProjectDetail(prjParam);
-				
-				if (CoConstDef.FLAG_YES.equals(prjInfo.getAndroidFlag())
-						&& !CoConstDef.FLAG_NO.equals(prjInfo.getIdentificationSubStatusAndroid())
-						&& !CoConstDef.CD_DTL_IDENTIFICATION_STATUS_NA.equals(prjInfo.getIdentificationSubStatusAndroid())) {
-					param = new ProjectIdentification();
-					param.setReferenceId(project.getPrjId());
-					param.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID);
-					map = projectService.getIdentificationGridList(param);
-
-					if (map != null && map.containsKey("mainData")
-							&& !((List<ProjectIdentification>) map.get("mainData")).isEmpty()) {
-						isAndroidModel = true;
-						T2CoProjectValidator pv = new T2CoProjectValidator();
-						pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_ANDROID);
-
-						pv.setAppendix("mainList", (List<ProjectIdentification>) map.get("mainData"));
-						pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) map.get("subData"));
-						T2CoValidationResult vr = pv.validate(new HashMap<>());
-						
-						// return validator result
-						if (!vr.isValid()) {
-							return makeJsonResponseHeader(false, getMessage("msg.project.android.valid"));
-						}
-					}
-				}
-			}
-			
-			if(CoConstDef.FLAG_YES.equals(prjInfo.getNetworkServerType())) {
-				if(!isNetworkRestriction) {
-					project.setSkipPackageFlag(CoConstDef.FLAG_YES);
-					project.setVerificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_NA);
-					project.setDestributionStatus(CoConstDef.CD_DTL_DISTRIBUTE_STATUS_NA);
-				}
-			} else {
-				if (isAndroidModel) {
-					project.setAndroidFlag(CoConstDef.FLAG_YES);
-				} else if (!hasNotificationOss) {
-					// Android model이 아니면서 bom 대상이 없는 경우
-					// package, distribute를 N/A 처리한다.
-					project.setSkipPackageFlag(CoConstDef.FLAG_YES);
-					project.setVerificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_NA);
-					project.setDestributionStatus(CoConstDef.CD_DTL_DISTRIBUTE_STATUS_NA);
-				}
-			}
-			
-			if(CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType())) {
-				if(!hasSourceOss) {
-					project.setSkipPackageFlag(CoConstDef.FLAG_YES);
-					project.setVerificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_NA);
-					project.setDestributionStatus(CoConstDef.CD_DTL_DISTRIBUTE_STATUS_NA);
-				}
-			}
-			
-			project.setModifier(project.getLoginUserName());
-			projectService.updateProjectIdentificationConfirm(project);
-			
-			// network server 이면서 notice 생성 대상이 없을 경우
-			if( hasNotificationOss
-					&& CoConstDef.FLAG_NO.equals(avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE,
-							prjInfo.getDistributionType())).trim().toUpperCase())
-					&& verificationService.checkNetworkServer(prjInfo.getPrjId()) ) {
-				project.setSkipPackageFlag(CoConstDef.FLAG_YES);
-				project.setVerificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_NA);
-				project.setDestributionStatus(CoConstDef.CD_DTL_DISTRIBUTE_STATUS_NA);
-				projectService.updateIdentificationConfirmSkipPackaing(project);
-				
-				hasNotificationOss = false;
-			}
-
-			// permissive로만 이루어져있고, notice type이 기본인 경우, 바로 packaging review상태로
-			// 변경한다.
-			if ((!isAndroidModel && !hasNotificationOss) 
-					|| (CoConstDef.FLAG_YES.equals(prjInfo.getNetworkServerType()) && !isNetworkRestriction) // Network service Only : yes 이지만 network restriction이 없는 case 
-					|| (CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType()) && !hasSourceOss)) { // OSS Notice가 N/A이면서 packaging이 필요 없는 경우
-				// do nothing
-				try {
-					mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_CONFIRMED_ONLY);
-					mailBean.setParamPrjId(project.getPrjId());
-					mailBean.setComment(userComment);
-					
-					CoMailManager.getInstance().sendMail(mailBean);
-				} catch (Exception e) {
-					log.error(e.getMessage(), e);
-				}
-			} else {
-				try {
-					mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_CONF);
-					mailBean.setParamPrjId(project.getPrjId());
-					mailBean.setComment(userComment);
-					
-					CoMailManager.getInstance().sendMail(mailBean);
-				} catch (Exception e) {
-					log.error(e.getMessage(), e);
-				}
-			}
-		} else if (!isEmpty(project.getCompleteYn())) {
-			// project complete 시
-			projectService.updateProjectMaster(project);
-			
-			String _tempComment = "";
-			
-			if(CoConstDef.FLAG_YES.equals(project.getCompleteYn())) {
-				_tempComment = avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_DEFAULT_CONTENTS, CoConstDef.CD_MAIL_TYPE_PROJECT_COMPLETED));
-				userComment = _tempComment + "<br />" + avoidNull(userComment);
-			}
-			
-			// complete log 추가
-			commentDiv = CoConstDef.CD_DTL_COMMENT_PROJECT_HIS;
-			status = CoConstDef.FLAG_YES.equals(project.getCompleteYn()) ? "Completed" : "Reopened";
-			
-			// complete mail 발송
-			try {
-				mailBean = new CoMail(CoConstDef.FLAG_YES.equals(project.getCompleteYn()) ? CoConstDef.CD_MAIL_TYPE_PROJECT_COMPLETED : CoConstDef.CD_MAIL_TYPE_PROJECT_REOPENED);
-				mailBean.setParamPrjId(project.getPrjId());
-				mailBean.setComment(userComment);
-				CoMailManager.getInstance().sendMail(mailBean);
-			} catch (Exception e) {
-				log.error(e.getMessage(), e);
-			}
-		} else if(!isEmpty(project.getDropYn())){
-			// project drop 시
-			projectService.updateProjectMaster(project);
-			
-			String _tempComment = avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_DEFAULT_CONTENTS, CoConstDef.CD_MAIL_TYPE_PROJECT_DROPPED));
-				userComment = _tempComment + "<br />" + avoidNull(userComment);
-			
-			// complete log 추가
-			commentDiv = CoConstDef.CD_DTL_COMMENT_PROJECT_HIS;
-			status = "Dropped";
-			
-			// complete mail 발송
-			try {
-				mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_DROPPED);
-				mailBean.setParamPrjId(project.getPrjId());
-				mailBean.setComment(userComment);
-				
-				CoMailManager.getInstance().sendMail(mailBean);
-			} catch (Exception e) {
-				log.error(e.getMessage(), e);
-			}
-		} else {
-			boolean ignoreValidation = CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(project.getIdentificationStatus()) 
-					|| CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(project.getVerificationStatus()) 
-					|| CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(project.getVerificationStatus());
-			boolean isIdentificationReject = false;
-			Project beforeInfo = projectService.getProjectDetail(project);
-			
-			// Identification
-			// default -> request
-			if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(project.getIdentificationStatus())
-					&& !CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(beforeInfo.getIdentificationStatus())) {
-				mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_REQ_REVIEW);
-				
-				// Admin 사용자의 경우 오류가 있어도 request review 가능하도록 수정
-				if(CommonFunction.isAdmin()) {
-					ignoreValidation = true;
-				}
-			} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_PROGRESS.equals(project.getIdentificationStatus())) {
-				ignoreValidation = true;
-				isIdentificationReject = true;
-				
-				if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(beforeInfo.getIdentificationStatus())) {
-					// self reject
-					mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_SELF_REJECT);
-				} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW
-						.equals(beforeInfo.getIdentificationStatus())) {
-					// reject by review
-					mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_REJECT);
-				} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM
-						.equals(beforeInfo.getIdentificationStatus())) {
-					// confirm to review
-					mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_CANCELED_CONF);
-				}
-			} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(project.getVerificationStatus()) // Packaging
-					&& !CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(beforeInfo.getVerificationStatus())) {
-				mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_REQ_REVIEW);
-				//ignoreValidation = true;
-			} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_PROGRESS.equals(project.getVerificationStatus())) {
-				ignoreValidation = true;
-				
-				if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(beforeInfo.getVerificationStatus())) {
-					// self reject
-					mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_SELF_REJECT);
-				} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(beforeInfo.getVerificationStatus())) {
-					// review -> reject
-					mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_REJECT);
-				} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(beforeInfo.getVerificationStatus())) {
-					mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_CANCELED_CONF);
-				}
-			}
-			
-			// 사용자가 reject하는 경우는 validation check 수행하지 않음
-			if(!ignoreValidation) {
-				// Identification Reqeust review인 경우, 필수 항목 체크 추가
-				Map<String, Object> map = null;
-				// confirm 시 다시 DB Data를 가져와서 체크한다.
-				ProjectIdentification param = new ProjectIdentification();
-				param.setReferenceId(project.getPrjId());
-				param.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_BOM);
-				param.setMerge(CoConstDef.FLAG_NO);
-				map = projectService.getIdentificationGridList(param);
-				
-				if (map != null && map.containsKey("rows") && !((List<ProjectIdentification>) map.get("rows")).isEmpty()) {
-					T2CoProjectValidator pv = new T2CoProjectValidator();
-					pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_BOM_MERGE);
-					pv.setValidLevel(pv.VALID_LEVEL_REQUEST);
-					pv.setAppendix("bomList", (List<ProjectIdentification>) map.get("rows"));
-
-					T2CoValidationResult vr = pv.validate(new HashMap<>());
-					// return validator result
-					if (!vr.isValid()) {
-						if (!vr.isDiff()) {
-							return makeJsonResponseHeader(false, null, vr.getValidMessageMap(), vr.getDiffMessageMap());
-						}
-						return makeJsonResponseHeader(false, null, vr.getValidMessageMap());
-					}
-				}
-				
-				Project prjInfo = null;
-				
-				{
-					// ANDROID PROJECT인 경우
-					Project prjParam = new Project();
-					prjParam.setPrjId(project.getPrjId());
-					prjInfo = projectService.getProjectDetail(prjParam);
-					
-					if (CoConstDef.FLAG_YES.equals(prjInfo.getAndroidFlag())
-							&& !CoConstDef.FLAG_NO.equals(prjInfo.getIdentificationSubStatusAndroid())
-							&& !CoConstDef.CD_DTL_IDENTIFICATION_STATUS_NA.equals(prjInfo.getIdentificationSubStatusAndroid())) {
-						param = new ProjectIdentification();
-						param.setReferenceId(project.getPrjId());
-						param.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID);
-						map = projectService.getIdentificationGridList(param);
-
-						if (map != null && map.containsKey("mainData")
-								&& !((List<ProjectIdentification>) map.get("mainData")).isEmpty()) {
-							T2CoProjectValidator pv = new T2CoProjectValidator();
-							pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_ANDROID);
-
-							pv.setAppendix("mainList", (List<ProjectIdentification>) map.get("mainData"));
-							pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) map.get("subData"));
-							T2CoValidationResult vr = pv.validate(new HashMap<>());
-							
-							// return validator result
-							if (!vr.isValid()) {
-								return makeJsonResponseHeader(false, getMessage("msg.project.android.valid"));
-							}
-						}
-					}
-				}			
-			}
-			
-			project.setModifier(project.getLoginUserName());
-			project.setModifiedDate(project.getCreatedDate());
-			projectService.updateProjectStatus(project);
-
-			try {
-				if (mailBean != null) {
-					mailBean.setParamPrjId(project.getPrjId());
-					mailBean.setComment(userComment);
-					
-					CoMailManager.getInstance().sendMail(mailBean);
-				}
-			} catch (Exception e) {
-				log.error(e.getMessage(), e);
-			}
-		}
-
 		try {
-			History h = new History();
-			h = projectService.work(project);
-			h.sethAction(CoConstDef.ACTION_CODE_UPDATE);
-			project = (Project) h.gethData();
-			h.sethEtc(project.etcStr());
-			historyService.storeData(h);
+			 resultMap = projectService.updateProjectStatus(project);
+			 
+			 if(resultMap.containsKey("androidMessage")) {
+				 return makeJsonResponseHeader(false, getMessage("msg.project.android.valid"));
+			 }
+			 
+			 if(resultMap.containsKey("diffMap")) {
+				 return makeJsonResponseHeader(false, null, (Map<String, Object>) resultMap.get("validMap"), (Map<String, Object>) resultMap.get("diffMap"));
+			 }
+			 
+			 if(resultMap.containsKey("validMap")) {
+				 return makeJsonResponseHeader(false, null, (Map<String, Object>) resultMap.get("validMap"));
+			 }
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		}
 		
-		if (!isEmpty(avoidNull(userComment).trim())) {
-			try {
-				CommentsHistory commHisBean = new CommentsHistory();
-				commHisBean.setReferenceDiv(commentDiv);
-				commHisBean.setReferenceId(project.getPrjId());
-				commHisBean.setContents(userComment);
-				commHisBean.setStatus(status);
-				log.info(status + " 상태 comment 저장!!");
-				commentService.registComment(commHisBean);
-			} catch (Exception e) {
-				log.error(e.getMessage(), e);
-			}
-		} else if (!isEmpty(status)) {
-			try {
-				CommentsHistory commHisBean = new CommentsHistory();
-				commHisBean.setReferenceDiv(commentDiv);
-				commHisBean.setReferenceId(project.getPrjId());
-				commHisBean.setContents(userComment);
-				commHisBean.setStatus(status);
-				log.info("comment empty, " + status + " 상태 comment 저장!!");
-				commentService.registComment(commHisBean);
-			} catch (Exception e) {
-				log.error(e.getMessage(), e);
-			}
-		}
-
-		if (reDirectPackagingFlag) {
-			return makeJsonResponseHeader(true, "goPackaging"); // validMsg를 이용 redirect한다.
-		}
+		updateProjectNotification(project, resultMap);
 		
 		return makeJsonResponseHeader();
 	}
@@ -3503,7 +3210,8 @@ public class ProjectController extends CoTopComponent {
 		project.setPrjId(prjId);
 
 		project = projectService.getProjectDetail(project);
-		String comemnt = "Copy From (" + prjId + ")" + project.getPrjName();
+		
+		String comemnt = "Copied from [PRJ-" + prjId + "] " + project.getPrjName();
 		
 		if (!isEmpty(project.getPrjVersion())) {
 			comemnt += "_" + project.getPrjVersion();
@@ -4078,5 +3786,63 @@ public class ProjectController extends CoTopComponent {
 		map.put("viewOnlyFlag", avoidNull(prjBean.getViewOnlyFlag(), CoConstDef.FLAG_NO));
 		
 		return makeJsonResponseHeader(map);
+	}
+	
+	public void updateProjectNotification(Project project, Map<String, Object> resultMap) {
+		if(resultMap != null){
+			String mailType = (String) resultMap.get("mailType");
+			String userComment = (String) resultMap.get("userComment");
+			String commentDiv = (String) resultMap.get("commentDiv");
+			String status = (String) resultMap.get("status");
+			
+			try {
+				History h = new History();
+				h = projectService.work(project);
+				h.sethAction(CoConstDef.ACTION_CODE_UPDATE);
+				project = (Project) h.gethData();
+				h.sethEtc(project.etcStr());
+				historyService.storeData(h);
+			} catch (Exception e) {
+				log.error(e.getMessage(), e);
+			}
+			
+			if(!isEmpty(mailType)) {
+				try {
+					CoMail mailBean = new CoMail(mailType);
+					mailBean.setParamPrjId(project.getPrjId());
+					mailBean.setComment(userComment);
+					
+					CoMailManager.getInstance().sendMail(mailBean);
+				} catch (Exception e) {
+					log.error(e.getMessage(), e);
+				}
+			}
+			
+			if (!isEmpty(avoidNull(userComment).trim())) {
+				try {
+					CommentsHistory commHisBean = new CommentsHistory();
+					commHisBean.setReferenceDiv(commentDiv);
+					commHisBean.setReferenceId(project.getPrjId());
+					commHisBean.setContents(userComment);
+					commHisBean.setStatus(status);
+					log.info(status + " 상태 comment 저장!!");
+					commentService.registComment(commHisBean);
+				} catch (Exception e) {
+					log.error(e.getMessage(), e);
+				}
+			} else if (!isEmpty(status)) {
+				try {
+					CommentsHistory commHisBean = new CommentsHistory();
+					commHisBean.setReferenceDiv(commentDiv);
+					commHisBean.setReferenceId(project.getPrjId());
+					commHisBean.setContents(userComment);
+					commHisBean.setStatus(status);
+					log.info("comment empty, " + status + " 상태 comment 저장!!");
+					commentService.registComment(commHisBean);
+				} catch (Exception e) {
+					log.error(e.getMessage(), e);
+				}
+			}
+		}
 	}
 }

--- a/src/main/java/oss/fosslight/controller/SPDXDownloadController.java
+++ b/src/main/java/oss/fosslight/controller/SPDXDownloadController.java
@@ -60,14 +60,16 @@ public class SPDXDownloadController extends CoTopComponent {
 		
 		try {
 			String spdxType = (String)map.get("type");
-			String prjId = (String)map.get("parameter");
+			String dataStr = (String)map.get("dataStr");
+			String prjId = (String)map.get("prjId");
+			
 			Project prjBean = projectService.getProjectBasicInfo(prjId);
 			
 			if("spdxRdf".equals(spdxType)) {
 				if(!isEmpty(prjBean.getSpdxRdfFileId())) {
 					downloadId = prjBean.getSpdxRdfFileId();
 				} else {
-					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
+					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 					T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 					String sheetFullPath = sheetFile.getLogiPath();
 					
@@ -109,7 +111,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				if(!isEmpty(prjBean.getSpdxTagFileId())) {
 					downloadId = prjBean.getSpdxTagFileId();
 				} else {
-					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
+					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 					T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 					String sheetFullPath = sheetFile.getLogiPath();
 					
@@ -151,7 +153,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				if (!isEmpty(prjBean.getSpdxJsonFileId())) {
 					downloadId = prjBean.getSpdxJsonFileId();
 				} else {
-					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
+					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 					T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 					String sheetFullPath = sheetFile.getLogiPath();
 
@@ -192,7 +194,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				if (!isEmpty(prjBean.getSpdxYamlFileId())) {
 					downloadId = prjBean.getSpdxYamlFileId();
 				} else {
-					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
+					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 					T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 					String sheetFullPath = sheetFile.getLogiPath();
 
@@ -233,7 +235,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				if(!isEmpty(prjBean.getSpdxSheetFileId())) {
 					downloadId = prjBean.getSpdxSheetFileId();
 				} else {
-					downloadId = ExcelDownLoadUtil.getExcelDownloadId("spdx", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
+					downloadId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 				}
 			} else {
 				log.error("not match type...");

--- a/src/main/java/oss/fosslight/controller/VerificationController.java
+++ b/src/main/java/oss/fosslight/controller/VerificationController.java
@@ -602,7 +602,7 @@ public class VerificationController extends CoTopComponent {
 		project.setAllowDownloadSPDXJsonYn(	 CoConstDef.FLAG_YES.equals(ossNotice.getEditNoticeYn()) ? allowDownloadSPDXJsonYn 	 : CoConstDef.FLAG_NO);
 		project.setAllowDownloadSPDXYamlYn(	 CoConstDef.FLAG_YES.equals(ossNotice.getEditNoticeYn()) ? allowDownloadSPDXYamlYn 	 : CoConstDef.FLAG_NO);
 
-		projectService.updateProjectAllowDownloadBitFlag(project);
+		verificationService.updateProjectAllowDownloadBitFlag(project);
 		
 		return makeJsonResponseHeader(vResult.getValidMessageMap());
 	}

--- a/src/main/java/oss/fosslight/repository/ProjectMapper.java
+++ b/src/main/java/oss/fosslight/repository/ProjectMapper.java
@@ -18,6 +18,7 @@ import oss.fosslight.domain.OssComponents;
 import oss.fosslight.domain.OssComponentsLicense;
 import oss.fosslight.domain.OssMaster;
 import oss.fosslight.domain.OssNotice;
+import oss.fosslight.domain.PartnerMaster;
 import oss.fosslight.domain.Project;
 import oss.fosslight.domain.ProjectIdentification;
 import oss.fosslight.domain.T2File;
@@ -327,4 +328,8 @@ public interface ProjectMapper {
 	void insertStatisticsMostUsedLicenseInfo(Project project);
 
 	void deleteStatisticsMostUsedInfo(Project project);
+	
+	int selectAdminCheckCnt(ProjectIdentification projectIdentification);
+	
+	List<Project> selectPartnerRefPrjList(PartnerMaster partner);
 }

--- a/src/main/java/oss/fosslight/service/ProjectService.java
+++ b/src/main/java/oss/fosslight/service/ProjectService.java
@@ -57,7 +57,9 @@ public interface ProjectService extends HistoryConfig{
 
 	public void registBom(String prjId, String merge, List<ProjectIdentification> projectIdentification);
 	
-	public void updateProjectStatus(Project project);
+	public void checkProjectReviewer(Project project);
+	
+	public Map<String, Object> updateProjectStatus(Project project) throws Exception;
 	
 	public List<ProjectIdentification> getBomListExcel(ProjectIdentification bom);
 	
@@ -149,8 +151,6 @@ public interface ProjectService extends HistoryConfig{
 	void insertAddList(List<Project> project);
 	
 	public OssNotice setCheckNotice(Project project);
-	
-	public void updateProjectAllowDownloadBitFlag(Project project);
 
 	Map<String, Object> identificationSubGrid(ProjectIdentification identification);
 	
@@ -167,6 +167,8 @@ public interface ProjectService extends HistoryConfig{
 	public List<Map<String, String>> getBomCompare(List<ProjectIdentification> beforeBomList, List<ProjectIdentification> afterBomList, String flag) throws Exception;
 
 	public void deleteStatisticsMostUsedInfo(Project project);
+	
+	public void addPartnerData(Project project);
 }
 
 

--- a/src/main/java/oss/fosslight/service/VerificationService.java
+++ b/src/main/java/oss/fosslight/service/VerificationService.java
@@ -77,4 +77,6 @@ public interface VerificationService {
 	List<OssComponents> setMergeGridData(List<OssComponents> gridData);
 
 	void setUploadFileSave(String prjId, String fileSeq, String registFileId) throws Exception;
+	
+	public void updateProjectAllowDownloadBitFlag(Project project);
 }

--- a/src/main/java/oss/fosslight/util/ExcelDownLoadUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelDownLoadUtil.java
@@ -1926,7 +1926,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 	 * @throws IOException
 	 */
 	@SuppressWarnings("unchecked")
-	private static String getVerificationSPDX_SpreadSheetExcelPost(String prjId) throws IOException {
+	private static String getVerificationSPDX_SpreadSheetExcelPost(String dataStr) throws IOException {
 
 		Workbook wb = null;
 		Sheet sheetDoc = null; // Document info
@@ -1938,6 +1938,13 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		
 		// download file name
 		String downloadFileName = "SPDXRdf-"; // Default
+		
+		Type ossNoticeType = new TypeToken<OssNotice>(){}.getType();
+		
+		OssNotice ossNotice = (OssNotice) fromJson(dataStr, ossNoticeType);
+		ossNotice.setFileType("text");
+		
+		String prjId = ossNotice.getPrjId();
 		
 		try {
 			inFile= new FileInputStream(new File(downloadpath+"/SPDXRdf_2.2.2.xls"));
@@ -1959,9 +1966,6 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 
 			T2Users userInfo = new T2Users();
 			userInfo.setUserId(projectInfo.getCreator());
-			
-			OssNotice ossNotice = verificationService.selectOssNoticeOne(prjId);
-			ossNotice.setFileType("text");
 			
 			Map<String, Object> packageInfo = verificationService.getNoticeHtmlInfo(ossNotice);
 			
@@ -2031,6 +2035,8 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				
 				List<OssComponents> sourceList = (List<OssComponents>) packageInfo.get("disclosureObligationList");
 				
+				boolean hideOssVersionFlag = CoConstDef.FLAG_YES.equals(ossNotice.getHideOssVersionYn());
+				
 				// permissive oss와 copyleft oss를 병합
 				if(sourceList != null && !sourceList.isEmpty()) {
 					noticeList.addAll(sourceList);
@@ -2070,7 +2076,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					
 					// Package Version
 					Cell cellPackageVersion = getCell(row, cellIdx); cellIdx++;
-					cellPackageVersion.setCellValue(avoidNull(bean.getOssVersion()));
+					cellPackageVersion.setCellValue(hideOssVersionFlag ? "" : avoidNull(bean.getOssVersion()));
 					
 					// Package FileName
 					cellIdx++;
@@ -2199,15 +2205,13 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					cellIdx++;
 					
 					
-					// Attribution Info 
+					// Attribution Text
 					Cell attributionInfo = getCell(row, cellIdx); cellIdx++;
-					attributionInfo.setCellValue(attributionText);
+					attributionInfo.setCellValue(hideOssVersionFlag ? bean.getOssAttribution().replaceAll("<br>", "\n") : attributionText);
 					
 					// Files Analyzed
 					Cell filesAnalyzed = getCell(row, cellIdx); cellIdx++;
 					filesAnalyzed.setCellValue("false");
-					
-					// Files Analyzed
 					
 					// User Defined Columns...
 					

--- a/src/main/resources/oss/fosslight/repository/PartnerMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/PartnerMapper.xml
@@ -699,16 +699,16 @@
 		COMPONENT_ID
 		, LICENSE_ID
 		, LICENSE_NAME
-		, LICENSE_TEXT
 		, COPYRIGHT_TEXT
+		, EXCLUDE_YN
 		)
 		VALUES
 		(
 		#{componentId}
 		, #{licenseId}
 		, #{licenseName}
-		, #{licenseText}
 		, #{copyrightText}
+		, 'N'
 		)
 	</insert>
 	
@@ -1706,6 +1706,4 @@
 		  FROM OSS_ANALYSIS_STATUS
 		 WHERE PRJ_ID = #{partnerId}
 	 </select>
-
-
 </mapper>

--- a/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
@@ -1203,7 +1203,6 @@
 		  AND  A.COMPONENT_ID = #{componentId}
 		  AND  A.LICENSE_ID = #{licenseId}
 		  AND  A.LICENSE_NAME = #{licenseName}
-		  AND  A.LICENSE_TEXT = #{licenseText}
 		  AND  A.COPYRIGHT_TEXT = #{copyrightText}
 	</select>	
 	
@@ -1214,7 +1213,6 @@
 			COMPONENT_ID
 			, LICENSE_ID
 			, LICENSE_NAME
-			, LICENSE_TEXT
 			, COPYRIGHT_TEXT
 			, EXCLUDE_YN
 			)
@@ -1223,9 +1221,8 @@
 			#{componentId}
 			, #{licenseId}
 			, TRIM(#{licenseName})
-			, #{licenseText}
 			, #{copyrightText}
-			, #{excludeYn}
+			, 'N'
 			)
 	</insert>
 	
@@ -2023,7 +2020,6 @@
 			COMPONENT_ID
 			, LICENSE_ID
 			, LICENSE_NAME
-			, LICENSE_TEXT
 			, COPYRIGHT_TEXT
 			, EXCLUDE_YN
 			)
@@ -2032,9 +2028,8 @@
 			#{componentId}
 			, #{licenseId}
 			, #{licenseName}
-			, #{licenseText}
 			, #{copyrightText}
-			, #{excludeYn}
+			, 'N'
 			)
 	</insert>
 	
@@ -2649,14 +2644,6 @@
 			ORDER BY IFNULL(T1.EXCLUDE_YN, 'N') ASC, GROUP_CONCAT(T2.LICENSE_NAME ORDER BY T2.LICENSE_ID DESC SEPARATOR ',') DESC
 		</if>
 	</if>
-	<if test="sortField eq 'licenseText'">
-		<if test="sortOrder eq 'asc'">
-			ORDER BY IFNULL(T1.EXCLUDE_YN, 'N') ASC, GROUP_CONCAT(T2.LICENSE_TEXT ORDER BY T2.LICENSE_ID DESC SEPARATOR ',') ASC
-		</if>
-		<if test="sortOrder eq 'desc'">
-			ORDER BY IFNULL(T1.EXCLUDE_YN, 'N') ASC, GROUP_CONCAT(T2.LICENSE_TEXT ORDER BY T2.LICENSE_ID DESC SEPARATOR ',') DESC
-		</if>
-	</if>
 	<if test="sortField eq 'copyrightText'">
 		<if test="sortOrder eq 'asc'">
 			ORDER BY IFNULL(T1.EXCLUDE_YN, 'N') ASC, GROUP_CONCAT(T2.COPYRIGHT_TEXT ORDER BY T2.LICENSE_ID DESC SEPARATOR ',') ASC
@@ -2706,13 +2693,15 @@
 					, LICENSE_NAME
 					, LICENSE_TEXT
 					, COPYRIGHT_TEXT
+					, EXCLUDE_YN
 					)
 			SELECT
 					#{componentId}
 					, LICENSE_ID
 					, LICENSE_NAME
 					, LICENSE_TEXT
-					, COPYRIGHT_TEXT	
+					, COPYRIGHT_TEXT
+					, 'N' AS EXCLUDE_YN	
 			FROM 
 				OSS_COMPONENTS_LICENSE
 			WHERE 
@@ -2909,7 +2898,7 @@
 					, LICENSE_NAME
 					, LICENSE_TEXT
 					, COPYRIGHT_TEXT
-					, EXCLUDE_YN
+					, 'N' AS EXCLUDE_YN
 			FROM 
 				OSS_COMPONENTS_LICENSE
 			WHERE 
@@ -4029,4 +4018,46 @@
 		DELETE FROM STATISTICS_MOSTUSED
 		WHERE PRJ_ID = #{prjId}
 	</delete>
+	
+	<select id="selectAdminCheckCnt" parameterType="oss.fosslight.domain.ProjectIdentification" resultType="int">
+		SELECT COUNT(1) AS CNT 
+		  FROM OSS_COMPONENTS 
+		 WHERE REFERENCE_ID = #{referenceId}
+		   AND REFERENCE_DIV = '13' 
+		   AND (
+				 REF_COMPONENT_ID = #{componentId}
+		    	 OR (
+				  	  	(
+				  	  		OSS_NAME IN (SELECT OSS_NAME FROM OSS_NICKNAME WHERE OSS_NICKNAME = #{ossName})
+				  	  		OR OSS_NAME = #{ossName}
+				  	  	)
+						AND OSS_VERSION = #{ossVersion} 
+						AND REF_DIV = #{referenceDiv}
+				 	)
+		   	   )
+		   AND ADMIN_CHECK_YN = 'Y'
+	</select>
+	
+	<select id="selectPartnerRefPrjList" parameterType="oss.fosslight.domain.PartnerMaster" resultType="oss.fosslight.domain.Project">
+		SELECT PM.PRJ_ID
+			 , PM.PRJ_NAME
+			 , PM.PRJ_VERSION
+			 , PM.MODIFIED_DATE
+		  FROM PROJECT_MASTER PM
+		 INNER JOIN PROJECT_PARTNER_MAP PP
+		    ON PM.PRJ_ID = PP.PRJ_ID
+		 WHERE PP.PARTNER_ID = #{partnerId}
+		 <if test="@oss.fosslight.util.StringUtil@notEquals('ROLE_ADMIN', loginUserRole)">
+		   AND (
+				PM.CREATOR = #{loginUserName} 
+				OR EXISTS (
+							SELECT 1
+						  	  FROM PROJECT_WATCHER PW 
+						 	 INNER JOIN T2_USERS USR ON USR.USE_YN = 'Y' AND USR.USER_ID = #{loginUserName}
+						 	 WHERE PW.PRJ_ID = PM.PRJ_ID AND (PW.USER_ID = USR.USER_ID OR (PW.USER_ID = 'all' AND PW.DIVISION = USR.DIVISION))
+				)
+			)
+		 </if>
+		ORDER BY PM.MODIFIED_DATE DESC LIMIT 100
+	</select>
 </mapper>

--- a/src/main/resources/oss/fosslight/repository/SelfCheckMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/SelfCheckMapper.xml
@@ -633,7 +633,6 @@
 		  AND  A.COMPONENT_ID = #{componentId}
 		  AND  A.LICENSE_ID = #{licenseId}
 		  AND  A.LICENSE_NAME = #{licenseName}
-		  AND  A.LICENSE_TEXT = #{licenseText}
 		  AND  A.COPYRIGHT_TEXT = #{copyrightText}
 	</select>	
 	
@@ -649,7 +648,6 @@
 			, COMPONENT_LICENSE_IDX
 			, LICENSE_ID
 			, LICENSE_NAME
-			, LICENSE_TEXT
 			, COPYRIGHT_TEXT
 			, EXCLUDE_YN
 			)
@@ -659,9 +657,8 @@
 			, #{componentLicenseId}
 			, #{licenseId}
 			, #{licenseName}
-			, #{licenseText}
 			, #{copyrightText}
-			, #{excludeYn}
+			, 'N'
 			)
 	</insert>
 	
@@ -1172,7 +1169,6 @@
 			COMPONENT_ID
 			, LICENSE_ID
 			, LICENSE_NAME
-			, LICENSE_TEXT
 			, COPYRIGHT_TEXT
 			, EXCLUDE_YN
 			)
@@ -1181,9 +1177,8 @@
 			#{componentId}
 			, #{licenseId}
 			, #{licenseName}
-			, #{licenseText}
 			, #{copyrightText}
-			, #{excludeYn}
+			, 'N'
 			)
 	</insert>
 	
@@ -1507,14 +1502,6 @@
 			ORDER BY GROUP_CONCAT(T2.LICENSE_NAME ORDER BY T2.LICENSE_ID DESC SEPARATOR ',') DESC
 		</if>
 	</if>
-	<if test="sortField eq 'licenseText'">
-		<if test="sortOrder eq 'asc'">
-			ORDER BY GROUP_CONCAT(T2.LICENSE_TEXT ORDER BY T2.LICENSE_ID DESC SEPARATOR ',') ASC
-		</if>
-		<if test="sortOrder eq 'desc'">
-			ORDER BY GROUP_CONCAT(T2.LICENSE_TEXT ORDER BY T2.LICENSE_ID DESC SEPARATOR ',') DESC
-		</if>
-	</if>
 	<if test="sortField eq 'copyrightText'">
 		<if test="sortOrder eq 'asc'">
 			ORDER BY GROUP_CONCAT(T2.COPYRIGHT_TEXT ORDER BY T2.LICENSE_ID DESC SEPARATOR ',') ASC
@@ -1564,13 +1551,15 @@
 					, LICENSE_NAME
 					, LICENSE_TEXT
 					, COPYRIGHT_TEXT
+					, EXCLUDE_YN
 					)
 			SELECT
 					#{componentId}
 					, LICENSE_ID
 					, LICENSE_NAME
 					, LICENSE_TEXT
-					, COPYRIGHT_TEXT	
+					, COPYRIGHT_TEXT
+					, 'N' AS EXCLUDE_YN	
 			FROM 
 				OSS_COMPONENTS_LICENSE
 			WHERE 
@@ -1742,7 +1731,7 @@
 					, LICENSE_NAME
 					, LICENSE_TEXT
 					, COPYRIGHT_TEXT
-					, EXCLUDE_YN
+					, 'N' AS EXCLUDE_YN
 			FROM 
 				OSS_COMPONENTS_LICENSE
 			WHERE 
@@ -2381,9 +2370,4 @@
 							  AND IFNULL(EXCLUDE_YN, 'N') <![CDATA[<>]]> 'Y')
 		GROUP BY PRODUCT
 	</select>
-
-
-
-
-
 </mapper>

--- a/src/main/resources/static/css/commonIframe.css
+++ b/src/main/resources/static/css/commonIframe.css
@@ -136,6 +136,7 @@ input.cal:focus {background:#fff8ea url("../images/bg_cal.png") no-repeat right 
 .w120 {width:120px !important;}
 .w150 {width:150px !important;}
 .w155 {width:155px !important;} /* 161104 jh_son 추가 */
+.w200 {width:200px !important;}
 .w220 {width:220px !important;} /* 171017 yuns 추가 */
 .w250 {width:250px !important;}
 .w350 {width:350px !important;}

--- a/src/main/webapp/WEB-INF/views/admin/partner/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/edit-js.jsp
@@ -16,6 +16,7 @@ var delDocumentsFile = [];
 var etcDomain = "${ct:getConstDef('CD_DTL_ECT_DOMAIN')}";
 var divisionEmptyCd = "${ct:getConstDef('CD_USER_DIVISION_EMPTY')}";
 var partnerData = ${empty detailJson ? '{}' : detailJson};
+var prjList = ${empty prjList ? '{}' : prjList};
 var sampleFile =  ${ct:getAllValuesJson(ct:getConstDef('CD_SAMPLE_FILE'))};
 
 	$(document).ready(function () {
@@ -67,6 +68,46 @@ var sampleFile =  ${ct:getAllValuesJson(ct:getConstDef('CD_SAMPLE_FILE'))};
 		if(userRole == "ROLE_ADMIN" && '${detail.partnerId}' != ""){
 			$("input[name=creatorNm]").val('${detail.creatorName }');
 		}
+		
+		$("#_projectList").jqGrid({
+			datatype: 'local',
+			data: prjList,
+			colNames:['ID','Project Name', 'Project Version'],
+			colModel:[
+				{name:'prjId',index:'prjId', width:70, sortable:false, align:"center", key:true},
+				{name:'prjName',index:'prjName', width:400, sortable:false},
+				{name:'prjVersion',index:'prjVersion', width:100, sortable:false, align:"center"}
+			],
+			rowNum:100,
+			viewrecords: true,
+			height: 'auto',
+			ondblClickRow: function(rowid,iRow,iCol,e) {
+				var rowData = $("#_projectList").jqGrid('getRowData',rowid);
+				if("Y" != rowData.oldSystemFlag) {
+					createTabInFrame(rowData['prjId']+'_Project','#<c:url value="/project/edit/'+rowData['prjId']+'"/>');
+				}
+			},
+			loadComplete: function(data) {
+				if(data.records > 0) {
+					var multRowIds = []; 
+					var rowIdx = 0, rows = this.rows, rowsCount = rows.length, row, rowid, rowData, className;
+					for(var _idx=0;_idx<rowsCount;_idx++) {
+						row = rows[_idx];
+						className = row.className;
+						if (className.indexOf('jqgrow') !== -1) {
+							rowid = row.id;
+							rowData = data.rows[rowIdx++];
+							if(rowData.oldSystemFlag == "Y") {
+								className = className + ' excludeRow';
+							}
+							row.className = className;
+						} else if(className.indexOf('ui-subgrid') !== -1){
+							rowIdx++;
+						}
+					}
+				}
+			}
+		});
 	});
 	var commentTemp = '';
 	var modifyCommentId = '${detail.comment}';
@@ -449,6 +490,15 @@ var sampleFile =  ${ct:getAllValuesJson(ct:getConstDef('CD_SAMPLE_FILE'))};
 				} else {
 					$("#emailTemp").val(domain).hide();
 				}
+			});
+
+			//프로젝트 리스트 더보기
+			$("#listMore").on("click",function(){
+				createTabInFrameWithCondition("Project List", '#<c:url value="/project/list"/>', 'PARTNERLISTMORE', $('input[name=partnerName]').val());
+			});
+
+			$("#createProject").on("click", function(){
+				createTabInFrameWithCondition("New_Project", '#<c:url value="/project/edit"/>', 'PARTNER', "${detail.partnerId}||${detail.partnerName}||${detail.softwareName}");
 			});
 		},
 		tabInit: function(){

--- a/src/main/webapp/WEB-INF/views/admin/partner/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/edit.jsp
@@ -18,6 +18,9 @@
 				<c:if test="${detail.viewOnlyFlag ne 'Y'}">
 					<c:if test="${detail.loginUserRole ne 'ROLE_VIEWER'}">
 						<div class="projdecBtn" style="top:0px;">
+						<c:if test="${detail.status eq 'CONF'}">
+							<input id="createProject" type="button" value="Create Project for OSS Notice" class="btnColor red w200" />
+						</c:if>
 						<c:if test="${detail.loginUserRole eq 'ROLE_ADMIN'}">
 							<c:if test="${detail.status eq 'REV' }">
 							<a href="javascript:void(0);" class="btnSet confirm" onclick="fn.confirm()"><span>Confirm</span></a>
@@ -208,7 +211,14 @@
 						</td>
 					</tr>
 					<c:if test="${detail.viewOnlyFlag ne 'Y'}">
-					
+					<c:if test="${not empty prjList}">
+						<tr>
+							<th class="dCase"><spring:message code="msg.common.field.project" /><br/><input id="listMore" type="button" value="List more" class="btnCLight gray" /></th>
+							<td class="dCase">
+								<table id="_projectList"><tr><td></td></tr></table>
+							</td>
+						</tr>
+					</c:if>
 					<tr>
 						<th class="dCase"><spring:message code="msg.common.field.watcher" /></th>
 						<td class="dCase watchCase">

--- a/src/main/webapp/WEB-INF/views/admin/project/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/edit.jsp
@@ -60,6 +60,7 @@
 				<!-- 2018-07-19 choye 추가 -->
 				<input type="hidden" name="commId" />
 				<input type="hidden" name="statusRequestYn" />
+				<input type="hidden" id="refPartnerId" name="refPartnerId" value="${project.refPartnerId}" />
 				<table class="dCase">
 					<colgroup>
 						<col width="188" />

--- a/src/main/webapp/WEB-INF/views/admin/project/verification-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/verification-js.jsp
@@ -1801,10 +1801,12 @@
 			}).submit();
 		},
 		downloadSpdxSpreadSheetExcel : function(){
+			var dataStr = JSON.stringify($('#noticeForm').serializeObject());
+			
 			$.ajax({
 				type: "POST",
 				url: '<c:url value="/spdxdownload/getSPDXPost"/>',
-				data: JSON.stringify({"type":"spdx", "parameter":'${project.prjId}'}),
+				data: JSON.stringify({"type":"spdx", "prjId":'${project.prjId}', "dataStr":dataStr}),
 				dataType : 'json',
 				cache : false,
 				contentType : 'application/json',
@@ -1822,10 +1824,12 @@
 		},
 		
 		downloadSpdxRdf : function() {
+			var dataStr = JSON.stringify($('#noticeForm').serializeObject());
+			
 			$.ajax({
 				type: "POST",
 				url: '<c:url value="/spdxdownload/getSPDXPost"/>',
-				data: JSON.stringify({"type":"spdxRdf", "parameter":'${project.prjId}'}),
+				data: JSON.stringify({"type":"spdxRdf", "prjId":'${project.prjId}', "dataStr":dataStr}),
 				dataType : 'json',
 				cache : false,
 				contentType : 'application/json',
@@ -1843,10 +1847,12 @@
 		},
 		
 		downloadSpdxTag : function() {
+			var dataStr = JSON.stringify($('#noticeForm').serializeObject());
+			
 			$.ajax({
 				type: "POST",				   
 				url: '<c:url value="/spdxdownload/getSPDXPost"/>',
-				data: JSON.stringify({"type":"spdxTag", "parameter":'${project.prjId}'}),
+				data: JSON.stringify({"type":"spdxTag", "prjId":'${project.prjId}', "dataStr":dataStr}),
 				dataType : 'json',
 				cache : false,
 				contentType : 'application/json',
@@ -1864,10 +1870,12 @@
 		},
 
 		downloadSpdxJson : function() {
+			var dataStr = JSON.stringify($('#noticeForm').serializeObject());
+			
 			$.ajax({
 				type: "POST",
 				url: '<c:url value="/spdxdownload/getSPDXPost"/>',
-				data: JSON.stringify({"type":"spdxJson", "parameter":'${project.prjId}'}),
+				data: JSON.stringify({"type":"spdxJson", "prjId":'${project.prjId}', "dataStr":dataStr}),
 				dataType : 'json',
 				cache : false,
 				contentType : 'application/json',
@@ -1885,10 +1893,12 @@
 		},
 
 		downloadSpdxYaml : function() {
+			var dataStr = JSON.stringify($('#noticeForm').serializeObject());
+			
 			$.ajax({
 				type: "POST",
 				url: '<c:url value="/spdxdownload/getSPDXPost"/>',
-				data: JSON.stringify({"type":"spdxYaml", "parameter":'${project.prjId}'}),
+				data: JSON.stringify({"type":"spdxYaml", "prjId":'${project.prjId}', "dataStr":dataStr}),
 				dataType : 'json',
 				cache : false,
 				contentType : 'application/json',


### PR DESCRIPTION
## Description
### New Feature
- Add a "Create Project for OSS Notice" button for the confirmed 3rd party.
    When the corresponding button is clicked, the 3rd party loaded Project is created. At this time, the project is made into Identification confirm state. However, only when it is impossible to confirm the identification, the status of the identification request is made.
### Improvements
- Packaging > Notice tab > Hide OSS Version
   After hiding the OSS version, merge the OSS names and issue an OSS Notice.
- Identification tab > admin check
    In case of admin check, even if OSS Name is changed to nickname, keep OSS Name written by user.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
