### PR TITLE
Eliminate null pointer exception in OSS Controller

### DIFF
--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -526,9 +526,6 @@ public class OssController extends CoTopComponent{
 		if(ossMailInfo.getOssNicknames() != null) {
 			ossMailInfo.setOssNickname(CommonFunction.arrayToString(ossMailInfo.getOssNicknames(), "<br>"));	
 		}
-		
-		// 삭제처리
-		ossService.deleteOssMaster(ossMaster);
 
 		CoCodeManager.getInstance().refreshOssInfo();
 		resCd="10";
@@ -554,6 +551,9 @@ public class OssController extends CoTopComponent{
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		}
+
+		// 삭제처리
+		ossService.deleteOssMaster(ossMaster);
 		
 		resMap.put("resCd", resCd);
 		


### PR DESCRIPTION
Signed-off-by: yugeeklab <yugeeklab@gmail.com>

## Description
<!-- 
Please describe what this PR do.
 -->
There's a bug that "work" method tried to find deleted ossMaster using "getOssMasterOne" method.
So Null point exception occured in getOssMaster.

I think delete function should be done in the later.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
