### PR TITLE
Fix the bug where the warning message is not displayed for the deactivated OSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.3.5 (29/04/2022)
+## Changes
+## 🐛 Hotfixes
+
+- Fix a bug on clicking the Rename button @FOSSLight-dev (#489)
+- Update OSS Table > Validation Downloadlocation @FOSSLight-dev (#488)
+
+---
+
 ## v1.3.4 (22/04/2022)
 ## 🚀 Features
 
@@ -521,28 +530,3 @@
 - Fix error where download location is not output when ossname is "-" @riyenas0925 (#186)
 - Change the SPDX Spreadsheet output method for OSS Name is - @riyenas0925 (#179)
 - Change the status column to icon in 3rd party list @epicarts (#154)
-
----
-
-## v1.2.10 (08/10/2021)
-## Changes
-## 🚀 Features
-
-- Updated bom compare & oss name merge @FOSSLight-dev (#178)
-- Delete spdx-tools jar file and add spdx tools java dependency @riyenas0925 (#148)
-
-## 🐛 Hotfixes
-
-- bug fix - Handling exceptions when creating a new project @FOSSLight-dev (#180)
-- Fix no items are printed in the "Per File Info" sheet @riyenas0925 (#173)
-- Updated bom compare & oss name merge @FOSSLight-dev (#178)
-- Update SPDX tool and fix typo @soimkim (#174)
-
-## 🔧 Maintenance
-
-- Update SPDX tool and fix typo @soimkim (#174)
-- Enable cursor pointer on the vulnerbility icon @epicarts (#157)
-- Fix the nickname input width size to double @epicarts (#155)
-- Change from RestTemplate to WebClient @riyenas0925 (#152)
-- Fix nickname typo in mail template @epicarts (#153)
-- Add template to docker environment @soimkim (#150)

--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -267,6 +267,10 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 
 			oss.setDownloadLocation(protocol + oss.getDownloadLocation() + downloadlocationUrlEndSplit + endUrl);
 			
+			protocol = "";
+			endUrl = "";
+			downloadlocationUrlEndSplit = "";
+			
 			// Search Priority 4. find by Clearly Defined And Github API
 			DependencyType dependencyType = DependencyType.downloadLocationToType(downloadLocation);
 

--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -167,6 +167,10 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			errors.add(e.getStatusText());
 		}
 
+		String protocol = "";
+		String endUrl = "";
+		String downloadlocationUrlEndSplit = "";
+		
 		for(ProjectIdentification oss : ossList) {
 			List<ProjectIdentification> prjOssLicenses;
 			String downloadLocation = oss.getDownloadLocation();
@@ -192,6 +196,40 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				continue;
 			}
 
+			if(oss.getDownloadLocation().contains("github.com")) {
+				if(oss.getDownloadLocation().startsWith("git@")){
+					protocol = "git@";
+					oss.setDownloadLocation(oss.getDownloadLocation().split("@")[1]);
+				}
+				
+				if(oss.getDownloadLocation().startsWith("http://") 
+						|| oss.getDownloadLocation().startsWith("https://")
+						|| oss.getDownloadLocation().startsWith("git://")
+						|| oss.getDownloadLocation().startsWith("ftp://")
+						|| oss.getDownloadLocation().startsWith("svn://")) {
+					if(isEmpty(protocol)) {
+						protocol = oss.getDownloadLocation().split("//")[0] + "//";
+						oss.setDownloadLocation(oss.getDownloadLocation().split("//")[1]);
+					}
+				}
+				
+				if(oss.getDownloadLocation().startsWith("www.")) {
+					protocol += oss.getDownloadLocation().substring(0, 4);
+					oss.setDownloadLocation(oss.getDownloadLocation().substring(5, oss.getDownloadLocation().length()));
+				}
+				
+				String[] downloadlocationUrlSplit = oss.getDownloadLocation().split("/");
+				if(downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
+					downloadlocationUrlEndSplit = oss.getDownloadLocation().substring(oss.getDownloadLocation().indexOf("#"), oss.getDownloadLocation().length());
+					oss.setDownloadLocation(oss.getDownloadLocation().substring(0, oss.getDownloadLocation().indexOf("#")));
+				}
+				
+				if(oss.getDownloadLocation().endsWith(".git")) {
+					endUrl = ".git";
+					oss.setDownloadLocation(oss.getDownloadLocation().substring(0, oss.getDownloadLocation().length()-4));
+				}
+			}
+			
 			// Search Priority 2. find by oss download location and version
 			prjOssLicenses = projectMapper.getOssFindByVersionAndDownloadLocation(oss);
 			checkedLicense = combineOssLicenses(prjOssLicenses, currentLicense);
@@ -202,6 +240,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				oss.setCheckLicense(checkedLicense);
 				oss.setCheckedEvidence(evidence);
 				oss.setCheckedEvidenceType("DB");
+				oss.setDownloadLocation(protocol + oss.getDownloadLocation() + downloadlocationUrlEndSplit + endUrl);
 				result.add(oss);
 				continue;
 			}
@@ -221,10 +260,13 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				oss.setCheckLicense(checkedLicense);
 				oss.setCheckedEvidence(evidence);
 				oss.setCheckedEvidenceType("DB");
+				oss.setDownloadLocation(protocol + oss.getDownloadLocation() + downloadlocationUrlEndSplit + endUrl);
 				result.add(oss);
 				continue;
 			}
 
+			oss.setDownloadLocation(protocol + oss.getDownloadLocation() + downloadlocationUrlEndSplit + endUrl);
+			
 			// Search Priority 4. find by Clearly Defined And Github API
 			DependencyType dependencyType = DependencyType.downloadLocationToType(downloadLocation);
 

--- a/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
@@ -1672,6 +1672,36 @@ public class T2CoProjectValidator extends T2CoValidator {
 							errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
 						}
 					}
+					
+					OssMaster ossBean = CoCodeManager.OSS_INFO_UPPER.get(checkKey);
+					if(ossBean != null) {
+						if(CoConstDef.FLAG_YES.equals(ossBean.getDeactivateFlag())){
+							if (CommonFunction.isAdmin()) {
+								errMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
+							} else {
+								diffMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
+							}
+						}
+					} else {
+						OssMaster om = null;
+						
+						for(String key : CoCodeManager.OSS_INFO_UPPER.keySet()) {
+							if(key.contains(bean.getOssName().toUpperCase())) {
+								om = CoCodeManager.OSS_INFO_UPPER.get(key);
+								break;
+							}
+						}
+						
+						if(om != null) {
+							if(CoConstDef.FLAG_YES.equals(om.getDeactivateFlag())){
+								if (CommonFunction.isAdmin()) {
+									errMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
+								} else {
+									diffMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
+								}
+							}
+						}
+					}
 				}
 
 				// 2) OSS VERSION

--- a/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
@@ -1050,10 +1050,15 @@
 				 , A.CVSS_SCORE
 				 , A.COPYRIGHT AS COPYRIGHT_TEXT
 		  FROM OSS_MASTER A
-		WHERE A.USE_YN = 'Y'
-			AND A.DEACTIVATE_FLAG = 'N'
-			AND A.OSS_VERSION = #{ossVersion}
-			AND A.DOWNLOAD_LOCATION = #{downloadLocation}
+		  LEFT JOIN OSS_DOWNLOADLOCATION DOWN
+	 	    ON A.OSS_ID = DOWN.OSS_ID
+		 WHERE A.USE_YN = 'Y'
+		   AND A.DEACTIVATE_FLAG = 'N'
+		   AND A.OSS_VERSION = #{ossVersion}
+		   AND (
+				A.DOWNLOAD_LOCATION LIKE CONCAT('%', #{downloadLocation}, '%') 
+				OR DOWN.DOWNLOAD_LOCATION LIKE CONCAT('%', #{downloadLocation}, '%')
+			   )
 	</select>
 
 	<select id="getOssFindByDownloadLocation" parameterType="string" resultType="oss.fosslight.domain.ProjectIdentification">
@@ -1067,10 +1072,14 @@
 				 , A.COPYRIGHT AS COPYRIGHT_TEXT
 				 , B.VERSION_DIFF_FLAG
 		  FROM OSS_MASTER A
-		  INNER JOIN OSS_MASTER_LICENSE_FLAG B ON A.OSS_ID = B.OSS_ID
+		 INNER JOIN OSS_MASTER_LICENSE_FLAG B ON A.OSS_ID = B.OSS_ID
+		  LEFT JOIN OSS_DOWNLOADLOCATION DOWN ON A.OSS_ID = DOWN.OSS_ID
 		WHERE A.USE_YN = 'Y'
 			AND A.DEACTIVATE_FLAG = 'N'
-			AND A.DOWNLOAD_LOCATION = #{downloadLocation}
+			AND (
+				A.DOWNLOAD_LOCATION LIKE CONCAT('%', #{downloadLocation}, '%') 
+				OR DOWN.DOWNLOAD_LOCATION LIKE CONCAT('%', #{downloadLocation}, '%')
+			   )
 	</select>
 
 	<select id="getLicenses" parameterType="string" resultType="oss.fosslight.domain.ProjectIdentification">


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Fix the bug where the warning message is not displayed for the deactivated OSS.
- Modify the Check OSS Name to read only before # in the github link.


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
