### PR TITLE
Fix the bug that Copyright is not displayed in OSS Notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.2.34 (01/01/1970)
+## Changes
+## 🔧 Maintenance
+
+- Update version to 1.2.33 @soimkim (#423)
+
+---
+
 ## v1.2.33 (11/03/2022)
 ## Changes
 ## 🔧 Maintenance
@@ -526,26 +534,3 @@
 
 - Delete "Need check" in the Obligation Type from the search box in the License List @Lee-JaeHyuk (#101)
 - Translate some korean comments to english @wkdalsgh192 (#60)
-
----
-
-## v1.2.4 (03/09/2021)
-## Changes
-## 🚀 Features
-
-- 3rd party / project status check func & oss sync func @FOSSLight-dev (#113)
-- Add Docker mailserver in docker-compose @epicarts (#112)
-- Add license information display when clicking the Restriction icon @riyenas0925 (#71)
-- Expose a save button for a creator, watcher, and admin @astrod (#88)
-
-## 🐛 Hotfixes
-
-- 3rd party/project status check function @FOSSLight-dev (#115)
-- 3rd party / project status check func & oss sync func @FOSSLight-dev (#113)
-
-## 🔧 Maintenance
-
-- Fix hide 'Check OSS Name' button from unrelated users @hyewoncc (#110)
-- Modify pop-up phrases that occur when you press the reopen button @suhwan-cheon (#97)
-- Rename 'Excel Download' Button to 'Export' @sw-develop (#104)
-- Drop button requires comment @soimkim (#105)

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -4263,7 +4263,7 @@ public class CommonFunction extends CoTopComponent {
 		
 		if(list != null) {
 			for(ProjectIdentification bean : list) {
-				if("-".equals(bean.getOssName()) && isEmpty(bean.getObligationType())) {
+				if("-".equals(bean.getOssName()) && isEmpty(bean.getObligationType()) && !checkIncludeUnconfirmedLicense(bean.getComponentLicenseList())) {
 					String obligationType = CommonFunction.getObligationTypeWithSelectedLicense(bean);
 					if(!isEmpty(obligationType)) {
 						bean.setObligationType(obligationType);

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -4263,12 +4263,33 @@ public class CommonFunction extends CoTopComponent {
 		
 		if(list != null) {
 			for(ProjectIdentification bean : list) {
-				if(unclearObligationList.contains(bean.getGridId())) {
+				if("-".equals(bean.getOssName()) && isEmpty(bean.getObligationType())) {
+					String obligationType = CommonFunction.getObligationTypeWithSelectedLicense(bean);
+					if(!isEmpty(obligationType)) {
+						bean.setObligationType(obligationType);
+						continue;
+					}
+				}
+				
+				// Check unconfirmed license, the actual message is (Declared : ~~), so check again registered license.
+				if(unclearObligationList.contains(bean.getGridId())
+						|| (!isEmpty(bean.getObligationType()) && checkIncludeUnconfirmedLicense(bean.getComponentLicenseList()))) {
 					bean.setObligationGrayFlag(CoConstDef.FLAG_YES);
 					bean.setObligationMsg(getMessage("msg.project.obligation.unclear"));
 				}
 			}
 		}
 		return list;
+	}
+
+	private static boolean checkIncludeUnconfirmedLicense(List<ProjectIdentification> licenseList) {
+		if(licenseList != null) {
+			for(ProjectIdentification bean : licenseList) {
+				if(!isEmpty(bean.getLicenseName()) && !CoCodeManager.LICENSE_INFO_UPPER.containsKey(bean.getLicenseName().toUpperCase())) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 }

--- a/src/main/java/oss/fosslight/repository/VerificationMapper.java
+++ b/src/main/java/oss/fosslight/repository/VerificationMapper.java
@@ -64,4 +64,6 @@ public interface VerificationMapper {
 							, @Param("refPrjId") String refPrjId, @Param("refFileSeq") String refFileSeq);
 	
 	int updatePackagingReuseMap(Project project);
+
+	OssComponents checkOssNickName2(OssComponents bean);
 }

--- a/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
@@ -1735,6 +1735,13 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		OssComponents ossComponent;
 		
 		for(OssComponents bean : ossComponentList) {
+			OssComponents oc = verificationMapper.checkOssNickName2(bean);
+			if(oc != null) {
+				if(isEmpty(bean.getCopyrightText())) {
+					bean.setCopyrightText(CoCodeManager.OSS_INFO_BY_ID.get(oc.getOssId()).getCopyright());
+				}
+			}
+			
 			String componentKey = (hideOssVersionFlag
 									? bean.getOssName() 
 									: bean.getOssName() + "|" + bean.getOssVersion()).toUpperCase();

--- a/src/main/java/oss/fosslight/util/FileUtil.java
+++ b/src/main/java/oss/fosslight/util/FileUtil.java
@@ -435,7 +435,7 @@ public class FileUtil {
 			}
 			
 			if(Files.exists(zipPath)) {
-				Files.move(zipPath, movePath.resolve(zipPath.getFileName() + "_" + CommonFunction.getCurrentDateTime()));
+				Files.move(zipPath, movePath.resolve(zipPath.getFileName() + "_" + CommonFunction.getCurrentDateTime("yyyyMMddHHmmss")));
 			}
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);

--- a/src/main/resources/oss/fosslight/repository/VerificationMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/VerificationMapper.xml
@@ -426,4 +426,13 @@
 		   AND T2.PACKAGING_FILE_ID != #{packageFileId3}
 		 </if>
 	</update>
+	
+	<select id="checkOssNickName2" parameterType="oss.fosslight.domain.OssComponents" resultType="oss.fosslight.domain.OssComponents">
+		SELECT T2.OSS_ID, T2.OSS_NAME, T1.OSS_NICKNAME 
+		FROM OSS_NICKNAME T1 
+		INNER JOIN OSS_MASTER T2 ON T1.OSS_NAME = T2.OSS_NAME AND T2.USE_YN = 'Y'
+		WHERE OSS_NICKNAME = #{ossName}
+		ORDER BY T2.OSS_ID DESC
+		LIMIT 1
+ 	</select>
 </mapper>


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
1. Fix the bug that Copyright is not displayed in OSS Notice.
    - Copyright text, Homepage cannot be loaded if identification is confirmed with nickname.
2. Update self-check unclear obligation message display condition.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
