### PR TITLE
Fix the license duplication bug in Check License

### DIFF
--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -181,7 +181,12 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			}
 			
 			// Search Priority 3. find by oss download location
-			prjOssLicenses = projectMapper.getOssFindByDownloadLocation(oss);
+			prjOssLicenses = projectMapper.getOssFindByDownloadLocation(oss).stream()
+					.filter(CommonFunction.distinctByKeys(
+							ProjectIdentification::getOssName,
+							ProjectIdentification::getLicenseName
+					))
+					.collect(Collectors.toList());
 			checkedLicense = combineOssLicenses(prjOssLicenses);
 
 			if (!checkedLicense.isEmpty() && !currentLicense.equals(checkedLicense) && !isEachOssVersionDiff(prjOssLicenses)) {


### PR DESCRIPTION
## Description
* Fix an error where licenses were displayed as duplicates on the Check License page

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
