### PR TITLE
Fix the bug if the download location is null

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
@@ -124,13 +124,13 @@
 							if(index == 0){
 								$('.multiDownloadLocationSet span:first').remove();
 							}
-							if(downloadLocation!=''){
+							if(downloadLocation != '' && downloadLocation != null){
 								$(data.cloneDownloadLocation).appendTo('.multiDownloadLocationSet');
 								$('.multiDownloadLocationSet input[type=text]:last').val(downloadLocation);
 								$('.smallDelete').on('click', function(){
 									$(this).parent().remove();
 								});
-							}					
+							}
 						});
 						
 						break;


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Fix a bug where the download location is null when it is displayed as null in the OSS details tab.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
