### PR TITLE
Fix the bug where OSS Type is not Dual and not version diff is displayed incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.2.27 (21/01/2022)
+## Changes
+## 🐛 Hotfixes
+
+- Fix bugs related to Auto ID and BOM Obligation. @FOSSLight-dev (#391)
+- Fix bugs in BOM Compare and Auto ID @FOSSLight-dev (#389)
+- Delete the arrow from the left menu @FOSSLight-dev (#388)
+
+## 🔧 Maintenance
+
+- Add a default value for server domain @FOSSLight-dev (#392)
+- Add a shortcut link when sending a license email @soimkim (#390)
+- Delete the arrow from the left menu @FOSSLight-dev (#388)
+
+---
+
 ## v1.2.26 (14/01/2022)
 ## Changes
 ## 🐛 Hotfixes
@@ -573,8 +589,3 @@
 ## v1.0.1 (27/05/2021)
 ## Changes
 * Set up automated deployment.
-
----
-
-## v1.0 (30/04/2021)
-Release FOSSLight v1.0 🎉

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'oss.fosslight'
-version = '1.2.26'
+version = '1.2.27'
 sourceCompatibility = '1.8'
 
 configurations {

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -428,6 +428,7 @@ public class OssController extends CoTopComponent{
 			if(!isNew){
 				beforeBean = ossService.getOssInfo(ossId, true);
 				result = ossService.registOssMaster(ossMaster);
+				ossService.updateVersionDiff(ossMaster); // process v-diff
 				CoCodeManager.getInstance().refreshOssInfo();
 				h = ossService.work(ossMaster);
 				action = CoConstDef.ACTION_CODE_UPDATE;
@@ -454,6 +455,7 @@ public class OssController extends CoTopComponent{
 				isNewVersion = CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossMaster.getOssName().toUpperCase());
 				
 				result = ossService.registOssMaster(ossMaster);
+				ossService.updateVersionDiff(ossMaster); // process v-diff
 				CoCodeManager.getInstance().refreshOssInfo();
 				ossId = result;
 				
@@ -555,6 +557,7 @@ public class OssController extends CoTopComponent{
 
 		// 삭제처리
 		ossService.deleteOssMaster(ossMaster);
+		ossService.updateVersionDiff(ossMaster); // process v-diff
 		CoCodeManager.getInstance().refreshOssInfo();
 		
 		resMap.put("resCd", resCd);
@@ -1131,6 +1134,7 @@ public class OssController extends CoTopComponent{
 		ossMaster.setComment(CommonFunction.lineReplaceToBR(ossMaster.getComment()) );
 		ossMaster.setAddNicknameYn(CoConstDef.FLAG_YES); //nickname을 clear&insert 하지 않고, 중복제거를 한 나머지 nickname에 대해서는 add함.
 		String resultOssId = ossService.registOssMaster(ossMaster);
+		ossService.updateVersionDiff(ossMaster); // process v-diff
 		CoCodeManager.getInstance().refreshOssInfo();
 		
 		History h = ossService.work(ossMaster);
@@ -1690,6 +1694,7 @@ public class OssController extends CoTopComponent{
 		
 		try {
 			resultOssId = ossService.registOssMaster(resultData); // oss 정보 등록
+			ossService.updateVersionDiff(resultData); // process v-diff
 			
 			analysisBean.setComponentId(analysisBean.getGroupId());
 			analysisBean.setReferenceOssId(resultOssId);

--- a/src/main/java/oss/fosslight/service/OssService.java
+++ b/src/main/java/oss/fosslight/service/OssService.java
@@ -108,4 +108,6 @@ public interface OssService extends HistoryConfig{
 	void syncOssMaster(OssMaster syncBean, boolean declaredLicenseCheckFlag, boolean detectedLicenseCheckFlag, boolean downloadLocationCheckFlag);
 
 	OssMaster makeEmailSendFormat(OssMaster beforeBean);
+
+	void updateVersionDiff(OssMaster ossMaster);
 }

--- a/src/main/resources/messages/message_en_US.properties
+++ b/src/main/resources/messages/message_en_US.properties
@@ -127,7 +127,7 @@ msg.distribute.complete=Distribution has been completed.
 msg.distribute.reset=Distributed information has been initialized.
 #msg.distribute.confrim.overwritefile=A file with the same name already exists in the category.  Do you want to continue? <br />(If you change the file, it applies to all relevant models, regardless of release date.)
 msg.distribute.confrim.overwritefile=File(<b>{0}<b/>) with the same name already exists in the category. <span style="color:red;">Do you want to overwrite <b>{0}<b/> file?</span><br>(If you change the file, it applies to <span style="color:blue;">all relevant models that already distributed.</span>)
-msg.distribute.confirm.reset=<b>This description is already registered on the Open Source Distribution Site.</b><br /><br />This distribution will only be removed in the FOSSLight Hub.<br />If you want to delete it from OSDD site, Click the DELETE WITH OSDD button<br /><br />Are you sure to reject the distribution?
+msg.distribute.confirm.reset=<b>This description is already registered on the Open Source Distribution Site.</b><br /><br />This distribution will be removed in the FOSSLight Hub and OSS Distribution site.<br /><br />Are you sure to reject the distribution?
 msg.distribute.confirm.reset.warn=This description can not be found on the Open Source Distribution Site.<br />Are you sure to reject the distribution?
 msg.distribute.model.required=Model information is required.
 msg.distribute.sync.addedmodel=There are models added to the OSDD system. <br/>Please check the model information and try again.<br/>

--- a/src/main/resources/messages/message_ko_KR.properties
+++ b/src/main/resources/messages/message_ko_KR.properties
@@ -127,7 +127,7 @@ msg.distribute.complete = 배포가 완료되었습니다.
 msg.distribute.reset=배포 정보가 초기화되었습니다.
 #msg.distribute.confrim.overwritefile = 같은 이름의 파일이 이미 카테고리에 있습니다. 계속하시겠습니까? <br />(파일을 변경하면 출시일과 관계없이 모든 관련 모델에 적용됩니다.)
 msg.distribute.confrim.overwritefile=동일한 Category에 동일한 이름의 파일(<b>{0}<b/>)이 이미 존재합니다. <span style="color:red;"><b>{0}<b/> 파일을 덮어 씌우겠습니까?</span><br>(만약 해당 파일을 덮어씌우게 될 경우, 변경 사항은 <span style="color:blue;">이미 배포되었던 모델</span>에도 적용됩니다.)
-msg.distribute.confirm.reset=<b>이 설명은 이미 오픈 소스 배포 사이트에 등록되어 있습니다.</b><br /><br />이 배포는 FOSSLight Hub에서만 제거됩니다.<br />OSDD 사이트에서 삭제를 원하시면 DELETE WITH OSDD 버튼을 클릭해주세요.<br /><br />정말로 배포를 reject하시겠습니까?
+msg.distribute.confirm.reset=<b>이 description은 이미 오픈 소스 배포 사이트에 등록되어 있습니다.</b><br /><br />Delete버튼 클릭 시, 이 배포는 FOSSLight Hub와 OSS Distribution 사이트에서 제거됩니다.<br /><br />정말로 배포를 reject하시겠습니까?
 msg.distribute.confirm.reset.warn=이 설명은 오픈 소스 배포 사이트에서 찾을 수 없습니다.<br />배포를 reject하시겠습니까?
 msg.distribute.model.required=모델 정보가 필요합니다.
 msg.distribute.sync.addedmodel=OSDD 시스템에 추가된 모델이 있습니다. <br/>모델 정보를 확인하고 다시 시도해주세요.<br/>


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Fix the bug where OSS Type is not Dual and not version diff is displayed incorrectly.
- In case of V-Diff when saving a new OSS: When saving the same oss name and different version at the same time, when saving a new one > After collecting the information of the same oss name, the oss type flag value is saved. After collecting the information, the deletion process proceeds before saving the flag value. When this happens, the V-Diff value is stored in the oss type flag value.
- When the OSS Type is different from the saved value when editing: When the same oss name, different version (1.0, 2.0) is modified at a similar point in time > There is a phenomenon in which a flag value different from the license in which the oss type flag value is stored is stored.


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
