### PR TITLE
Fix bug where OSS Rename popup appears for new OSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.2.28 (28/01/2022)
+## 🐛 Hotfixes
+
+- Fix the bug where OSS Type is not Dual and not version diff is displayed incorrectly @FOSSLight-dev (#393)
+
+## 🔧 Maintenance
+
+- Add the function to change the OSS Name of OSS with different versions @FOSSLight-dev (#395)
+- Reorder user comments before email default content @soimkim (#394)
+
+---
+
 ## v1.2.27 (21/01/2022)
 ## Changes
 ## 🐛 Hotfixes
@@ -583,9 +595,3 @@
 - Move DB related files to db directory @soimkim (#5)
 - Update docker files @soimkim (#4)
 - Remove unnecessary files @soimkim (#1)
-
----
-
-## v1.0.1 (27/05/2021)
-## Changes
-* Set up automated deployment.

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2088,6 +2088,17 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				throw new Exception(ossMaster.getOssName() + " -> NickName field is required.");
 			}
 			
+			List<String> ossNameList = new ArrayList<>();
+			ossNameList.add(paramBean.getOssName());
+			String[] ossNames = new String[ossNameList.size()];
+			ossMaster.setOssNames(ossNameList.toArray(ossNames));
+			
+			Map<String, OssMaster> ossMap = getBasicOssInfoList(ossMaster);
+			
+			if(ossMap == null || ossMap.isEmpty()) {}else {
+				throw new Exception(paramBean.getOssName() + " -> OSS Name registered in OSS list.");
+			}
+			
 			int insertCnt = ossMapper.insertOssNickname(ossMaster);
 			
 			if(insertCnt == 1) {
@@ -2685,9 +2696,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	@Override
 	public String checkOssVersionDiff(OssMaster ossMaster) {
 		boolean ossVersion_Flag = false;
-		OssMaster om = ossMapper.checkExistsOssname(ossMaster);
+		boolean isNew = StringUtil.isEmpty(ossMaster.getOssId());
 		
-		if(om == null) {
+		if(!isNew) {
 			List<String> afterOssNameList = new ArrayList<>();
 			afterOssNameList.add(ossMaster.getOssName().trim());
 			String[] afterOssNames = new String[afterOssNameList.size()];

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2699,14 +2699,23 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		boolean isNew = StringUtil.isEmpty(ossMaster.getOssId());
 		
 		if(!isNew) {
-			List<String> afterOssNameList = new ArrayList<>();
-			afterOssNameList.add(ossMaster.getOssName().trim());
-			String[] afterOssNames = new String[afterOssNameList.size()];
-			ossMaster.setOssNames(afterOssNameList.toArray(afterOssNames));
+			OssMaster beforeOss = CoCodeManager.OSS_INFO_BY_ID.get(ossMaster.getOssId());
+			
+			List<String> ossNameList = new ArrayList<>();
+			ossNameList.add(beforeOss.getOssName().trim());
+			String[] ossNames = new String[ossNameList.size()];
+			beforeOss.setOssNames(ossNameList.toArray(ossNames));
+			
+			Map<String, OssMaster> beforeOssMap = getBasicOssInfoList(beforeOss);
+			
+			ossNameList = new ArrayList<>();
+			ossNameList.add(ossMaster.getOssName().trim());
+			ossNames = new String[ossNameList.size()];
+			ossMaster.setOssNames(ossNameList.toArray(ossNames));
 			
 			Map<String, OssMaster> afterOssMap = getBasicOssInfoList(ossMaster);
 									
-			if(afterOssMap == null || afterOssMap.isEmpty()) {
+			if((afterOssMap == null || afterOssMap.isEmpty()) && beforeOssMap.size() > 1) {
 				ossVersion_Flag = true;
 			}
 			

--- a/src/main/resources/messages/message_en_US.properties
+++ b/src/main/resources/messages/message_en_US.properties
@@ -171,6 +171,8 @@ msg.oss.change.bulkedit=Are you sure you want to change data for the selected ro
 msg.oss.delete.bulkedit=Are you sure you want to delete data for the selected row?
 msg.oss.select.attribute.bulkedit=Check the attribute to be edited.
 msg.oss.check.version.bulk=There are different versions of the same oss name.<br>Do you want to change the OSS name for every version?
+msg.oss.check.version.bulk.ok=OK (Rename all versions)
+msg.oss.check.version.bulk.no=NO (Change only for this OSS)
 
 # Partner
 msg.partner.notice=Binary analysis results are used only as reference data. Until the accuracy of the tool is improved, it is not included in the BOM and OSS Notice
@@ -202,6 +204,7 @@ msg.licensename.error=For license name ',' cannot be used.
 
 # Check OSS Name
 already.added.nickname=Already added nickname.
+msg.value.registered.oss.name=OSS Name registered in OSS list.
 
 # Check License
 check.evidence.exist.nameAndVersion=DB : Matched by OSS name AND OSS version

--- a/src/main/resources/messages/message_ko_KR.properties
+++ b/src/main/resources/messages/message_ko_KR.properties
@@ -170,6 +170,9 @@ msg.oss.select.ossTable=수정할 Row를 체크하세요.
 msg.oss.change.bulkedit=선택한 row에 대하여 일괄 변경하시겠습니까?
 msg.oss.delete.bulkedit=선택한 row에 대하여 일괄 삭제하시겠습니까?
 msg.oss.select.attribute.bulkedit=수정할 속성을 체크하세요.
+msg.oss.check.version.bulk=동일한 OSS Name으로 다른 버전이 존재한다.<br>모든 버전에 대하여 OSS Name을 변경하시겠습니까?
+msg.oss.check.version.bulk.ok=네 (모든 버전의 이름 변경)
+msg.oss.check.version.bulk.no=아니오 (이 버전만 수정)
 
 # Partner
 msg.partner.notice=Binary 분석 결과는 참조 데이터로만 사용됩니다. 정확도가 향상될 때까지 BOM 및 OSS 공지사항에 포함되지 않습니다.
@@ -202,6 +205,7 @@ msg.licensename.error=라이선스 이름에는 ','를 사용할 수 없습니�
 
 # Check OSS Name
 already.added.nickname=이미 추가된 닉네임 입니다.
+msg.value.registered.oss.name=기존 등록된 OSS 이름이 있습니다.
 
 # Check License
 check.evidence.exist.nameAndVersion=DB : OSS 이름과 버전으로 일치


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Fix the bug where OSS rename popup appears even when OSS is newly added.
- Change the message that pops up when OSS is renamed.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
