### PR TITLE
Change SPDX dependecy version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,9 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 
 	implementation group: 'org.spdx', name: 'tools-java', version: '1.0.3'
+	implementation (group: 'org.spdx', name: 'spdx-rdf-store', version: '1.0.2') {
+		force = true
+	}
 
 	implementation group: 'com.navercorp.lucy', name: 'lucy-xss', version: '1.6.3'
 


### PR DESCRIPTION
## Description
Downgrade the version of spdx-rdf-store for spdx rdf download before changing to java 11.
* tools-java 1.0.3 (not changed)
* spdx-rdf-store 1.0.3 -> 1.0.2 (downgrade)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
