### PR TITLE
Hide the Check License, Check OSS Name buttons with the same conditions as the Save button.

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/project/common-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/common-js.jsp
@@ -358,7 +358,7 @@ var com_fn = {
 		var btn_Save = $(".idenSave");
 		var btn_Analysis = $(".idenAnalysis");
 		var btn_Analysis_Result = $(".idenAnalysisResult");
-		var btn_checkossname = $(".checkOssName");
+		var btn_check = $(".btnCheck");
 		var btn_supplement_Notice = $(".supplementNotice");
 		
 		if(role == "ROLE_ADMIN"){ // 관리자 권한 일 경우
@@ -366,61 +366,63 @@ var com_fn = {
 				case "":
 					btn_div.hide();
 					btn_confirm.hide();btn_reject.hide();btn_review.show();btn_restart.hide();
-					btn_Reset.show();btn_Merge.show();btn_Save.show();
+					btn_Reset.show();btn_Merge.show();btn_Save.show();btn_check.show();
 
 					break;
 				case "PROG":
 					btn_confirm.hide();btn_reject.hide();btn_review.show();btn_restart.hide();
-					btn_Reset.show();btn_Merge.show();btn_Save.show();
+					btn_Reset.show();btn_Merge.show();btn_Save.show();btn_check.show();
 
 					break;
 				case "REQ":
 					btn_confirm.hide();btn_reject.hide();btn_review.hide();btn_restart.show();
-					btn_Reset.show();btn_Merge.show();btn_Save.show();
+					btn_Reset.show();btn_Merge.show();btn_Save.show();btn_check.show();
 
 					break;
 				case "REV":
 					btn_confirm.show();btn_reject.show();btn_review.hide();btn_restart.hide();
-					btn_Reset.show();btn_Merge.show();btn_Save.show();
+					btn_Reset.show();btn_Merge.show();btn_Save.show();btn_check.show();
 
 					break;
 				case "CONF":
 					btn_confirm.hide();btn_reject.show();btn_review.hide();btn_restart.hide();
 					btn_Reset.hide();btn_Merge.hide();btn_Save.hide();btn_Analysis.hide();
 					btn_Analysis_Result.hide(); btn_supplement_Notice.hide();
+					btn_check.hide();
 
 					break;
 			}
 		} else if('${project.viewOnlyFlag}' == 'Y'){
 			btn_confirm.hide();btn_reject.hide();btn_review.hide();btn_restart.hide();
-			btn_Reset.hide();btn_Merge.hide();btn_Save.hide();
+			btn_Reset.hide();btn_Merge.hide();btn_Save.hide();btn_check.hide();
 		} else { // 일반 사용자 일 경우
 			switch(status){
 				case "":
 					btn_div.hide();
 					btn_confirm.hide();btn_reject.hide();btn_review.show();btn_restart.hide();
-					btn_Reset.show();btn_Merge.show();btn_Save.show();
+					btn_Reset.show();btn_Merge.show();btn_Save.show();btn_check.show();
 
 					break;
 				case "PROG":
 					btn_confirm.hide();btn_reject.hide();btn_review.show();btn_restart.hide();
-					btn_Reset.show();btn_Merge.show();btn_Save.show();
+					btn_Reset.show();btn_Merge.show();btn_Save.show();btn_check.show();
 
 					break;
 				case "REQ":
 					btn_confirm.hide();btn_reject.show();btn_review.hide();btn_restart.hide();
-					btn_Reset.hide();btn_Merge.hide();btn_Save.hide();
+					btn_Reset.hide();btn_Merge.hide();btn_Save.hide();btn_check.hide();
 
 					break;
 				case "REV":
 					btn_confirm.hide();btn_reject.hide();btn_review.hide();btn_restart.hide();
-					btn_Reset.hide();btn_Merge.hide();btn_Save.hide();
+					btn_Reset.hide();btn_Merge.hide();btn_Save.hide();btn_check.hide();
 
 					break;
 				case "CONF":
 					btn_confirm.hide();btn_reject.show();btn_review.hide();btn_restart.hide();
 					btn_Reset.hide();btn_Merge.hide();btn_Save.hide(); btn_Analysis.hide();
 					btn_Analysis_Result.hide(); btn_supplement_Notice.hide();
+					btn_check.hide();
 
 					break;
 			}

--- a/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
@@ -334,8 +334,8 @@
 	                        <input type="button" value="OSS bulk registration" onclick="fn_grid_com.ossBulkReg('${project.prjId}','11')" class="btnColor red" style="width: 145px;" />
                     	</c:if>
                     	<c:if test="${project.dropYn ne 'Y' and (ct:isAdmin() or project.viewOnlyFlag eq 'N')}">
-                    		<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('SRC')" class="btnColor red srcBtn" style="width: 115px;" />
-                    		<input type="button" value="Check License" onclick="com_fn.CheckOssLicenseViewPage('SRC')" class="btnColor red srcBtn" style="width: 100px;" />
+                    		<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('SRC')" class="btnColor red srcBtn btnCheck" style="width: 115px;" />
+                    		<input type="button" value="Check License" onclick="com_fn.CheckOssLicenseViewPage('SRC')" class="btnColor red srcBtn btnCheck" style="width: 100px;" />
                     		<input type="button" value="Bulk Edit" onclick="com_fn.bulkEdit('SRC')" class="btnColor btnColor red idenEdit" />
                     	</c:if>
                     </span>
@@ -519,8 +519,8 @@
 	                       <input type="button" value="OSS bulk registration" onclick="fn_grid_com.ossBulkReg('${project.prjId}','15')" class="btnColor red" style="width: 145px;" />
                     	</c:if>
                     	<c:if test="${project.dropYn ne 'Y' and (ct:isAdmin() or project.viewOnlyFlag eq 'N')}">
-                    		<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('BIN')" class="btnColor red binBtn" style="width: 115px;" />
-                    		<input type="button" value="Check License" onclick="com_fn.CheckOssLicenseViewPage('BIN')" class="btnColor red binBtn" style="width: 100px;" />
+                    		<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('BIN')" class="btnColor red binBtn btnCheck" style="width: 115px;" />
+                    		<input type="button" value="Check License" onclick="com_fn.CheckOssLicenseViewPage('BIN')" class="btnColor red binBtn btnCheck" style="width: 100px;" />
                     		<input type="button" value="Bulk Edit" onclick="com_fn.bulkEdit('BIN')" class="btnColor btnColor red idenEdit" />
                     	</c:if>
                     </span>
@@ -755,8 +755,8 @@
                     	</c:if>
                     	<c:if test="${project.dropYn ne 'Y'}">
 	                    	<input type="button" value="check License Text" class="downSet btnPackage" id="checkLicenseTextFile" onclick="binAndroid_fn.downloadFile()" style="display:none;float:right;">
-	                    	<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('ANDROID')" class="btnColor red binAndroidBtn" style="width: 115px;" />
-	                    	<input type="button" value="Check License" onclick="com_fn.CheckOssLicenseViewPage('ANDROID')" class="btnColor red binAndroidBtn" style="width: 100px;" />
+	                    	<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('ANDROID')" class="btnColor red binAndroidBtn btnCheck" style="width: 115px;" />
+	                    	<input type="button" value="Check License" onclick="com_fn.CheckOssLicenseViewPage('ANDROID')" class="btnColor red binAndroidBtn btnCheck" style="width: 100px;" />
 	                    	<input type="button" value="Bulk Edit" onclick="com_fn.bulkEdit('BINANDROID')" class="btnColor btnColor red idenEdit" />
                     	</c:if>
                     </span>

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
@@ -129,7 +129,7 @@
                 <input type="hidden" value="OSS Notice" onclick="src_fn.createNoticeTab()" class="btnColor red btnExpor srcBtn"  style="width: 80px;" />
                 <input type="button" value="Export" onclick="src_fn.downloadExcel()" class="btnColor red btnExpor srcBtn" />
                 <input type="button" value="Bulk Edit" onclick="fn.bulkEdit()" class="btnColor red"/>
-                <input type="button" value="Check OSS Name" onclick="src_fn.CheckOssViewPage()" class="btnColor red btnExpor srcBtn" style="width: 115px;" />
+                <input type="button" value="Check OSS Name" onclick="src_fn.CheckOssViewPage()" class="btnColor red btnExpor srcBtn btnCheck" style="width: 115px;" />
                 <input id="srcResetUp" type="button" value="Reset" class="btnColor btnReset srcBtn idenReset" />
                 <input id="srcSaveUp" type="button" value="Save" class="btnSave btnColor red idenSave"/>
             </span>
@@ -145,7 +145,7 @@
 				<input type="hidden" value="OSS Notice" onclick="createTabInFrame('Notice','#/selfCheck/verification/'+'${project.prjId}')" class="btnColor red btnNotice srcBtn"/>
 				<input type="button" value="Export" onclick="src_fn.downloadExcel()" class="btnColor red btnExpor srcBtn" />
 				<input type="button" value="Bulk Edit" onclick="fn.bulkEdit()" class="btnColor red"/>
-				<input type="button" value="Check OSS Name" onclick="src_fn.CheckOssViewPage()" class="btnColor red btnExpor srcBtn" style="width: 115px;" />
+				<input type="button" value="Check OSS Name" onclick="src_fn.CheckOssViewPage()" class="btnColor red btnExpor srcBtn btnCheck" style="width: 115px;" />
 				<input id="srcReset" type="button" value="Reset" class="btnColor btnReset srcBtn idenReset" />
 				<input id="srcSave" type="button" value="Save" class="btnSave btnColor red idenSave"/>
 			</span>


### PR DESCRIPTION
Hi, this is my solution for the issue #341 

## Description
The Check License and Check OSS Name buttons did not follow the same display conditions as the Save button.

<img width="1212" alt="Screen Shot 2021-12-22 at 13 30 18" src="https://user-images.githubusercontent.com/35499170/147139026-39073a4e-1ee2-4445-8996-b4a755fae85d.png">

I changed the display conditions oh these buttons in Identification and Self-check so that now when they are deployed it's because they actually work.

Please let me know if there are any corrections I need to make :)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
