### PR TITLE
Add a shortcut link when sending a license email

### DIFF
--- a/src/main/java/oss/fosslight/domain/CoMailManager.java
+++ b/src/main/java/oss/fosslight/domain/CoMailManager.java
@@ -155,6 +155,11 @@ public class CoMailManager extends CoTopComponent {
 					|| CoConstDef.CD_MAIL_TYPE_OSS_MODIFIED_COMMENT.equals(bean.getMsgType())
 					|| CoConstDef.CD_MAIL_TYPE_OSS_DEACTIVATED.equals(bean.getMsgType())
 					|| CoConstDef.CD_MAIL_TYPE_OSS_ACTIVATED.equals(bean.getMsgType())
+					|| CoConstDef.CD_MAIL_TYPE_LICENSE_REGIST.equals(bean.getMsgType())
+					|| CoConstDef.CD_MAIL_TYPE_LICENSE_UPDATE.equals(bean.getMsgType())
+					|| CoConstDef.CD_MAIL_TYPE_LICENSE_UPDATE_TYPE.equals(bean.getMsgType())
+					|| CoConstDef.CD_MAIL_TYPE_LICENSE_RENAME.equals(bean.getMsgType())
+					|| CoConstDef.CD_MAIL_TYPE_LICENSE_MODIFIED_COMMENT.equals(bean.getMsgType())
 					) {
 				convertDataMap.put("contentsTitle", StringUtil.replace(makeMailSubject((isTest ? "[TEST]" : "") + CoCodeManager.getCodeString(CoConstDef.CD_MAIL_TYPE, bean.getMsgType()), bean, true), "[FOSSLight]", ""));
 			} else {
@@ -1383,7 +1388,17 @@ public class CoMailManager extends CoTopComponent {
 				}
 				_s += licenseInfo.getLicenseName();
 			}
-			
+			if (isMailBodySubject
+					&& (CoConstDef.CD_MAIL_TYPE_LICENSE_REGIST.equals(bean.getMsgType())
+							|| CoConstDef.CD_MAIL_TYPE_LICENSE_UPDATE.equals(bean.getMsgType())
+							|| CoConstDef.CD_MAIL_TYPE_LICENSE_UPDATE_TYPE.equals(bean.getMsgType())
+							|| CoConstDef.CD_MAIL_TYPE_LICENSE_RENAME.equals(bean.getMsgType())
+							|| CoConstDef.CD_MAIL_TYPE_LICENSE_MODIFIED_COMMENT.equals(bean.getMsgType())
+					)) {
+				String linkUrl = CommonFunction.emptyCheckProperty("server.domain", "http://fosslight.org");
+				linkUrl += "/license/edit/" + bean.getParamLicenseId();
+				_s = "<a href='" + linkUrl + "' target='_blank'>" + _s + "</a>";
+			}
 			title = StringUtil.replace(title, "${License Name}", _s);
 		}
 		

--- a/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
@@ -236,7 +236,7 @@
 								<dd>
 									<div class="basicCase">
 										<div class="uploadTit">
-											<span class="checkSet"><label for="2">General Model</label></span>	
+											<span class="checkSet"><label for="2">FOSSLight Report</label></span>	
 										</div>
 										<div class="uploadGroup">
 											<div class="uploadSet">


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- When sending license mail, add a shortcut link to license name.
- In the SRC tab of the project, change the text in the upload field from General Model to FOSSLight Report.
![image](https://user-images.githubusercontent.com/4284712/149869680-05ab6a82-092a-4b32-a889-62a468bf25b9.png)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
