### PR TITLE
disable server.servlet.session.cookie.http-only

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,7 @@ spring.mvc.view.suffix=.jsp
 spring.servlet.multipart.max-file-size=4000MB
 spring.servlet.multipart.max-request-size=4000MB
 server.servlet.session.timeout=10800s
+server.servlet.session.cookie.http-only=false
 
 server.tomcat.max-http-post-size=-1
 server.tomcat.max-swallow-size=-1


### PR DESCRIPTION

## Description

when you run `fosslight` behind https proxy like `nginx`
without this configuration session cookie can't be accessed in https
environment


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
