### PR TITLE
Fix the bug where the license was not displayed on the OSS details page

### DIFF
--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -738,49 +738,51 @@ public class CommonFunction extends CoTopComponent {
 		String currentType = "";
 		boolean breakFlag = false;
 		
-		for(OssLicense bean : andList) {
-			// 가장 Strong한 라이선스부터 case
-			switch (bean.getLicenseType()) {
-				case CoConstDef.CD_LICENSE_TYPE_NA:
-					currentType = CoConstDef.CD_LICENSE_TYPE_NA;
-					rtnVal = bean;
-					breakFlag = true;
-					
-					break;
-				case CoConstDef.CD_LICENSE_TYPE_PF:
-					if(!CoConstDef.CD_LICENSE_TYPE_NA.equals(currentType)) {
-						currentType = CoConstDef.CD_LICENSE_TYPE_PF;
+		if(andList != null) {
+			for(OssLicense bean : andList) {
+				// 가장 Strong한 라이선스부터 case
+				switch (bean.getLicenseType()) {
+					case CoConstDef.CD_LICENSE_TYPE_NA:
+						currentType = CoConstDef.CD_LICENSE_TYPE_NA;
 						rtnVal = bean;
-					}
-					
+						breakFlag = true;
+						
+						break;
+					case CoConstDef.CD_LICENSE_TYPE_PF:
+						if(!CoConstDef.CD_LICENSE_TYPE_NA.equals(currentType)) {
+							currentType = CoConstDef.CD_LICENSE_TYPE_PF;
+							rtnVal = bean;
+						}
+						
+						break;
+					case CoConstDef.CD_LICENSE_TYPE_CP:
+						if(!CoConstDef.CD_LICENSE_TYPE_PF.equals(currentType)) {
+							currentType = CoConstDef.CD_LICENSE_TYPE_CP;
+							rtnVal = bean;
+						}
+						
+						break;
+					case CoConstDef.CD_LICENSE_TYPE_WCP:
+						if(!CoConstDef.CD_LICENSE_TYPE_CP.equals(currentType)) {
+							currentType = CoConstDef.CD_LICENSE_TYPE_WCP;
+							rtnVal = bean;
+						}
+						
+						break;
+					case CoConstDef.CD_LICENSE_TYPE_PMS:
+						if(isEmpty(currentType)) {
+							currentType = CoConstDef.CD_LICENSE_TYPE_PMS;
+							rtnVal = bean;
+						}
+						
+						break;
+					default:
+						break;
+				}
+				
+				if(breakFlag) {
 					break;
-				case CoConstDef.CD_LICENSE_TYPE_CP:
-					if(!CoConstDef.CD_LICENSE_TYPE_PF.equals(currentType)) {
-						currentType = CoConstDef.CD_LICENSE_TYPE_CP;
-						rtnVal = bean;
-					}
-					
-					break;
-				case CoConstDef.CD_LICENSE_TYPE_WCP:
-					if(!CoConstDef.CD_LICENSE_TYPE_CP.equals(currentType)) {
-						currentType = CoConstDef.CD_LICENSE_TYPE_WCP;
-						rtnVal = bean;
-					}
-					
-					break;
-				case CoConstDef.CD_LICENSE_TYPE_PMS:
-					if(isEmpty(currentType)) {
-						currentType = CoConstDef.CD_LICENSE_TYPE_PMS;
-						rtnVal = bean;
-					}
-					
-					break;
-				default:
-					break;
-			}
-			
-			if(breakFlag) {
-				break;
+				}
 			}
 		}
 		

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -897,7 +897,7 @@ public class OssController extends CoTopComponent{
 		OssMaster orgMaster = null;
 		
 		if(!isEmpty(ossMaster.getOssName())) {
-			orgMaster = ossService.getLastModifiedOssInfoByName(ossMaster);
+			orgMaster = ossService.getSaveSesstionOssInfoByName(ossMaster);
 		}
 		
 		if(orgMaster != null && !isEmpty(orgMaster.getOssId())) {

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -202,7 +202,7 @@ public class OssController extends CoTopComponent{
 			model.addAttribute("downloadLocation", avoidNull(bean.getDownloadLocation()));
 			model.addAttribute("homepage", avoidNull(bean.getHomepage()));
 			
-			if(bean.getLicenseName() != null && bean.getLicenseName().contains(",")) {
+			if(!isEmpty(avoidNull(bean.getLicenseName()))) {
 				List<OssLicense> licenseList = new ArrayList<OssLicense>();
 				HashMap<String, Object> map = new HashMap<String, Object>();
 				int idx = 1;
@@ -233,8 +233,6 @@ public class OssController extends CoTopComponent{
 				
 				map.put("rows", licenseList);
 				model.addAttribute("list", toJson(map));
-			} else {
-				model.addAttribute("licenseName", avoidNull(bean.getLicenseName()));
 			}
 			
 			model.addAttribute("copyright", avoidNull(bean.getCopyright()));

--- a/src/main/java/oss/fosslight/domain/ProjectIdentification.java
+++ b/src/main/java/oss/fosslight/domain/ProjectIdentification.java
@@ -133,6 +133,9 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	
 	/** The bat string match percentage. */
 	private String batStringMatchPercentage;
+
+	/** The bat string match percentage float. */
+	private String batStringMatchPercentageFloat;
 	
 	/** The bat percentage. */
 	private String batPercentage;
@@ -1123,6 +1126,16 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	 */
 	public void setBatStringMatchPercentage(String batStringMatchPercentage) {
 		this.batStringMatchPercentage = batStringMatchPercentage;
+	}
+	
+	
+
+	public String getBatStringMatchPercentageFloat() {
+		return batStringMatchPercentageFloat;
+	}
+
+	public void setBatStringMatchPercentageFloat(String batStringMatchPercentageFloat) {
+		this.batStringMatchPercentageFloat = batStringMatchPercentageFloat;
 	}
 
 	/**

--- a/src/main/java/oss/fosslight/repository/OssMapper.java
+++ b/src/main/java/oss/fosslight/repository/OssMapper.java
@@ -225,4 +225,6 @@ public interface OssMapper {
 	void deleteOssLicenseDetectedSync(OssMaster ossMaster);
 
 	void updateOssComponents(OssMaster ossMaster);
+
+	OssMaster getSaveSesstionOssInfoByName(OssMaster ossMaster);
 }

--- a/src/main/java/oss/fosslight/service/OssService.java
+++ b/src/main/java/oss/fosslight/service/OssService.java
@@ -114,4 +114,6 @@ public interface OssService extends HistoryConfig{
 	String checkOssVersionDiff(OssMaster ossMaster);
 
 	Map<String, List<OssMaster>> updateOssNameVersionDiff(OssMaster ossMaster);
+
+	OssMaster getSaveSesstionOssInfoByName(OssMaster ossMaster);
 }

--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -461,9 +461,12 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				HttpStatus statusCode = response.statusCode();
 				if(statusCode.is4xxClientError()) {
 					return Mono.error(new HttpServerErrorException(statusCode));
+				}else if (statusCode.is5xxServerError()) {
+					return Mono.error(new HttpServerErrorException(statusCode));
 				}
 				return Mono.just(response);
 			})
+			.retry(1)
 			.flatMap(response -> response.bodyToMono(Object.class));
 	}
 
@@ -484,9 +487,12 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 					HttpStatus statusCode = response.statusCode();
 					if (statusCode.is4xxClientError()) {
 						return Mono.error(new HttpServerErrorException(statusCode));
+					}else if (statusCode.is5xxServerError()) {
+						return Mono.error(new HttpServerErrorException(statusCode));
 					}
 					return Mono.just(response);
 				})
+				.retry(1)
 				.flatMap(response -> response.bodyToMono(Object.class));
 	}
 

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2866,4 +2866,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		return ossNameVersionDiffMergeObject;
 	}
+
+	@Override
+	public OssMaster getSaveSesstionOssInfoByName(OssMaster ossMaster) {
+		return ossMapper.getSaveSesstionOssInfoByName(ossMaster);
+	}
 }

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -697,6 +697,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						}
 
 						bean.setBatStrPlus(batPercentageStr);
+						
+						// Change bat grid result percentage (UI) Number only
+						if(!isEmpty(bean.getBatStringMatchPercentage())) {
+							bean.setBatStringMatchPercentageFloat(bean.getBatStringMatchPercentage().replace("%", "").trim());
+						}
+						
 					}
 					
 					// License Restriction 저장

--- a/src/main/resources/oss/fosslight/repository/OssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/OssMapper.xml
@@ -2138,4 +2138,15 @@
     	</choose>
            AND T1.ADMIN_CHECK_YN	!= 'Y'
     </update>
+    
+    <select id="getSaveSesstionOssInfoByName" parameterType="oss.fosslight.domain.OssMaster" resultType="oss.fosslight.domain.OssMaster">
+		SELECT T1.OSS_ID
+		     , T1.DOWNLOAD_LOCATION
+		     , (SELECT GROUP_CONCAT(D.DOWNLOAD_LOCATION SEPARATOR ',') FROM OSS_DOWNLOADLOCATION D WHERE D.OSS_ID = T1.OSS_ID ) AS DOWNLOAD_LOCATION_GROUP
+		  FROM OSS_MASTER T1 
+		  LEFT OUTER JOIN OSS_NICKNAME T2 ON T1.OSS_NAME = T2.OSS_NAME
+		 WHERE T1.USE_YN = 'Y' AND (T1.OSS_NAME = #{ossName} OR T2.OSS_NICKNAME = #{ossName}) 
+		   AND T1.OSS_VERSION = #{ossVersion}
+		 ORDER BY CREATED_DATE DESC, OSS_VERSION DESC LIMIT 1;
+	</select>
 </mapper>

--- a/src/main/resources/static/css/commonIframe.css
+++ b/src/main/resources/static/css/commonIframe.css
@@ -503,6 +503,7 @@ body,html {/*overflow:hidden !important;letter-spacing:0.06em;*/background:#fff;
 .editSearchUp dl.fideCase dd label {display:inline-block;padding:0 15px 0 0;width:115px;text-align:right;font-size:13px;color:#454545;}
 .editSearchUp dl.fideCase dd input {width:766px;}
 
+.uploadSet .fileex_fontcolor {color:#ff5a00;}
 .uploadSet .fileex_back {float:left;}
 .uploadSet .uploadList {float:left;display:inline-block;padding:0 0 0 21px;}
 .uploadSet .uploadList li {padding:3px 0;}

--- a/src/main/webapp/WEB-INF/views/admin/project/src-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/src-js.jsp
@@ -91,11 +91,12 @@ var src_evt = {
 			allowedTypes:accept1,
 			sequential:true,
 			sequentialCount:1,
-			dynamicFormData: function(){
+/*			dynamicFormData: function(){
 				var data ={ "registFileId" :$('#srcCsvFileId').val(), "tabNm" : "SRC"}
 				
 				return data;
-			},
+			},*/
+			formData:{"registFileId" : $('#srcCsvFileId').val(), "tabNm" : "SRC"},
 			onSuccess:function(files,data,xhr,pd) {
 				var result = jQuery.parseJSON(data);
 				


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Fix the bug where the license is not loaded in the OSS details popup that appears when you double-click a row in the OSS Table.
- Fix a bug that occurs when uploading the FOSSLight Report file from the SRC tab.
- When you click Check License, when ClearyDefined returns an error, try one more time. 
- Add exception handling in case of 5** error from ClearyDefined.
- In BAT, remove % from the Percentage Column and modify it so that it can be sorted numerically.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
