### PR TITLE
License and Comment output when loading SPDX

### DIFF
--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -1085,18 +1085,46 @@ public class ExcelUtil extends CoTopComponent {
     						bean.setDownloadLocation("");
     						bean.setHomepage("");
     					}
-    				}
-    				else {
+    				} else {
     					// basic info
     					bean.setOssName(ossNameCol < 0 ? "" : avoidNull(getCellData(row.getCell(ossNameCol))).trim().replaceAll("\t", ""));
     					bean.setOssVersion(ossVersionCol < 0 ? "" : avoidNull(getCellData(row.getCell(ossVersionCol))).trim().replaceAll("\t", ""));
-    					bean.setDownloadLocation(downloadLocationCol < 0 ? "" : avoidNull(getCellData(row.getCell(downloadLocationCol))).trim().replaceAll("\t", ""));
+    					
+    					String downloadLocation = avoidNull(getCellData(row.getCell(downloadLocationCol))).trim().replaceAll("\t", "");
+    					if(downloadLocation.equals("NONE") || downloadLocation.equals("NOASSERTION") || downloadLocationCol < 0) {
+    						bean.setDownloadLocation("");
+    					} else {
+    						bean.setDownloadLocation(downloadLocation);
+    					}
+    					
     					bean.setHomepage(homepageCol < 0 ? "" : avoidNull(getCellData(row.getCell(homepageCol))).trim().replaceAll("\t", ""));
     					bean.setFilePath(pathOrFileCol < 0 ? "" : avoidNull(getCellData(row.getCell(pathOrFileCol))).trim().replaceAll("\t", ""));
     					bean.setBinaryName(binaryNameCol < 0 ? "" : avoidNull(getCellData(row.getCell(binaryNameCol))).trim().replaceAll("\t", ""));
-    					bean.setCopyrightText(copyrightTextCol < 0 ? "" : getCellData(row.getCell(copyrightTextCol)));
-//  					bean.setComments(commentCol < 0 ? getCellData(row.getCell(licenseCol)) : getCellData(row.getCell(licenseCol)) + ", " + getCellData(row.getCell(commentCol)));
-    					bean.setComments(commentCol < 0 ? "" : getCellData(row.getCell(commentCol)));
+    
+    					String copyrightText = getCellData(row.getCell(copyrightTextCol));
+    					if(copyrightText.equals("NONE") || copyrightText.equals("NOASSERTION") || copyrightTextCol < 0) {
+    						bean.setCopyrightText("");
+    					} else {
+    						bean.setCopyrightText(copyrightText);
+    					}
+
+    					String licenseConcluded = getCellData(row.getCell(licenseCol));
+    					String licenseComment = getCellData(row.getCell(commentCol));
+    					String comment = "";
+
+    					if(!licenseConcluded.isEmpty()) {
+    						comment += licenseConcluded;
+    					}
+
+    					if(!licenseComment.isEmpty()) {
+    						if(licenseConcluded.isEmpty()) {
+    							comment += licenseComment;
+    						} else {
+    							comment += " / " + licenseComment;
+    						}
+    					}
+    					bean.setComments(commentCol < 0 ? "" : comment);
+
     					bean.setOssNickName(nickNameCol < 0 ? "" : getCellData(row.getCell(nickNameCol)));
     					bean.setSpdxIdentifier(spdxIdentifierCol < 0 ? "" : getCellData(row.getCell(spdxIdentifierCol)));
     				}


### PR DESCRIPTION
## Description
* If the value to be loaded is NONE or NOASSERTION, load in a null space.
* Make it possible to upload SPDX documents as if uploading FOSSLIGHT REPORT to the following Tab.
    * Project > SRC, BIN
    * 3rd Party
    * Self-check
* How to do "Comment Load method.
    * AS-IS: Load values read from License Comments
    * TO-BE: If there is anything already written in the comment section in License Confused, divide it into / and attach it.
        * ex) License Concluded : (MIT OR GPL-2.0), License Comments : This is test
        * Comment : (MIT OR GPL-2.0) / This is test

### spdx file
[test.xls](https://github.com/fosslight/fosslight/files/7782493/test.xls)

### imported oss
![image](https://user-images.githubusercontent.com/32615702/147522419-6bda16d1-18d8-4dcc-b15a-c97a61fbe4db.png)


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
