### PR TITLE
Change Status Message for Row Registration Failed in OSS Bulk

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
@@ -41,12 +41,17 @@
 
     function checkLoaded(){
         $("#list").jqGrid('clearGridData');
-        for (var i=0; i < loadedInfo.length; i++){
-            for (var j = 0; j < jsonData.length; j++){
-                if (jsonData[j]['oss']['ossName'] === loadedInfo[i]['ossName']){
-                    jsonData[j]['status'] = 'Added';
+        for (var i=0; i < jsonData.length; i++){
+            var addedOSS = false;
+            for (var j = 0; j < loadedInfo.length; j++){
+                if (jsonData[i]['oss']['ossName'] === loadedInfo[j]['ossName']){
+                    jsonData[i]['status'] = 'Added';
+                    addedOSS = true;
                     break;
                 }
+            }
+            if (!addedOSS) {
+                jsonData[i]['status'] = 'Failed';
             }
         }
         stubColData();


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Change Status Message for Row Registration Failed in OSS Bulk.
- AS-IS: The status message for the row where OSS registration failed is not changed.
- TO-BE : Change the status of the row that has failed OSS registration to `Failed`.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
