### PR TITLE
Do not print () if the OSS version is null when leaving a comment in the Check License.

### DIFF
--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -512,12 +512,14 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 					if(updateCnt >= 1) {
 						String commentId = paramBean.getReferenceId();
 						String checkOssLicenseComment = "";
-						String changeOssLicenseInfo = "<p>"
-								+ paramBean.getOssName()
-								+ " (" + paramBean.getOssVersion() + ") "
-								+ paramBean.getDownloadLocation() + " "
-								+ paramBean.getLicenseName() + " => " + paramBean.getCheckLicense()
-								+ "</p>";
+						String changeOssLicenseInfo = "<p>" + paramBean.getOssName();
+
+						if(!paramBean.getOssVersion().isEmpty()) {
+							changeOssLicenseInfo += " (" + paramBean.getOssVersion() + ") ";
+						}
+
+						changeOssLicenseInfo += paramBean.getDownloadLocation() + " "
+								+ paramBean.getLicenseName() + " => " + paramBean.getCheckLicense() + "</p>";
 						CommentsHistory commentInfo = null;
 
 						if(isEmpty(commentId)) {


### PR DESCRIPTION
## Description
When leaving a comment in the Check License function, do not print `()` if the OSS version is null.

```
The following Licenses were modified by Check License.
https://github.com/explosion/spaCy WRONG LICENSE 7 => MIT
https://github.com/fosslight/fosslight WRONG LICENSE 1 => AGPL-3.0
https://github.com/fosslight/fosslight_binary_scanner WRONG LICENSE 13 => Apache-2.0
https://github.com/fosslight/fosslight_dependency_scanner WRONG LICENSE 5 => Apache-2.0
https://github.com/fosslight/fosslight_reuse WRONG LICENSE 4 => GPL-3.0
https://github.com/fosslight/fosslight_scanner WRONG LICENSE 11 => Apache-2.0
https://github.com/fosslight/fosslight_scanner_service WRONG LICENSE 12 => Apache-2.0
https://github.com/fosslight/fosslight_source_scanner WRONG LICENSE 9 => Apache-2.0
https://github.com/fosslight/fosslight_util WRONG LICENSE 2 => Apache-2.0
https://github.com/fosslight/guide_theme WRONG LICENSE 15 => MIT
iotjs (1.0) https://github.com/jerryscript-project/iotjs WRONG LICENSE 1 => Apache-2.0,MIT
https://github.com/jerryscript-project/iotjs WRONG LICENSE 3 => Apache-2.0,MIT
(1.0) https://github.com/jerryscript-project/iotjs WRONG LICENSE 2 => Apache-2.0,MIT
JNA (5.0.0) https://mvnrepository.com/artifact/net.java.dev.jna/jna WRONG LICENSE 5 => Apache-2.0
JNA (3.3.0) https://mvnrepository.com/artifact/net.java.dev.jna/jna WRONG LICENSE 4 => LGPL-2.1
```

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
