### PR TITLE
Add a function to copy even the status when copying the project.

### DIFF
--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -3243,10 +3243,33 @@ public class ProjectController extends CoTopComponent {
 
 		project = projectService.getProjectDetail(project);
 		
-		String comemnt = "Copied from [PRJ-" + prjId + "] " + project.getPrjName();
+		String comemnt = "";
+		String identificationStatus = project.getIdentificationStatus();
+		String verificationStatus = project.getVerificationStatus();
 		
-		if (!isEmpty(project.getPrjVersion())) {
-			comemnt += "_" + project.getPrjVersion();
+		project.setPrjName(project.getPrjName() + "_Copied");
+		
+		if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(identificationStatus)) {
+			T2Users user = new T2Users();
+			user.setUserId(loginUserName());
+			
+			project.setIdentificationStatusConfFlag(CoConstDef.FLAG_YES);
+			project.setPrjVersion(avoidNull(project.getPrjVersion(), "").equals("") ? avoidNull(project.getPrjVersion()) : project.getPrjVersion() + "_Copied");
+			project.setPriority(CoConstDef.CD_PRIORITY_P2);
+			project.setReviewerName("");
+			project.setPrjUserName(userService.getUser(user).getUserName());
+			
+			comemnt = "Copy with confirm status from [PRJ-" + prjId + "] " + project.getPrjName();
+			
+			if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(verificationStatus)) {
+				project.setVerificationStatusConfFlag(CoConstDef.FLAG_YES);
+			}
+		}else {
+			comemnt = "Copied from [PRJ-" + prjId + "] " + project.getPrjName();
+			
+			if (!isEmpty(project.getPrjVersion())) {
+				comemnt += "_" + project.getPrjVersion();
+			}
 		}
 		
 		project.setComment(comemnt);

--- a/src/main/java/oss/fosslight/controller/VerificationController.java
+++ b/src/main/java/oss/fosslight/controller/VerificationController.java
@@ -422,7 +422,7 @@ public class VerificationController extends CoTopComponent {
 					project.setNeedPackageFileReset(CoConstDef.FLAG_YES);
 				}
 				
-				verificationService.updateStatusWithConfirm(project, ossNotice);
+				verificationService.updateStatusWithConfirm(project, ossNotice, false);
 				
 				try {
 					History h = new History();

--- a/src/main/java/oss/fosslight/domain/Project.java
+++ b/src/main/java/oss/fosslight/domain/Project.java
@@ -337,7 +337,11 @@ public class Project extends ComBean implements Serializable {
 	private String srcAndroidCsvFileFlag = "N";
 	
 	private String srcAndroidNoticeFileFlag = "N";
-
+	
+	private String identificationStatusConfFlag = "N";
+	
+	private String verificationStatusConfFlag = "N";
+	
 	public String getIgnoreUserCommentReg() {
 		return ignoreUserCommentReg;
 	}
@@ -4124,5 +4128,21 @@ public class Project extends ComBean implements Serializable {
 
 	public void setSrcAndroidNoticeFileFlag(String srcAndroidNoticeFileFlag) {
 		this.srcAndroidNoticeFileFlag = srcAndroidNoticeFileFlag;
+	}
+
+	public String getIdentificationStatusConfFlag() {
+		return identificationStatusConfFlag;
+	}
+
+	public void setIdentificationStatusConfFlag(String identificationStatusConfFlag) {
+		this.identificationStatusConfFlag = identificationStatusConfFlag;
+	}
+
+	public String getVerificationStatusConfFlag() {
+		return verificationStatusConfFlag;
+	}
+
+	public void setVerificationStatusConfFlag(String verificationStatusConfFlag) {
+		this.verificationStatusConfFlag = verificationStatusConfFlag;
 	}
 }

--- a/src/main/java/oss/fosslight/repository/ProjectMapper.java
+++ b/src/main/java/oss/fosslight/repository/ProjectMapper.java
@@ -334,4 +334,8 @@ public interface ProjectMapper {
 	List<Project> selectPartnerRefPrjList(PartnerMaster partner);
 	
 	void updateFileId2(Project project);
+
+	void updateCopyConfirmStatusProjectStatus(Project project);
+
+	void updateConfirmCopyVerificationDestributionStatus(Project project);
 }

--- a/src/main/java/oss/fosslight/service/VerificationService.java
+++ b/src/main/java/oss/fosslight/service/VerificationService.java
@@ -56,7 +56,7 @@ public interface VerificationService {
 	
 	OssNotice selectOssNoticeOne(String prjId);
 	
-	void updateStatusWithConfirm(Project project, OssNotice ossNotice) throws Exception;
+	void updateStatusWithConfirm(Project project, OssNotice ossNotice, boolean copyConfirmFlag) throws Exception;
 	
 	Map<String, Integer> setAddFileCount(Map<String, Integer> deCompResultMap, String url, int fileCnt) throws Exception;
 	
@@ -79,4 +79,6 @@ public interface VerificationService {
 	void setUploadFileSave(String prjId, String fileSeq, String registFileId) throws Exception;
 	
 	public void updateProjectAllowDownloadBitFlag(Project project);
+
+	void registOssNoticeConfirmStatus(OssNotice ossNotice);
 }

--- a/src/main/resources/messages/message_en_US.properties
+++ b/src/main/resources/messages/message_en_US.properties
@@ -123,6 +123,8 @@ msg.project.check.license.success=Successfully changed OSS License <br> into OSS
 msg.project.entered.first.tab=It moves to the tab you entered first.
 msg.project.notice.save=Notice file was not saved. Please click the \\'Save\\' button first.
 msg.project.obligation.unclear=Obligation is unclear
+msg.project.copy.confirm.status.fail.identification=The project was created with Identification Progress status due to error.
+msg.project.copy.confirm.status.fail.verification=The project was created with Packaging Progress status due to error.
 
 # Distribute
 msg.distribute.cancel=Distribution has been canceled.

--- a/src/main/resources/messages/message_ko_KR.properties
+++ b/src/main/resources/messages/message_ko_KR.properties
@@ -123,6 +123,8 @@ msg.project.check.license.success=선택한 라이선스로 변경되었습니�
 msg.project.entered.first.tab=이전 탭으로 이동합니다.
 msg.project.notice.save=Notice file이 저장되지 않았습니다. 먼저 \\'Save\\' 버튼을 클릭해주세요.
 msg.project.obligation.unclear=Obligation is unclear
+msg.project.copy.confirm.status.fail.identification=에러로 인해 Identification Progress 상태로 프로젝트 생성되었습니다.
+msg.project.copy.confirm.status.fail.verification=에러로 인해 Verification Progress 상태로 프로젝트 생성되었습니다.
 
 # Distribute
 msg.distribute.cancel = 배포가 취소되었습니다.

--- a/src/main/resources/messages/message_ko_KR.properties
+++ b/src/main/resources/messages/message_ko_KR.properties
@@ -124,7 +124,7 @@ msg.project.entered.first.tab=이전 탭으로 이동합니다.
 msg.project.notice.save=Notice file이 저장되지 않았습니다. 먼저 \\'Save\\' 버튼을 클릭해주세요.
 msg.project.obligation.unclear=Obligation is unclear
 msg.project.copy.confirm.status.fail.identification=에러로 인해 Identification Progress 상태로 프로젝트 생성되었습니다.
-msg.project.copy.confirm.status.fail.verification=에러로 인해 Verification Progress 상태로 프로젝트 생성되었습니다.
+msg.project.copy.confirm.status.fail.verification=에러로 인해 Packaging Progress 상태로 프로젝트 생성되었습니다.
 
 # Distribute
 msg.distribute.cancel = 배포가 취소되었습니다.

--- a/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
@@ -2080,6 +2080,9 @@
 			, REF_PARTNER_ID
 			, REPORT_FILE_ID
 			, PRE_OBLIGATION_TYPE
+			<if test="!@oss.fosslight.util.StringUtil@isEmpty(obligationType)">
+			, OBLIGATION_TYPE
+			</if>
 			, ADMIN_CHECK_YN
 			)
 			VALUES
@@ -2114,6 +2117,9 @@
 			, #{refPartnerId}
 			, #{reportFileId}
 			, #{preObligationType}
+			<if test="!@oss.fosslight.util.StringUtil@isEmpty(obligationType)">
+			, #{obligationType}
+			</if>
 			, #{adminCheckYn}
 			)
 	</insert>
@@ -4182,4 +4188,28 @@
 		 </if>
 		ORDER BY PM.MODIFIED_DATE DESC LIMIT 100
 	</select>
+	
+	<update id="updateCopyConfirmStatusProjectStatus" parameterType="oss.fosslight.domain.Project">
+		UPDATE
+			PROJECT_MASTER
+		SET
+		<if test="!@oss.fosslight.util.StringUtil@isEmpty(identificationStatus)">
+			IDENTIFICATION_STATUS = 'PROG'
+		</if>
+		<if test="!@oss.fosslight.util.StringUtil@isEmpty(verificationStatus)">
+			VERIFICATION_STATUS = 'PROG'
+		</if>	
+		WHERE
+			PRJ_ID = #{prjId}
+	</update>
+	
+	<update id="updateConfirmCopyVerificationDestributionStatus" parameterType="oss.fosslight.domain.Project">
+		UPDATE
+			PROJECT_MASTER
+		SET
+			VERIFICATION_STATUS = #{verificationStatus}
+			, DESTRIBUTION_STATUS = #{destributionStatus}
+		WHERE
+			PRJ_ID = #{prjId}
+	</update>
 </mapper>


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Add a function to copy even the status when copying the project.
- In the case of a project whose identification has been confirmed, it is possible to select the status to be copied.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
