### PR TITLE
Fix bugs in BOM Compare and Auto ID

### DIFF
--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -582,7 +582,8 @@ public class CommonFunction extends CoTopComponent {
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_CP:
-					if(!CoConstDef.CD_LICENSE_TYPE_WCP.equals(finalPermissive)) {
+					if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(finalPermissive)
+							&& !CoConstDef.CD_LICENSE_TYPE_WCP.equals(finalPermissive)) {
 						finalPermissive = CoConstDef.CD_LICENSE_TYPE_CP;
 						selectedIdx = idx;
 						permissiveListCP.add(selectedIdx);
@@ -590,7 +591,9 @@ public class CommonFunction extends CoTopComponent {
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_PF:
-					if(!CoConstDef.CD_LICENSE_TYPE_CP.equals(finalPermissive)) {
+					if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(finalPermissive)
+							&& !CoConstDef.CD_LICENSE_TYPE_WCP.equals(finalPermissive)
+							&& !CoConstDef.CD_LICENSE_TYPE_CP.equals(finalPermissive)) {
 						finalPermissive = CoConstDef.CD_LICENSE_TYPE_PF;
 						selectedIdx = idx;
 						permissiveListPF.add(selectedIdx);
@@ -666,13 +669,16 @@ public class CommonFunction extends CoTopComponent {
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_CP:
-					if(!CoConstDef.CD_LICENSE_TYPE_WCP.equals(rtnVal)) {
+					if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(rtnVal)
+							&& !CoConstDef.CD_LICENSE_TYPE_WCP.equals(rtnVal)) {
 						rtnVal = CoConstDef.CD_LICENSE_TYPE_CP;
 					}
 				
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_PF:
-					if(!CoConstDef.CD_LICENSE_TYPE_CP.equals(rtnVal)) {
+					if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(rtnVal)
+							&& !CoConstDef.CD_LICENSE_TYPE_WCP.equals(rtnVal)
+							&& !CoConstDef.CD_LICENSE_TYPE_CP.equals(rtnVal)) {
 						rtnVal = CoConstDef.CD_LICENSE_TYPE_PF;
 					}
 					

--- a/src/main/java/oss/fosslight/config/CustomAuthenticationProvider.java
+++ b/src/main/java/oss/fosslight/config/CustomAuthenticationProvider.java
@@ -99,12 +99,12 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 				con = new InitialDirContext(properties);
 				isAuthenticated = true;
 			}catch (NamingException e) {
-				log.error(e.getMessage());
+				log.warn("LDAP NamingException userId : " + user_id + " ERROR Message :" + e.getMessage());
 			} finally {
 				if(con != null) {
 					try {
 						con.close();
-					} catch (NamingException e) {}
+					} catch (Exception e) {}
 				}
 			}
 		}

--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -63,8 +63,9 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			for(String key : validMap.keySet()) {
 				if(key.toUpperCase().startsWith("LICENSENAME")
 						&& (validMap.get(key).equals(ruleMap.get("LICENSE_NAME.UNCONFIRMED.MSG"))
-						|| validMap.get(key).equals(ruleMap.get("LICENSE_NAME.REQUIRED.MSG")))
-						|| validMap.get(key).startsWith("Declared")) {
+						|| validMap.get(key).equals(ruleMap.get("LICENSE_NAME.REQUIRED.MSG"))
+						|| validMap.get(key).equals(ruleMap.get("LICENSE_NAME.NOLICENSE.MSG"))
+						|| validMap.get(key).startsWith("Declared"))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
 							.stream()
 							.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
@@ -89,7 +90,9 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 
 		if(diffMap != null) {
 			for(String key : diffMap.keySet()) {
-				if(key.toUpperCase().startsWith("LICENSENAME") && diffMap.get(key).equals(ruleMap.get("LICENSE_NAME.UNCONFIRMED.MSG"))) {
+				if(key.toUpperCase().startsWith("LICENSENAME") && 
+						(diffMap.get(key).equals(ruleMap.get("LICENSE_NAME.UNCONFIRMED.MSG"))
+								|| diffMap.get(key).startsWith("Declared"))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
 							.stream()
 							.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -624,7 +624,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 							// 어짜피 여기서 설정하는 라이선스 이름은 의미가 없음
 							if(bean.getComponentLicenseList() != null && bean.getComponentLicenseList().size() == 1 && bean.getComponentLicenseList().get(0) != null) {
 								bean.setLicenseName(bean.getComponentLicenseList().get(0).getLicenseName());
-							} else if(multiUIFlag) {
+							} else if(CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())) {
 								bean.setLicenseName(CommonFunction.makeLicenseExpressionIdentify(bean.getComponentLicenseList(), ","));
 							} else {
 								// TODO - 여기 수정하면 될거 같음.. multiUIFlag
@@ -4359,8 +4359,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						afterBomList
 								.stream()
 								.filter(afList -> 
-										(bfList.getOssName() + "||" + bfList.getOssVersion() + "||" + getLicenseNameSort(bfList.getLicenseName().trim().replaceAll(" ", "")))
-										.equalsIgnoreCase(afList.getOssName() + "||" + afList.getOssVersion() + "||" + getLicenseNameSort(afList.getLicenseName().trim().replaceAll(" ", "")))
+										(bfList.getOssName() + "||" + bfList.getOssVersion() + "||" + getLicenseNameSort(bfList.getLicenseName().trim()))
+										.equalsIgnoreCase(afList.getOssName() + "||" + afList.getOssVersion() + "||" + getLicenseNameSort(afList.getLicenseName().trim()))
 										).collect(Collectors.toList()).size() == 0
 						).collect(Collectors.toList());
 		
@@ -4370,8 +4370,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						beforeBomList
 								.stream()
 								.filter(bfList -> 
-										(afList.getOssName() + "||" + afList.getOssVersion() + "||" + getLicenseNameSort(afList.getLicenseName().trim().replaceAll(" ", "")))
-										.equalsIgnoreCase(bfList.getOssName() + "||" + bfList.getOssVersion() + "||" + getLicenseNameSort(bfList.getLicenseName().trim().replaceAll(" ", "")))
+										(afList.getOssName() + "||" + afList.getOssVersion() + "||" + getLicenseNameSort(afList.getLicenseName().trim()))
+										.equalsIgnoreCase(bfList.getOssName() + "||" + bfList.getOssVersion() + "||" + getLicenseNameSort(bfList.getLicenseName().trim()))
 										).collect(Collectors.toList()).size() == 0
 						).collect(Collectors.toList());
 		
@@ -4395,7 +4395,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				
 				if (flag.equals("list")) {
 					afterossname = changeStyle("add", afterossname);
-					afterlicense = changeStyle("add", getLicenseNameSort(afterlicense.trim().replaceAll(" ", "")));
+					afterlicense = changeStyle("add", getLicenseNameSort(afterlicense.trim()));
 				}
 				
 				addMap.put("status", "add");
@@ -4435,7 +4435,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				
 				if (flag.equals("list")) {
 					beforeossname = changeStyle("delete", beforeossname);
-					beforelicense = changeStyle("delete", getLicenseNameSort(beforelicense.trim().replaceAll(" ", "")));
+					beforelicense = changeStyle("delete", getLicenseNameSort(beforelicense.trim()));
 				}
 				
 				deleteMap.put("status", "delete");
@@ -4470,7 +4470,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}else {
 					addBeforeBomVO.setOssVersion(beforeBomCheckVO.getOssName() + "("+ beforeBomCheckVO.getOssVersion() + ")");
 				}
-				addBeforeBomVO.setLicenseName(getLicenseNameSort(avoidNull(beforeBomCheckVO.getLicenseName(), "N/A").replaceAll(" ", "")));
+				addBeforeBomVO.setLicenseName(getLicenseNameSort(avoidNull(beforeBomCheckVO.getLicenseName().trim(), "N/A")));
 									
 				if (beforeBomResult.size() > 0) {
 					for (int j=0; j<beforeBomResult.size(); j++) {
@@ -4503,7 +4503,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}else {
 					addAfterBomVO.setOssVersion(afterBomCheckVO.getOssName() + "(" + avoidNull(afterBomCheckVO.getOssVersion(), "N/A") + ")");
 				}
-				addAfterBomVO.setLicenseName(getLicenseNameSort(avoidNull(afterBomCheckVO.getLicenseName().trim(), "N/A").replaceAll(" ", "")));
+				addAfterBomVO.setLicenseName(getLicenseNameSort(avoidNull(afterBomCheckVO.getLicenseName().trim(), "N/A")));
 				
 				if (afterBomResult.size() > 0) {
 					for (int j=0; j<afterBomResult.size(); j++) {

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -715,11 +715,11 @@ public class ExcelUtil extends CoTopComponent {
 			}
 
 		} catch (ColumnNameDuplicateException e) {
-			log.error("There are duplicated header rows in the OSS Report. Please check it.<br/>" + e.getMessage());
+//			log.error("There are duplicated header rows in the OSS Report. Please check it.<br/>" + e.getMessage());
 			errMsgList.add("There are duplicated header rows in the OSS Report. Please check it.<br/>" + e.getMessage());
 			return false;
 		} catch (ColumnMissingException e) {
-			log.error(e.getMessage());
+//			log.warn(e.getMessage(), e);
 			errMsgList.add(e.getMessage());
 			return false;
 		} catch (Exception e) {


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Update log error message for LDAP.
- Delete the ColumnMissingException, ColumnNameDuplicateException  error output when reading the OSS Report.
- Fix the bug where the space disappears in the license name when comparing BOM in Project List.
- Fix the bug related to the license type check to be loaded during Auto ID.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
