### PR TITLE
Change github token in code management

### DIFF
--- a/db/initdb.d/fosslight_create.sql
+++ b/db/initdb.d/fosslight_create.sql
@@ -1794,6 +1794,7 @@ INSERT INTO `T2_CODE` (`CD_NO`, `CD_NM`, `CD_EXP`, `SYS_CD_YN`) VALUES
 	('702', 'marguee Contents', '', 'N'),
 	('703', 'regist Domain', '', 'N'),
 	('704', 'Support Locale List', '', 'N'),
+	('705', 'External Service Setting', 'System Detail Setting Code', 'N'),
 	('901', 'Excel Download/Export', 'Maximum rows that can be exported when downloading Excel file or Export at List', 'N'),
 	('903', 'checkOssNameUrl', 'Managing information to find OSS information from Download Location', 'N'),
 	('904', 'check License Text Server Info', '', 'N'),
@@ -1817,7 +1818,6 @@ INSERT INTO `T2_CODE` (`CD_NO`, `CD_NM`, `CD_EXP`, `SYS_CD_YN`) VALUES
 	('924', 'Compliance Status Detail Setting', 'System Detail Setting Code', 'Y'),
 	('926', 'System Detail Setting', 'System Detail Setting Code', 'Y'),
 	('927', 'Notice Info', '', 'Y'),
-	('930', 'External Service Setting', 'System Detail Setting Code', 'Y'),
 	('990', 'System initialize flag', '', 'Y');
 /*!40000 ALTER TABLE `T2_CODE` ENABLE KEYS */;
 
@@ -2269,6 +2269,7 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('702', '100', 'contents', '', '', 1, 'Y'),
 	('704', '001', 'English', '', 'en_US', 1, 'Y'),
 	('704', '002', '한국어', '', 'ko_KR', 2, 'Y'),
+	('705', '100', 'Github Token', '', 'github token', 1, 'Y'),
 	('901', '100', 'MaxRowCount', '', '5000', 1, 'Y'),
 	('903', '001', 'github.com', '', 'github url', 1, 'Y'),
 	('903', '002', 'www.npmjs.com/package/', '', 'npm url', 2, 'Y'),
@@ -2341,7 +2342,6 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('927', '100', 'HTML', '', 'Y', 1, 'Y'),
 	('927', '101', 'TEXT', '', 'Y', 2, 'Y'),
 	('927', '102', 'SPDX', '', 'Y', 3, 'Y'),
-	('930', '100', 'Github Token', '', 'github token', 1, 'Y'),
 	('990', '100', 'N', '', 'NVD Data Feed initialize flag', 1, 'Y');
 /*!40000 ALTER TABLE `T2_CODE_DTL` ENABLE KEYS */;
 

--- a/src/main/java/oss/fosslight/common/CoConstDef.java
+++ b/src/main/java/oss/fosslight/common/CoConstDef.java
@@ -143,10 +143,6 @@ public class CoConstDef {
 	public static final String CD_DTL_NOTICE_HTML				= "100";
 	public static final String CD_DTL_NOTICE_TEXT				= "101";
 	public static final String CD_DTL_NOTICE_SPDX				= "102";	
-
-	// External Service Setting
-	public static final String CD_EXTERNAL_SERVICE_SETTING		= "930";
-	public static final String CD_DTL_GITHUB_TOKEN  			= "100";
 	
 	/** System Setting Code List End */
 	
@@ -667,10 +663,7 @@ public class CoConstDef {
 	public static final String CD_LICENSE_NETWORK_RESTRICTION					= "2";
 	
 	/** 사용자별 Default Tab Menu 코드 */
-	public static final String CD_DEFAULT_TAB = "701";
-
-	/** 사용자별 Default Locale List 코드 **/
-	public static final String CD_DEFAULT_LOCALE = "704";
+	public static final String CD_DEFAULT_TAB 									= "701";
 	
 	/** marquee contents */
 	public static final String CD_MARQUEE										= "702";
@@ -680,6 +673,13 @@ public class CoConstDef {
 	public static final String CD_REGIST_DOMAIN									= "703";
 	public static final String CD_DTL_DEFAULT_DOMAIN							= "100";
 	public static final String CD_DTL_ECT_DOMAIN								= "ETC";
+
+	/** 사용자별 Default Locale List 코드 **/
+	public static final String CD_DEFAULT_LOCALE 								= "704";
+
+	/** External Service Setting */
+	public static final String CD_EXTERNAL_SERVICE_SETTING						= "705";
+	public static final String CD_DTL_GITHUB_TOKEN  							= "100";
 	
 	// -------------- 서브메뉴 대표 코드
 	/** 대메뉴 */

--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -371,12 +371,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 
 	@Override
 	public Mono<Object> requestGithubLicense(String location) {
-		String githubToken = "";
-		try {
-			githubToken = CryptUtil.decryptAES256(CoCodeManager.getCodeExpString(CoConstDef.CD_EXTERNAL_SERVICE_SETTING, CoConstDef.CD_DTL_GITHUB_TOKEN), CoConstDef.ENCRYPT_DEFAULT_SALT_KEY);
-		} catch(Exception e) {
-			log.error(e.getMessage());		
-		}
+		String githubToken = CoCodeManager.getCodeExpString(CoConstDef.CD_EXTERNAL_SERVICE_SETTING, CoConstDef.CD_DTL_GITHUB_TOKEN);
 
 		return webClient.get()
 			.uri(location)

--- a/src/main/java/oss/fosslight/service/impl/SystemConfigurationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SystemConfigurationServiceImpl.java
@@ -155,18 +155,8 @@ public class SystemConfigurationServiceImpl extends CoTopComponent implements Sy
 			tokenAuthList.stream().map(c -> {
 				switch (c.getCdDtlNo()) {
 					case CoConstDef.CD_DTL_GITHUB_TOKEN:
-						String _token = (String) tokenDetailMap.get(CoConstDef.CD_DTL_GITHUB_TOKEN);
-						if(!StringUtil.isEmpty(_token)) {
-							String _encToken = null;
-							try {
-								_encToken = CryptUtil.encryptAES256(_token, CoConstDef.ENCRYPT_DEFAULT_SALT_KEY);
-							} catch (Exception e) {
-                                log.error(e.getMessage(), e);
-							}
-							if(!StringUtil.isEmpty(_encToken)) {
-								c.setCdDtlExp(_encToken);
-							}
-						}
+						c.setCdDtlExp((String) tokenDetailMap.get(CoConstDef.CD_DTL_GITHUB_TOKEN));
+
 						break;
 				}
 

--- a/src/main/webapp/WEB-INF/views/admin/system/configuration.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/system/configuration.jsp
@@ -54,7 +54,7 @@
 											<dd><label>${code[1]}</label><span class="checkSet"><input type="checkbox" id="external${code[0]}" <c:if test="${code[3] eq 'Y'}">checked</c:if> /></dd>
 										</c:when>
 										<c:otherwise>
-											<dd><label>${code[1]}</label><input type="text" id="external${code[0]}" value="${code[0] eq '100' ? '' : code[3]}"/></dd>
+											<dd><label>${code[1]}</label><input type="text" id="external${code[0]}" value="${code[3]}"/></dd>
 										</c:otherwise>
 									</c:choose>
 								</c:forEach>


### PR DESCRIPTION
## Description
* delete token encryption
* changed to register Github Token in Code Management

![image](https://user-images.githubusercontent.com/32615702/144189972-4cdab205-0f41-4aa9-9655-004db30d8e2c.png)

### Update Query
```
DELETE FROM T2_CODE_DTL WHERE CD_NO=930;
DELETE FROM T2_CODE WHERE CD_NO=930;

INSERT INTO T2_CODE (CD_NO, CD_NM, CD_EXP, SYS_CD_YN) VALUES ('705', 'External Service Setting', 'System Detail Setting Code', 'N');
INSERT INTO T2_CODE_DTL (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_DTL_EXP`, `CD_ORDER`, `USE_YN`) VALUES ('705', '100', 'Github Token', '', 'github token', 1, 'Y');
```

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
