### PR TITLE
Add a default comment to the Packaging confirm mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.3.6 (06/05/2022)
+## 🐛 Hotfixes
+
+- Fix the bug if the download location is null @soimkim (#500)
+- Fix the page not showing in OSS Bulk @soimkim (#498)
+- After deleting the uploaded file in Self-check, change the error that occurs when saving. @FOSSLight-dev  (#496)
+- Fix bug where suffix is added twice in version @soimkim (#494)
+
+## 🔧 Maintenance
+
+- Change Status Message for Row Registration Failed in OSS Bulk @soimkim (#503)
+- When copying OSS and Project, try setting the name and version. @soimkim (#492)
+- Fix the bug where the warning message is not displayed for the deactivated OSS @FOSSLight-dev (#490)
+
+---
+
 ## v1.3.5 (29/04/2022)
 ## Changes
 ## 🐛 Hotfixes
@@ -502,31 +518,3 @@
 - Moving hardcoded messages to US and KR properties @epicarts (#210)
 - Change PR merged action to only work for main @soimkim (#208)
 - Add contributors to README @soimkim (#202)
-
----
-
-## v1.2.11 (15/10/2021)
-## Changes
-## 🚀 Features
-
-- Changed - Recover Missing Messages @FOSSLight-dev (#198)
-- Supports Self-Check List OSS report as csv attachment @riyenas0925 (#190)
-- Supports BIN tab OSS report as csv attachment @riyenas0925 (#181)
-- Add send to everyone when sending comments @riyenas0925 (#176)
-- Add SPDX json and yaml types for pakaging notice download @hyewoncc (#177)
-- Supports SRC tab OSS report as csv attachment @riyenas0925 (#162)
-- Add a language change function using the dropdown for task 4 @suhwan-cheon (#151)
-
-## 🐛 Hotfixes
-
-- Changed - Recover Missing Messages @FOSSLight-dev (#198)
-- Change link format of vulnerability discovered mail (#168) @acafela (#175)
-- Restore message.properties @epicarts (#185)
-
-## 🔧 Maintenance
-
-- Translated from English to Korean in ko properties file @epicarts (#183)
-- Change Self-Check in Obligation Warning message @Lee-JaeHyuk (#192)
-- Fix error where download location is not output when ossname is "-" @riyenas0925 (#186)
-- Change the SPDX Spreadsheet output method for OSS Name is - @riyenas0925 (#179)
-- Change the status column to icon in 3rd party list @epicarts (#154)

--- a/src/main/java/oss/fosslight/controller/VerificationController.java
+++ b/src/main/java/oss/fosslight/controller/VerificationController.java
@@ -447,36 +447,32 @@ public class VerificationController extends CoTopComponent {
 				} catch (Exception e) {
 					log.error(e.getMessage(), e);
 				}
-								
-				if(prjInfo != null && !CoConstDef.FLAG_YES.equals(prjInfo.getAndroidFlag()) && !ignoreMailSend) {
+
+				if (prjInfo != null) {
 					try {
-						CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_CONF);
-						mailBean.setParamPrjId(ossNotice.getPrjId());
-						
-						if(!isEmpty(ossNotice.getUserComment())) {
-							mailBean.setComment(ossNotice.getUserComment());
+						String mailTemplateCode = CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_CONF;
+						String mailContentCode = CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_CONF;
+						if (ignoreMailSend) {
+							mailTemplateCode = CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_COMFIRMED_ONLY;
+							mailContentCode = mailTemplateCode;
+						} else if (CoConstDef.FLAG_YES.equals(prjInfo.getAndroidFlag())) {
+							mailTemplateCode = CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_COMFIRMED_ONLY;
 						}
-						
-						CoMailManager.getInstance().sendMail(mailBean);
-					} catch (Exception e) {
-						log.error(e.getMessage(), e);
-					}
-				} else if(prjInfo != null) {
-					// android 또는 distributin과 관련 없는 경우, packaging이 완료되었음만 공지한다.
-					try {
-						CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_COMFIRMED_ONLY);
+						CoMail mailBean = new CoMail(mailTemplateCode);
 						mailBean.setParamPrjId(ossNotice.getPrjId());
-						
-						if(!isEmpty(ossNotice.getUserComment())) {
-							mailBean.setComment(ossNotice.getUserComment());
+						String _tempComment = avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_DEFAULT_CONTENTS, mailContentCode));
+						userComment = avoidNull(userComment) + "<br />" + _tempComment;
+
+						if (!isEmpty(userComment)) {
+							mailBean.setComment(userComment);
 						}
-						
+
 						CoMailManager.getInstance().sendMail(mailBean);
 					} catch (Exception e) {
 						log.error(e.getMessage(), e);
 					}
 				}
-				
+
 				// package file 이 존재하는 경우 파일명을 변경한다.
 				verificationService.changePackageFileNameDistributeFormat(ossNotice.getPrjId());
 			} else { // preview 인 경우

--- a/src/main/java/oss/fosslight/domain/Statistics.java
+++ b/src/main/java/oss/fosslight/domain/Statistics.java
@@ -59,6 +59,7 @@ public class Statistics extends ComBean implements Serializable {
 	private String columnName;
 	private int columnCnt;
 	private int diffMonthCnt;
+	private int categorySize;
 	
 	/**
 	 * UPDATED OSS & License CHART

--- a/src/main/java/oss/fosslight/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/StatisticsServiceImpl.java
@@ -160,6 +160,7 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		statistics.setTitleArray(titleArray); // Chart Title
 		statistics.setDiffMonthCnt(DateUtil.getDiffMonth(statistics.getStartDate(), statistics.getEndDate()));
 		statistics.setNoneUser(statisticsMapper.getNoneUser());
+		statistics.setCategorySize(titleArray.size());
 		
 		statistics.setUpdateType("ADD");
 		List<Statistics> list = statisticsMapper.getUpdatedOssChartData(statistics);
@@ -246,6 +247,7 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		statistics.setTitleArray(titleArray); // Chart Title
 		statistics.setDiffMonthCnt(DateUtil.getDiffMonth(statistics.getStartDate(), statistics.getEndDate()));
 		statistics.setNoneUser(statisticsMapper.getNoneUser());
+		statistics.setCategorySize(titleArray.size());
 		
 		statistics.setUpdateType("ADD");
 		List<Statistics> list = statisticsMapper.getUpdatedLicenseChartData(statistics);
@@ -335,6 +337,7 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		}
 		
 		statistics.setTitleArray(titleArray); // Chart Title
+		statistics.setCategorySize(titleArray.size());
 		
 		List<Statistics> list = statisticsMapper.getTrdPartyRelatedChartData(statistics);
 		

--- a/src/main/resources/oss/fosslight/repository/BinaryDataHistoryMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/BinaryDataHistoryMapper.xml
@@ -7,8 +7,9 @@
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
     <sql id="orderby">
-		ORDER BY ${sidx} ${sord}
-<!--  	<choose>
+    <if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+		ORDER BY
+ 	 	<choose>
 			<when test="@oss.fosslight.util.StringUtil@equals('ACTION_ID', sidx)">
 				ACTION_ID
 			</when>
@@ -41,25 +42,25 @@
 			</when>
 			<when test="@oss.fosslight.util.StringUtil@equals('LICENSE', sidx)">
 				LICENSE
-			</when> -->
+			</when>
 			<!--TODO : Change it to snake_case-->
-<!-- 		<when test="@oss.fosslight.util.StringUtil@equals('PARENTNAME', sidx)">
+ 			<when test="@oss.fosslight.util.StringUtil@equals('PARENTNAME', sidx)">
 				PARENT_NAME
-			</when> -->
+			</when>
 			<!--TODO : Change it to snake_case-->
-<!--		<when test="@oss.fosslight.util.StringUtil@equals('PLATFORMNAME', sidx)">
+			<when test="@oss.fosslight.util.StringUtil@equals('PLATFORMNAME', sidx)">
 				PLATFORM_NAME
-			</when> -->
+			</when>
 			<!--TODO : Change it to snake_case-->
-<!--			<when test="@oss.fosslight.util.StringUtil@equals('PLATFORMVERSION', sidx)">
+			<when test="@oss.fosslight.util.StringUtil@equals('PLATFORMVERSION', sidx)">
 				PLATFORM_VERSION
-			</when> -->
+			</when>
 			<!--TODO : Change it to snake_case-->
-<!--			<when test="@oss.fosslight.util.StringUtil@equals('UPDATEDATE', sidx)">
+			<when test="@oss.fosslight.util.StringUtil@equals('UPDATEDATE', sidx)">
 				UPDATE_DATE
-			</when> -->
+			</when>
 			<!--TODO : Change it to snake_case-->
-<!--		<when test="@oss.fosslight.util.StringUtil@equals('CREATED_DATE', sidx)">
+			<when test="@oss.fosslight.util.StringUtil@equals('CREATED_DATE', sidx)">
 				CREATED_DATE
 			</when>
 			<when test="@oss.fosslight.util.StringUtil@equals('MODIFIER', sidx)">
@@ -69,112 +70,113 @@
 				COMMENT
 			</when>
 		</choose>
-		<choose>
-			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
-				ASC
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
-				DESC
-			</when>
-		</choose> -->
+		<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+			<choose>
+				<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+					ASC
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+					DESC
+				</when>
+			</choose>
+		</if>
+	</if>
     </sql>
     
 	<sql id="filters">
-		<foreach collection="filtersMap.rules" item="item">
-			AND
+		AND
+		<foreach collection="filtersMap.rules" item="item" separator="AND">
 			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('actionId', item.field)">
+				<when test='item.field == "actionId"'>
 					ACTION_ID
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('actionType', item.field)">
+				<when test='item.field == "actionType"'>
 					ACTION_TYPE
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('binaryName', item.field)">
+				<when test='item.field == "binaryName"'>
 					FILE_NAME
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('filePath', item.field)">
+				<when test='item.field == "filePath"'>
 					PATH_NAME
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('sourcePath', item.field)">
+				<when test='item.field == "sourcePath"'>
 					SOURCE_PATH
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('checkSum', item.field)">
+				<when test='item.field == "checkSum"'>
 					CHECK_SUM
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('tlsh', item.field)">
+				<when test='item.field == "tlsh"'>
 					TLSH_CHECK_SUM
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ossName', item.field)">
+				<when test='item.field == "ossName"'>
 					OSS_NAME
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ossVersion', item.field)">
+				<when test='item.field == "ossVersion"'>
 					OSS_VERSION
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('license', item.field)">
+				<when test='item.field == "license"'>
 					LICENSE
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('parentname', item.field)">
+				<when test='item.field == "parentname"'>
 					PARENT_NAME
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('platformname', item.field)">
+				<when test='item.field == "platformname"'>
 					PLATFORM_NAME
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('platformversion', item.field)">
+				<when test='item.field == "platformversion"'>
 					PLATFORM_VERSION
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('updatedate', item.field)">
-					UPDATE_DATE
+				<when test='item.field == "updatedate"'>
+					DATE_FORMAT(UPDATE_DATE, '%Y%m%d')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('createdDate', item.field)">
-					CREATED_DATE
+				<when test='item.field == "createdDate"'>
+					DATE_FORMAT(CREATED_DATE, '%Y%m%d')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('modifier', item.field)">
+				<when test='item.field == "modifier"'>
 					MODIFIER
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('comment', item.field)">
+				<when test='item.field == "comment"'>
 					COMMENT
 				</when>
 			</choose>
 			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('eq', item.op)">
+				<when test='item.op == "eq"'>
 					= #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ne', item.op)">
+				<when test='item.op == "ne"'>
 					<![CDATA[<>]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bw', item.op)">
+				<when test='item.op == "bw"'>
 					LIKE CONCAT(#{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bn', item.op)">
+				<when test='item.op == "bn"'>
 					NOT LIKE CONCAT(#{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ew', item.op)">
+				<when test='item.op == "ew"'>
 					LIKE CONCAT('%', #{item.data})
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('en', item.op)">
+				<when test='item.op == "en"'>
 					NOT LIKE CONCAT('%', #{item.data})
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cn', item.op)">
+				<when test='item.op == "cn"'>
 					LIKE CONCAT('%', #{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('nc', item.op)">
+				<when test='item.op == "nc"'>
 					NOT LIKE CONCAT('%', #{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('lt', item.op)">
+				<when test='item.op == "lt"'>
 					<![CDATA[<]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('le', item.op)">
+				<when test='item.op == "le"'>
 					<![CDATA[<=]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('gt', item.op)">
+				<when test='item.op == "gt"'>
 					<![CDATA[>]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ge', item.op)">
+				<when test='item.op == "ge"'>
 					<![CDATA[>=]]> #{item.data}
 				</when>
-				<otherwise>
-
-				</otherwise>
+				<otherwise></otherwise>
 			</choose>
 		</foreach>
     </sql>
@@ -219,7 +221,7 @@
     		AND LICENSE LIKE CONCAT('%', #{license}, '%')
     	</if>
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if>
     </select>
 	<select id="selectBinaryDataHistoryList" parameterType="oss.fosslight.domain.BinaryAnalysisResult" resultType="oss.fosslight.domain.BinaryAnalysisResult">
@@ -277,7 +279,7 @@
     		AND LICENSE LIKE CONCAT('%', #{license}, '%')
     	</if>
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if>
 		<include refid="orderby"/>
 		<include refid="limitPage"/>

--- a/src/main/resources/oss/fosslight/repository/CodeMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/CodeMapper.xml
@@ -9,28 +9,32 @@
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
     <sql id="orderby">
-		ORDER BY ${sidx} ${sord}
-<!--   	<choose> -->
-			<!--TODO : CD_NO will be convert into CAST(CD_NO AS SIGNED) in the getter.
-			But It should be done in this file. Like equals('CD_NO', sidx)-->
-<!--		<when test="@oss.fosslight.util.StringUtil@equals('CAST(CD_NO AS SIGNED)',sidx)">
-				CAST(CD_NO AS SIGNED)
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('CD_NM',sidx)">
-				CD_NM
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('CD_EXP',sidx)">
-				CD_EXP
-			</when>
-		</choose>
-		<choose>
-			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
-				ASC
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
-				DESC
-			</when>
-		</choose> -->
+    	<if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+    		ORDER BY
+   			<choose>
+				<!--TODO : CD_NO will be convert into CAST(CD_NO AS SIGNED) in the getter.
+				But It should be done in this file. Like equals('CD_NO', sidx)-->
+				<when test="@oss.fosslight.util.StringUtil@equals('CAST(CD_NO AS SIGNED)', sidx)">
+					CAST(CD_NO AS SIGNED)
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('CD_NM', sidx)">
+					CD_NM
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('CD_EXP', sidx)">
+					CD_EXP
+				</when>
+			</choose>
+			<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+				<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+						ASC
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+						DESC
+					</when>
+				</choose>
+			</if>
+    	</if>
     </sql>
     
     <select id="selectCodeTotalCount" parameterType="oss.fosslight.domain.T2Code" resultType="int">

--- a/src/main/resources/oss/fosslight/repository/DashboardMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/DashboardMapper.xml
@@ -445,7 +445,6 @@
         <choose>
             <when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY T1.MODIFIED_DATE DESC</when>
 			<!--jQGrid uses "loadonce" option. So below line will have never been used.-->
-            <otherwise>ORDER BY ${sidx} ${sord}</otherwise>
         </choose>
     </select>
    
@@ -495,7 +494,6 @@
 	    <choose>
             <when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY T1.MODIFIED_DATE DESC</when>
 			<!--jQGrid uses "loadonce" option. So below line will have never been used.-->
-            <otherwise>ORDER BY ${sidx} ${sord}</otherwise>
         </choose>
     </select>
    

--- a/src/main/resources/oss/fosslight/repository/HistoryMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/HistoryMapper.xml
@@ -87,32 +87,39 @@
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(endDate)">
 			AND MODIFIED_DATE <![CDATA[<=]]> #{endDate}
 		</if>
-		<bind name="field" value="@oss.fosslight.util.StringUtil@convertToUnderScore(sortField)"/>
-		ORDER BY ${field} ${sortOrder}
-<!-- 	<if test="sortField eq 'idx'">
-			ORDER BY IDX
+		<if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+			ORDER BY
+			<choose>
+				<when test="@oss.fosslight.util.StringUtil@equals('IDX', sidx)">
+					IDX
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('H_TITLE', sidx)">
+					H_TITLE
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('H_TYPE_NM', sidx)">
+					H_TYPE_NM
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('H_ACTION', sidx)">
+					H_ACTION
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('MODIFIER', sidx)">
+					MODIFIER
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('MODIFIED_DATE', sidx)">
+					MODIFIED_DATE
+				</when>
+			</choose>
+			<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+				<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+						ASC
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+						DESC
+					</when>
+				</choose>
+			</if>
 		</if>
-		<if test="sortField eq 'hTitle'">
-			ORDER BY H_TITLE
-		</if>
-		<if test="sortField eq 'hTypeNm'">
-			ORDER BY H_TYPE_NM
-		</if>
-		<if test="sortField eq 'hAction'">
-			ORDER BY H_ACTION
-		</if>
-		<if test="sortField eq 'modifier'">
-			ORDER BY MODIFIER
-		</if>
-		<if test="sortField eq 'modifiedDate'">
-			ORDER BY MODIFIED_DATE
-		</if>
-		<if test="sortOrder eq 'asc'">
-			ASC
-		</if>
-		<if test="sortOrder eq 'desc'">
-			DESC
-		</if> -->
 		<include refid="limitPage"/>
 	</select>
 	

--- a/src/main/resources/oss/fosslight/repository/NoticeMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/NoticeMapper.xml
@@ -9,35 +9,39 @@
 	</sql>
 	
     <sql id="orderby">
-        ORDER BY ${sidx} ${sord}
-<!-- 	<choose>
-			<when test="@oss.fosslight.util.StringUtil@equals('SEQ',sidx)">
-				SEQ
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('TITLE',sidx)">
-				TITLE
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('REPLACE_NOTICE',sidx)">
-				NOTICE
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('S_DATE',sidx)">
-				S_DATE
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('E_DATE',sidx)">
-				E_DATE
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('PUBLISH_YN',sidx)">
-				PUBLISH_YN
-			</when>
-		</choose>
-		<choose>
-			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
-				ASC
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
-				DESC
-			</when>
-		</choose> -->
+        <if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+        	ORDER BY
+        	<choose>
+				<when test="@oss.fosslight.util.StringUtil@equals('SEQ', sidx)">
+					SEQ
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('TITLE', sidx)">
+					TITLE
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('REPLACE_NOTICE', sidx)">
+					NOTICE
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('S_DATE', sidx)">
+					S_DATE
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('E_DATE', sidx)">
+					E_DATE
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('PUBLISH_YN', sidx)">
+					PUBLISH_YN
+				</when>
+			</choose>
+			<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+				<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+						ASC
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+						DESC
+					</when>
+				</choose>
+			</if>
+        </if>
     </sql>
 	
 	<select id="selectNoticeTotalCount" parameterType="oss.fosslight.domain.Notice" resultType="int">

--- a/src/main/resources/oss/fosslight/repository/OssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/OssMapper.xml
@@ -15,64 +15,65 @@
     	</if>
     	<choose>
     		<when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)"> OSS_ID desc</when>
-    		<otherwise> ${sidx} ${sord}</otherwise>
-<!--   		<otherwise>
+   			<otherwise>
 				<choose>
-					<when test="@oss.fosslight.util.StringUtil@equals('OSS_ID',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('OSS_ID', sidx)">
 						OSS_ID
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('OSS_TYPE',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('OSS_TYPE', sidx)">
 						OSS_TYPE
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('OSS_NAME',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('OSS_NAME', sidx)">
 						OSS_NAME
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('OSS_VERSION',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('OSS_VERSION', sidx)">
 						OSS_VERSION
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('LICENSE_NAME',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('LICENSE_NAME', sidx)">
 						LICENSE_NAME
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('LICENSE_TYPE',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('LICENSE_TYPE', sidx)">
 						LICENSE_TYPE
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('OBLIGATION',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('OBLIGATION', sidx)">
 						OBLIGATION
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('DOWNLOAD_LOCATION',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('DOWNLOAD_LOCATION', sidx)">
 						DOWNLOAD_LOCATION
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('HOMEPAGE',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('HOMEPAGE', sidx)">
 						HOMEPAGE
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('SUMMARY_DESCRIPTION',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('SUMMARY_DESCRIPTION', sidx)">
 						SUMMARY_DESCRIPTION
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE', sidx)">
 						CVSS_SCORE
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('CREATOR',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('CREATOR', sidx)">
 						CREATOR
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('CREATED_DATE',sidx)">
-						CREATED_DATE
+					<when test="@oss.fosslight.util.StringUtil@equals('CREATED_DATE', sidx)">
+						DATE_FORMAT(T1.CREATED_DATE, '%Y%m%d')
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('MODIFIER',sidx)">
+					<when test="@oss.fosslight.util.StringUtil@equals('MODIFIER', sidx)">
 						MODIFIER
 					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('MODIFIED_DATE',sidx)">
-						MODIFIED_DATE
+					<when test="@oss.fosslight.util.StringUtil@equals('MODIFIED_DATE', sidx)">
+						DATE_FORMAT(T1.MODIFIED_DATE, '%Y%m%d')
 					</when>
 				</choose>
-				<choose>
-					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
-						ASC
-					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
-						DESC
-					</when>
-				</choose>
-			</otherwise> -->
+				<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+					<choose>
+						<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+							ASC
+						</when>
+						<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+							DESC
+						</when>
+					</choose>
+				</if>
+			</otherwise>
     	</choose>
     </sql>
     

--- a/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
@@ -9,149 +9,108 @@
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
     <sql id="orderby">
-    	<choose>
-    		<when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY PRJ_ID desc</when>
-    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('PRJ_NAME', sidx) and  @oss.fosslight.util.StringUtil@equals('asc', sord)">
-    			ORDER BY (
-    			  CASE 
-    				WHEN ${sidx} REGEXP '^[a-zA-Z].+$' then 1 
-					WHEN ${sidx} REGEXP '^[가-힣].+$' then 2 
-					WHEN ${sidx} REGEXP '^[0-9].+$' then 3 
-					ELSE 4 
-			      END), ${sidx} ${sord}
-    		</when>
-			<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('PRJ_NAME', sidx) and  @oss.fosslight.util.StringUtil@equals('desc', sord)">
-    			ORDER BY (
-    			  CASE 
-    				WHEN ${sidx} REGEXP '^[a-zA-Z].+$' then 4 
-					WHEN ${sidx} REGEXP '^[가-힣].+$' then 3 
-					WHEN ${sidx} REGEXP '^[0-9].+$' then 2 
-					ELSE 1 
-			      END), ${sidx} ${sord}
-    		</when>
-    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('IDENTIFICATION_STATUS', sidx)">
-    			ORDER BY (
-    				CASE ${sidx}
-    					WHEN '' THEN 1
-	    				WHEN 'NA' THEN 2
-	    				WHEN 'PROG' THEN 3
-	    				WHEN 'REQ' THEN 4
-	    				WHEN 'REV' THEN 5
-	    				WHEN 'CONF' THEN 6
-	    			END
-    			) ${sord}
-    		</when>
-    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('VERIFICATION_STATUS', sidx)">
-    			ORDER BY (
-    				CASE 
-    					WHEN IDENTIFICATION_STATUS != 'CONF' THEN 1
-    					WHEN ${sidx} = '' AND IDENTIFICATION_STATUS = 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
-    					WHEN ${sidx} = '' AND A.COMPLETE_YN = 'Y' THEN 3
-    					WHEN ${sidx} = 'NA' THEN 4
-	    				WHEN ${sidx} = 'PROG' THEN 5
-	    				WHEN ${sidx} = 'REQ' THEN 6
-	    				WHEN ${sidx} = 'REV' THEN 7
-	    				WHEN ${sidx} = 'CONF' THEN 8
-	    			END
-    			) ${sord}
-    		</when>
-    		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('DESTRIBUTION_STATUS', sidx)">
-    			ORDER BY (
-    				CASE
-						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'ERROR' THEN 7
-						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'DONE' THEN 6
-						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'RSV' THEN 5
-						WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'PROG' THEN 4
-						WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'NA' AND ${sidx} = 'NA') OR (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DISTRIBUTE_TARGET = 'NA' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
-						WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND ${sidx} = 'NA')  OR (VERIFICATION_STATUS != '' AND VERIFICATION_STATUS != 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') OR (${sidx} = '' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
-						WHEN VERIFICATION_STATUS = 'CONF' AND IDENTIFICATION_STATUS = 'CONF' AND ${sidx} = '' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
-						ELSE 1
-					END
-    			) ${sord}
-    		</when>
-    		<when test="@oss.fosslight.util.StringUtil@equals('DIVISION', sidx)">
-    			ORDER BY (SELECT CD.CD_DTL_NM FROM T2_CODE_DTL CD WHERE CD.CD_NO = '200' AND CD.CD_DTL_NO =  DIVISION) ${sord}
-    		</when>
-    		<when test="@oss.fosslight.util.StringUtil@equals('REVIEWER', sidx)">
-    			ORDER BY (SELECT u.USER_NAME FROM T2_USERS u WHERE REVIEWER = u.USER_ID) ${sord}
-    		</when>
-    		<otherwise>ORDER BY ${sidx} ${sord}</otherwise>
-    	</choose>
+    	<if test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY PRJ_ID desc</if>
+    	<if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and !@oss.fosslight.util.StringUtil@isEmpty(sord)">
+    		<choose>
+	    		<when test="@oss.fosslight.util.StringUtil@equals('PRJ_ID', sidx)">
+   	 				ORDER BY PRJ_ID
+   	 			</when>
+   	 			<when test="@oss.fosslight.util.StringUtil@equals('STATUS', sidx)">
+   	 				ORDER BY STATUS
+   	 			</when>
+   	 			<when test="@oss.fosslight.util.StringUtil@equals('PRJ_NAME', sidx) and @oss.fosslight.util.StringUtil@equals('asc', sord)">
+    				ORDER BY (
+    				  CASE 
+    					WHEN PRJ_NAME REGEXP '^[a-zA-Z].+$' then 1 
+						WHEN PRJ_NAME REGEXP '^[가-힣].+$' then 2 
+						WHEN PRJ_NAME REGEXP '^[0-9].+$' then 3 
+						ELSE 4 
+				      END), PRJ_NAME
+    			</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('PRJ_NAME', sidx) and @oss.fosslight.util.StringUtil@equals('desc', sord)">
+    				ORDER BY (
+    				  CASE 
+    					WHEN PRJ_NAME REGEXP '^[a-zA-Z].+$' then 4 
+						WHEN PRJ_NAME REGEXP '^[가-힣].+$' then 3 
+						WHEN PRJ_NAME REGEXP '^[0-9].+$' then 2 
+						ELSE 1 
+				      END), PRJ_NAME
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('IDENTIFICATION_STATUS', sidx)">
+    				ORDER BY (
+    					CASE IDENTIFICATION_STATUS
+    						WHEN '' THEN 1
+	    					WHEN 'NA' THEN 2
+	    					WHEN 'PROG' THEN 3
+	    					WHEN 'REQ' THEN 4
+	    					WHEN 'REV' THEN 5
+	    					WHEN 'CONF' THEN 6
+	    				END
+    				)
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('VERIFICATION_STATUS', sidx)">
+    				ORDER BY (
+    					CASE 
+    						WHEN IDENTIFICATION_STATUS != 'CONF' THEN 1
+    						WHEN VERIFICATION_STATUS = '' AND IDENTIFICATION_STATUS = 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
+    						WHEN VERIFICATION_STATUS = '' AND A.COMPLETE_YN = 'Y' THEN 3
+    						WHEN VERIFICATION_STATUS = 'NA' THEN 4
+	    					WHEN VERIFICATION_STATUS = 'PROG' THEN 5
+	    					WHEN VERIFICATION_STATUS = 'REQ' THEN 6
+	    					WHEN VERIFICATION_STATUS = 'REV' THEN 7
+	    						WHEN VERIFICATION_STATUS = 'CONF' THEN 8
+	    				END
+    				)
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('DESTRIBUTION_STATUS', sidx)">
+    				ORDER BY (
+    					CASE
+							WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'ERROR' THEN 7
+							WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'DONE' THEN 6
+							WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'RSV' THEN 5
+							WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'PROG' THEN 4
+							WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'NA' AND DESTRIBUTION_STATUS = 'NA') OR (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DISTRIBUTE_TARGET = 'NA' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
+							WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DESTRIBUTION_STATUS = 'NA')  OR (VERIFICATION_STATUS != '' AND VERIFICATION_STATUS != 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') OR (DESTRIBUTION_STATUS = '' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
+							WHEN VERIFICATION_STATUS = 'CONF' AND IDENTIFICATION_STATUS = 'CONF' AND DESTRIBUTION_STATUS = '' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
+							ELSE 1
+						END
+    				) 
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('DISTRIBUTION_TYPE', sidx)">
+    				ORDER BY (SELECT CD.CD_DTL_NM FROM T2_CODE_DTL CD WHERE CD.CD_NO = '207' AND CD.CD_DTL_NO =  DISTRIBUTION_TYPE)
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('DIVISION', sidx)">
+    				ORDER BY (SELECT CD.CD_DTL_NM FROM T2_CODE_DTL CD WHERE CD.CD_NO = '200' AND CD.CD_DTL_NO =  DIVISION)
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('CREATOR', sidx)">
+    				ORDER BY CREATOR
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('CREATED_DATE', sidx)">
+    				ORDER BY DATE_FORMAT(CREATED_DATE, '%Y%m%d')
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('MODIFIED_DATE', sidx)">
+    				ORDER BY DATE_FORMAT(MODIFIED_DATE, '%Y%m%d')
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('REVIEWER', sidx)">
+    				ORDER BY (SELECT USER_NAME FROM T2_USERS WHERE USER_ID = REVIEWER) IS NULL ASC, (SELECT USER_NAME FROM T2_USERS WHERE USER_ID = REVIEWER)
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('COMMENT', sidx)">
+    				ORDER BY COMMENT
+    			</when>
+    		</choose>
+    		<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+    			<choose>
+  	  				<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+    					ASC
+    				</when>
+    				<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+    					DESC
+    				</when>
+    			</choose>
+    		</if>
+    	</if>
     </sql>
-
-	<sql id="filters">
-		<foreach collection="filtersMap.rules" item="item">
-			AND
-			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('ossId', item.field)">
-					OSS_ID
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ossName', item.field)">
-					OSS_NAME
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ossVersion', item.field)">
-					OSS_VERSION
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cveId', item.field)">
-					CVE_ID
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cvssScore', item.field)">
-					CVSS_SCORE
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cveIdTo', item.field)">
-					CVE_ID_TO
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cvssScoreTo', item.field)">
-					CVSS_SCORE_TO
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('regDt', item.field)">
-					DATE_FORMAT(REG_DT, '%Y-%m-%d')
-				</when>
-			</choose>
-			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('eq', item.op)">
-					= #{item.data}
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ne', item.op)">
-					<![CDATA[<>]]> #{item.data}
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bw', item.op)">
-					LIKE CONCAT(#{item.data}, '%')
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bn', item.op)">
-					NOT LIKE CONCAT(#{item.data}, '%')
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ew', item.op)">
-					LIKE CONCAT('%', #{item.data})
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('en', item.op)">
-					NOT LIKE CONCAT('%', #{item.data})
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cn', item.op)">
-					LIKE CONCAT('%', #{item.data}, '%')
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('nc', item.op)">
-					NOT LIKE CONCAT('%', #{item.data}, '%')
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('lt', item.op)">
-					<![CDATA[<]]> #{item.data}
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('le', item.op)">
-					<![CDATA[<=]]> #{item.data}
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('gt', item.op)">
-					<![CDATA[>]]> #{item.data}
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ge', item.op)">
-					<![CDATA[>=]]> #{item.data}
-				</when>
-				<otherwise>
-
-				</otherwise>
-			</choose>
-		</foreach>
-    </sql>
-    	
+	
 	<select id="selectProjectTotalCount" parameterType="oss.fosslight.domain.Project" resultType="int">
 		/* ProjectMapper.selectProjectTotalCount */
 		SELECT COUNT(*) FROM (
@@ -1662,10 +1621,6 @@
 		) RTN
 		
 		WHERE 1=1
-		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
-		</if>
-		
 		GROUP BY GROUPBY
 		
 		<if test="@oss.fosslight.util.StringUtil@equals('componentId', sortField)">
@@ -3853,21 +3808,53 @@
 			</choose>
 	 <choose>
    		<when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY MODEL_NAME ASC, PRJ_ID DESC</when>
-   		<when test="!@oss.fosslight.util.StringUtil@isEmpty(sidx) and @oss.fosslight.util.StringUtil@equals('DESTRIBUTION_STATUS', sidx)">
-   			ORDER BY (
-   				CASE
-					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'ERROR' THEN 7
-					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'DONE' THEN 6
-					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'RSV' THEN 5
-					WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND ${sidx} = 'PROG' THEN 4
-					WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'NA' AND ${sidx} = 'NA') OR (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DISTRIBUTE_TARGET = 'NA' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
-					WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND ${sidx} = 'NA')  OR (VERIFICATION_STATUS != '' AND VERIFICATION_STATUS != 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') OR (${sidx} = '' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
-					WHEN VERIFICATION_STATUS = 'CONF' AND IDENTIFICATION_STATUS = 'CONF' AND ${sidx} = '' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
-					ELSE 1
-				END
-   			) ${sord}
-   		</when>
-		<otherwise>ORDER BY ${sidx} ${sord}</otherwise>
+   		<otherwise>
+   		<if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+   			ORDER BY
+   			<choose>
+   				<when test="@oss.fosslight.util.StringUtil@equals('MODEL_NAME', sidx)">
+   					MODEL_NAME
+   				</when>
+   				<when test="@oss.fosslight.util.StringUtil@equals('STATUS', sidx)">
+   					STATUS
+   				</when>
+   				<when test="@oss.fosslight.util.StringUtil@equals('PRJ_ID', sidx)">
+   					PRJ_ID
+   				</when>
+   				<when test="@oss.fosslight.util.StringUtil@equals('DISTRIBUTION_TYPE', sidx)">
+   					(SELECT CD.CD_DTL_NM FROM T2_CODE_DTL CD WHERE CD.CD_NO = '207' AND CD.CD_DTL_NO =  DISTRIBUTION_TYPE)
+   				</when>
+   				<when test="@oss.fosslight.util.StringUtil@equals('DESTRIBUTION_STATUS', sidx)">
+   					(
+   						CASE
+							WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'ERROR' THEN 7
+							WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'DONE' THEN 6
+							WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'RSV' THEN 5
+							WHEN IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND IFNULL(DISTRIBUTE_TARGET, 'NA') != 'NA' AND DESTRIBUTION_STATUS = 'PROG' THEN 4
+							WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'NA' AND DESTRIBUTION_STATUS = 'NA') OR (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DISTRIBUTE_TARGET = 'NA' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
+							WHEN (IDENTIFICATION_STATUS = 'CONF' AND VERIFICATION_STATUS = 'CONF' AND DESTRIBUTION_STATUS = 'NA')  OR (VERIFICATION_STATUS != '' AND VERIFICATION_STATUS != 'CONF' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') OR (DESTRIBUTION_STATUS = '' AND IFNULL(A.COMPLETE_YN, 'N') = 'Y') THEN 3
+							WHEN VERIFICATION_STATUS = 'CONF' AND IDENTIFICATION_STATUS = 'CONF' AND DESTRIBUTION_STATUS = '' AND IFNULL(A.COMPLETE_YN, 'N') != 'Y' THEN 2
+							ELSE 1
+						END
+   					)
+   				</when>
+   				<when test="@oss.fosslight.util.StringUtil@equals('DISTRIBUTE_DEPLOY_TIME', sidx)">
+   					DATE_FORMAT(DISTRIBUTE_DEPLOY_TIME, '%Y%m%d')
+   				</when>
+				<otherwise></otherwise>
+   			</choose>
+   			<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+   				<choose>
+   					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+    					ASC
+    				</when>
+    				<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+    					DESC
+    				</when>
+   				</choose>
+   			</if>
+   		</if>
+   		</otherwise>
    	</choose>
 	<include refid="limitPage"/>
 	</select>

--- a/src/main/resources/oss/fosslight/repository/SelfCheckMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/SelfCheckMapper.xml
@@ -9,19 +9,49 @@
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
     <sql id="orderby">
-    	<choose>
-    		<when test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">ORDER BY PRJ_ID desc</when>
-    		<when test="@oss.fosslight.util.StringUtil@equals('OS_TYPE_ETC', sidx)">
-    		ORDER BY CASE WHEN OS_TYPE = '999' THEN OS_TYPE_ETC ELSE (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '213' AND SORTCD.CD_DTL_NO = OS_TYPE) END ${sord}
-    		</when>
-    		<when test="@oss.fosslight.util.StringUtil@equals('DESTRIBUTION_NAME', sidx)">
-    		ORDER BY (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '207' AND SORTCD.CD_DTL_NO = DISTRIBUTION_TYPE) ${sord}
-    		</when>
-    		<when test="@oss.fosslight.util.StringUtil@equals('DIVISION', sidx)">
-    		ORDER BY (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '200' AND SORTCD.CD_DTL_NO = DIVISION) ${sord}
-    		</when>
-    		<otherwise>ORDER BY ${sidx} ${sord}</otherwise>
-    	</choose>
+    	<if test="@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+    		ORDER BY PRJ_ID DESC
+    	</if>
+    	<if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+    		ORDER BY
+    		<choose>
+    			<when test="@oss.fosslight.util.StringUtil@equals('PRJ_ID', sidx)">
+    				PRJ_ID
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('PRJ_NAME', sidx)">
+    				PRJ_NAME
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('DESTRIBUTION_NAME', sidx)">
+    				(SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '207' AND SORTCD.CD_DTL_NO = DISTRIBUTION_TYPE)
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE', sidx)">
+    				CVSS_SCORE
+    			</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('DIVISION', sidx)">
+    				(SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '200' AND SORTCD.CD_DTL_NO = DIVISION)
+	    		</when>
+	    		<when test="@oss.fosslight.util.StringUtil@equals('CREATOR', sidx)">
+    				CREATOR
+	    		</when>
+    			<when test="@oss.fosslight.util.StringUtil@equals('CREATED_DATE', sidx)">
+    				CREATED_DATE
+	    		</when>
+	    		<when test="@oss.fosslight.util.StringUtil@equals('OS_TYPE_ETC', sidx)">
+	 	   			CASE WHEN OS_TYPE = '999' THEN OS_TYPE_ETC ELSE (SELECT SORTCD.CD_DTL_NM FROM T2_CODE_DTL SORTCD WHERE SORTCD.CD_NO = '213' AND SORTCD.CD_DTL_NO = OS_TYPE) END
+	    		</when>
+	  	  		<otherwise></otherwise>
+    		</choose>
+    		<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+    			<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+						ASC
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+						DESC
+					</when>
+				</choose>
+    		</if>
+    	</if>
     </sql>
     	
 	<select id="selectProjectTotalCount" parameterType="oss.fosslight.domain.Project" resultType="int">

--- a/src/main/resources/oss/fosslight/repository/SentMailMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/SentMailMapper.xml
@@ -7,114 +7,117 @@
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
     <sql id="orderby">
-    	ORDER BY ${sidx} ${sord}
-    <!-- 
-        ORDER BY
-		<choose>
-			<when test="@oss.fosslight.util.StringUtil@equals('MSG_TYPE', sidx)">
-				MSG_TYPE
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('SND_STATUS', sidx)">
-				SND_STATUS
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('EML_TITLE', sidx)">
-				EML_TITLE
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('CREATION_DATE', sidx)">
-				CREATION_DATE
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('CREATION_USER_ID', sidx)">
-				CREATION_USER_ID
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('ERROR_MSG', sidx)">
-				ERROR_MSG
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('EML_TO', sidx)">
-				EML_TO
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('EML_CC', sidx)">
-				EML_CC
-			</when>
-		</choose>
-		<choose>
-			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
-				ASC
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
-				DESC
-			</when>
-		</choose>-->
+    	<if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+    		ORDER BY
+        	<choose>
+	        	<when test="@oss.fosslight.util.StringUtil@equals('SND_SEQ', sidx)">
+					SND_SEQ
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('MSG_TYPE', sidx)">
+					MSG_TYPE
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('SND_STATUS', sidx)">
+					SND_STATUS
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('EML_TITLE', sidx)">
+					EML_TITLE
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('CREATION_DATE', sidx)">
+					CREATION_DATE
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('CREATION_USER_ID', sidx)">
+					CREATION_USER_ID
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('ERROR_MSG', sidx)">
+					ERROR_MSG
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('EML_TO', sidx)">
+					EML_TO
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('EML_CC', sidx)">
+					EML_CC
+				</when>
+			</choose>
+			<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+			<choose>
+				<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+					ASC
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+					DESC
+				</when>
+			</choose>
+			</if>
+		</if>
     </sql>
 
 	<sql id="filters">
-		<foreach collection="filtersMap.rules" item="item">
-			AND
+		AND
+		<foreach collection="filtersMap.rules" item="item" separator="AND">
 			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('msgType', item.field)">
+				<when test='item.field == "msgType"'>
 					MSG_TYPE
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('sndStatus', item.field)">
+				<when test='item.field == "sndStatus"'>
 					SND_STATUS
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('emlTitle', item.field)">
+				<when test='item.field == "emlTitle"'>
 					EML_TITLE
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('creationDate', item.field)">
-					DATE_FORMAT(CREATION_DATE, '%Y-%m-%d')
+				<when test='item.field == "creationDate"'>
+					DATE_FORMAT(CREATION_DATE, '%Y%m%d')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('creationUserId', item.field)">
+				<when test='item.field == "creationUserId"'>
 					CREATION_USER_ID
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('errorMsg', item.field)">
+				<when test='item.field == "errorMsg"'>
 					ERROR_MSG
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('emlTo', item.field)">
+				<when test='item.field == "emlTo"'>
 					EML_TO
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('emlCc', item.field)">
+				<when test='item.field == "emlCc"'>
 					EML_CC
 				</when>
 			</choose>
 			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('eq', item.op)">
+				<when test='item.op == "eq"'>
 					= #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ne', item.op)">
+				<when test='item.op == "ne"'>
 					<![CDATA[<>]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bw', item.op)">
+				<when test='item.op == "bw"'>
 					LIKE CONCAT(#{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bn', item.op)">
+				<when test='item.op == "bn"'>
 					NOT LIKE CONCAT(#{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ew', item.op)">
+				<when test='item.op == "ew"'>
 					LIKE CONCAT('%', #{item.data})
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('en', item.op)">
+				<when test='item.op == "en"'>
 					NOT LIKE CONCAT('%', #{item.data})
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cn', item.op)">
+				<when test='item.op == "cn"'>
 					LIKE CONCAT('%', #{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('nc', item.op)">
+				<when test='item.op == "nc"'>
 					NOT LIKE CONCAT('%', #{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('lt', item.op)">
+				<when test='item.op == "lt"'>
 					<![CDATA[<]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('le', item.op)">
+				<when test='item.op == "le"'>
 					<![CDATA[<=]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('gt', item.op)">
+				<when test='item.op == "gt"'>
 					<![CDATA[>]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ge', item.op)">
+				<when test='item.op == "ge"'>
 					<![CDATA[>=]]> #{item.data}
 				</when>
-				<otherwise>
-
-				</otherwise>
+				<otherwise></otherwise>
 			</choose>
 		</foreach>
     </sql>
@@ -126,7 +129,7 @@
     	EMAIL_SND_HIS
     WHERE 1=1
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if>
     </select>
 	<select id="selectSentMailList" parameterType="oss.fosslight.domain.CoMail" resultType="oss.fosslight.domain.CoMail">
@@ -135,7 +138,7 @@
 		FROM EMAIL_SND_HIS
 		WHERE 1=1
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if>
 		<include refid="orderby"/>
 		<include refid="limitPage"/>

--- a/src/main/resources/oss/fosslight/repository/StatisticsMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/StatisticsMapper.xml
@@ -47,29 +47,29 @@
 		SELECT RTN.CD_DTL_NM AS DIVISION_NM
 		     , RTN.CD_ORDER AS DIVISION_ORDER
 			<foreach collection="titleArray" item="item" index="index">
-			 , MAX(RTN.CATEGORY${index}) AS CATEGORY${index}_CNT
+			 , MAX(RTN.CATEGORY#{index}) AS CATEGORY#{index}_CNT
 			</foreach>
 			<if test="@oss.fosslight.util.StringUtil@equals('REV', categoryType)">
-			 , MAX(RTN.CATEGORY${titleArray.size}) AS CATEGORY${titleArray.size}_CNT
+			 , MAX(RTN.CATEGORY#{categorySize}) AS CATEGORY#{categorySize}_CNT
 			 </if>
 		  FROM (SELECT A.CD_DTL_NM
 		  			 , A.CD_ORDER
 			 	  <foreach collection="titleArray" item="item" index="index">
 			 	  	<choose>
     					<when test="@oss.fosslight.util.StringUtil@equals('unassigned', item)">
-							, IF(STAT.CD_DTL_NM IS NOT NULL AND STAT.CATEGORY IS NULL, COUNT(1), 0) AS CATEGORY${index}
+							, IF(STAT.CD_DTL_NM IS NOT NULL AND STAT.CATEGORY IS NULL, COUNT(1), 0) AS CATEGORY#{index}
 						</when>
     					<otherwise>
-    						, IF(STAT.CATEGORY = <![CDATA['${item}']]>, COUNT(1), 0) AS CATEGORY${index}
+    						, IF(STAT.CATEGORY = #{item}, COUNT(1), 0) AS CATEGORY#{index}
     					</otherwise>
     				</choose>
 	  			  </foreach>
 	  			  <if test="@oss.fosslight.util.StringUtil@equals('REV', categoryType)">
 	  			  	  , IF(
 					  <foreach collection="noneUser" item="user" index="index" separator=" OR ">
-					  	   STAT.CATEGORY = <![CDATA['${user}']]>
+					  	   STAT.CATEGORY = #{user}
 					  </foreach>
-					  , COUNT(1), 0) AS CATEGORY${titleArray.size}
+					  , COUNT(1), 0) AS CATEGORY#{categorySize}
 	  			  </if>
 				  FROM (SELECT CD_DTL_NM
 						     , CD_ORDER
@@ -288,22 +288,22 @@
 	<select id="getUpdatedOssChartData"  parameterType="oss.fosslight.domain.Statistics" resultType="oss.fosslight.domain.Statistics">
 		SELECT CONCAT(RTN.DATE, '(', #{updateType}, ')') AS COLUMN_NAME		
 			<foreach collection="titleArray" item="item" index="index">
-			 , MAX(RTN.CATEGORY${index}) AS CATEGORY${index}_CNT
+			 , MAX(RTN.CATEGORY#{index}) AS CATEGORY#{index}_CNT
 			</foreach>
-			 , MAX(RTN.CATEGORY${titleArray.size}) AS CATEGORY${titleArray.size}_CNT
+			 , MAX(RTN.CATEGORY#{categorySize}) AS CATEGORY#{categorySize}_CNT
 		  FROM (SELECT A.DATE
 			 	  <foreach collection="titleArray" item="item" index="index">
-	  			 	 , IF(STAT.CATEGORY = <![CDATA['${item}']]>, COUNT(1), 0) AS CATEGORY${index}
+	  			 	 , IF(STAT.CATEGORY = #{item}, COUNT(1), 0) AS CATEGORY#{index}
 	  			  </foreach>
 	  			  	 , IF(
 				  <foreach collection="noneUser" item="user" index="index" separator=" OR ">
-				  	   STAT.CATEGORY = <![CDATA['${user}']]>
+				  	   STAT.CATEGORY = #{user}
 				  </foreach>
-				     , COUNT(1), 0) AS CATEGORY${titleArray.size}
-				  FROM (SELECT DATE_FORMAT(DATE_ADD('${startDate}', INTERVAL (@num := @num + 1)-1 MONTH), '%Y%m') AS DATE
+				     , COUNT(1), 0) AS CATEGORY#{categorySize}
+				  FROM (SELECT DATE_FORMAT(DATE_ADD(#{startDate}, INTERVAL (@num := @num + 1)-1 MONTH), '%Y%m') AS DATE
 					  	  FROM INFORMATION_SCHEMA.TABLES TAB
 					     	 , (select @num := 0) NUM
-					 	 LIMIT ${diffMonthCnt}) A
+					 	 LIMIT #{diffMonthCnt}) A
 				  LEFT JOIN (SELECT ADMIN.USER_NAME AS CATEGORY
 				  			<choose>
 								<when test="@oss.fosslight.util.StringUtil@equals('ADD', updateType)"> 
@@ -332,11 +332,11 @@
 					<choose>
 						<when test="@oss.fosslight.util.StringUtil@equals('ADD', updateType)">
 							  	 ON OM.CREATOR = ADMIN.USER_ID AND OM.USE_YN = 'Y'
-							  WHERE DATE_FORMAT(OM.CREATED_DATE, '%Y%m%d') BETWEEN #{startDate} AND #{endDate}) STAT
+							  WHERE DATE_FORMAT(OM.CREATED_DATE, '%Y%m%d') BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') AND DATE_FORMAT(#{endDate}, '%Y%m%d')) STAT
 						</when>
 						<when test="@oss.fosslight.util.StringUtil@equals('MOD', updateType)">
 							  	 ON OM.MODIFIER = ADMIN.USER_ID AND OM.USE_YN = 'Y'
-							  WHERE DATE_FORMAT(OM.MODIFIED_DATE, '%Y%m%d') BETWEEN #{startDate} AND #{endDate} 
+							  WHERE DATE_FORMAT(OM.MODIFIED_DATE, '%Y%m%d') BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') AND DATE_FORMAT(#{endDate}, '%Y%m%d')
 								AND DATE_FORMAT(OM.CREATED_DATE, '%Y%m%d') != DATE_FORMAT(OM.MODIFIED_DATE, '%Y%m%d')) STAT
 						</when>
 					</choose>    
@@ -350,22 +350,22 @@
 	<select id="getUpdatedLicenseChartData"  parameterType="oss.fosslight.domain.Statistics" resultType="oss.fosslight.domain.Statistics">
 		SELECT CONCAT(RTN.DATE, '(', #{updateType}, ')') AS COLUMN_NAME	
 			<foreach collection="titleArray" item="item" index="index">
-			 , MAX(RTN.CATEGORY${index}) AS CATEGORY${index}_CNT
+			 , MAX(RTN.CATEGORY#{index}) AS CATEGORY#{index}_CNT
 			</foreach>
-			 , MAX(RTN.CATEGORY${titleArray.size}) AS CATEGORY${titleArray.size}_CNT
+			 , MAX(RTN.CATEGORY#{categorySize}) AS CATEGORY#{categorySize}_CNT
 		  FROM (SELECT A.DATE
 			 	  <foreach collection="titleArray" item="item" index="index">
-	  			 	 , IF(STAT.CATEGORY = <![CDATA['${item}']]>, COUNT(1), 0) AS CATEGORY${index}
+	  			 	 , IF(STAT.CATEGORY = #{item}, COUNT(1), 0) AS CATEGORY#{index}
 	  			  </foreach>
 	  			     , IF(
 				  <foreach collection="noneUser" item="user" index="index" separator=" OR ">
-				  	   STAT.CATEGORY = <![CDATA['${user}']]>
+				  	   STAT.CATEGORY = #{user}
 				  </foreach>
-				     , COUNT(1), 0) AS CATEGORY${titleArray.size}
-				  FROM (SELECT DATE_FORMAT(DATE_ADD('${startDate}', INTERVAL (@num := @num + 1)-1 MONTH), '%Y%m') AS DATE
+				     , COUNT(1), 0) AS CATEGORY#{categorySize}
+				  FROM (SELECT DATE_FORMAT(DATE_ADD(#{startDate}, INTERVAL (@num := @num + 1)-1 MONTH), '%Y%m') AS DATE
 					  	  FROM INFORMATION_SCHEMA.TABLES TAB
 					     	 , (select @num := 0) NUM
-					 	 LIMIT ${diffMonthCnt}) A
+					 	 LIMIT #{diffMonthCnt}) A
 				  LEFT JOIN (SELECT ADMIN.USER_NAME AS CATEGORY
 				  			<choose>
 								<when test="@oss.fosslight.util.StringUtil@equals('ADD', updateType)">
@@ -382,7 +382,7 @@
 							  	  	  FROM OSS_MASTER OM
 							  	INNER JOIN OSS_LICENSE_DECLARED OLD
 							  	        ON OM.OSS_ID = OLD.OSS_ID
-							  	     WHERE DATE_FORMAT(OM.MODIFIED_DATE, '%Y%m%d') BETWEEN #{startDate} AND #{endDate} 
+							  	     WHERE DATE_FORMAT(OM.MODIFIED_DATE, '%Y%m%d') BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') AND DATE_FORMAT(#{endDate}, '%Y%m%d')
 							  	       AND DATE_FORMAT(OM.CREATED_DATE, '%Y%m%d') != DATE_FORMAT(OM.MODIFIED_DATE, '%Y%m%d')
 							  	  GROUP BY OLD.LICENSE_ID
 							  ) OSM
@@ -404,11 +404,11 @@
 					<choose>
 						<when test="@oss.fosslight.util.StringUtil@equals('ADD', updateType)">
 							  	 ON LM.CREATOR = ADMIN.USER_ID AND LM.USE_YN = 'Y'
-							  WHERE DATE_FORMAT(LM.CREATED_DATE, '%Y%m%d') BETWEEN #{startDate} AND #{endDate}) STAT
+							  WHERE DATE_FORMAT(LM.CREATED_DATE, '%Y%m%d') BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') AND DATE_FORMAT(#{endDate}, '%Y%m%d')) STAT
 						</when>
 						<when test="@oss.fosslight.util.StringUtil@equals('MOD', updateType)">
 							  	 ON LM.MODIFIER = ADMIN.USER_ID AND LM.USE_YN = 'Y'
-							  WHERE DATE_FORMAT(LM.MODIFIED_DATE, '%Y%m%d') BETWEEN #{startDate} AND #{endDate} 
+							  WHERE DATE_FORMAT(LM.MODIFIED_DATE, '%Y%m%d') BETWEEN DATE_FORMAT(#{startDate}, '%Y%m%d') AND DATE_FORMAT(#{endDate}, '%Y%m%d')
 							    AND DATE_FORMAT(LM.CREATED_DATE, '%Y%m%d') != DATE_FORMAT(LM.MODIFIED_DATE, '%Y%m%d')) STAT
 						</when>
 					</choose>
@@ -422,29 +422,29 @@
 	<select id="getTrdPartyRelatedChartData" parameterType="oss.fosslight.domain.Statistics" resultType="oss.fosslight.domain.Statistics">
 		SELECT RTN.CD_DTL_NM AS DIVISION_NM
 			<foreach collection="titleArray" item="item" index="index">
-			 , MAX(RTN.CATEGORY${index}) AS CATEGORY${index}_CNT
+			 , MAX(RTN.CATEGORY#{index}) AS CATEGORY#{index}_CNT
 			</foreach>
 			<if test="@oss.fosslight.util.StringUtil@equals('REV', categoryType)">
-			 , MAX(RTN.CATEGORY${titleArray.size}) AS CATEGORY${titleArray.size}_CNT
+			 , MAX(RTN.CATEGORY#{categorySize}) AS CATEGORY#{categorySize}_CNT
 			 </if>
 		  FROM (SELECT A.CD_DTL_NM
 		  			 , A.CD_ORDER
 			 	  <foreach collection="titleArray" item="item" index="index">
 	  			  <choose>
     					<when test="@oss.fosslight.util.StringUtil@equals('unassigned', item)">
-							, IF(STAT.CD_DTL_NM IS NOT NULL AND STAT.CATEGORY IS NULL, COUNT(1), 0) AS CATEGORY${index}
+							, IF(STAT.CD_DTL_NM IS NOT NULL AND STAT.CATEGORY IS NULL, COUNT(1), 0) AS CATEGORY#{index}
 						</when>
     					<otherwise>
-    						, IF(STAT.CATEGORY = <![CDATA['${item}']]>, COUNT(1), 0) AS CATEGORY${index}
+    						, IF(STAT.CATEGORY = #{item}, COUNT(1), 0) AS CATEGORY#{index}
     					</otherwise>
     				</choose>
 	  			  </foreach>
 	  			  <if test="@oss.fosslight.util.StringUtil@equals('REV', categoryType)">
 	  			  	  , IF(
 					  <foreach collection="noneUser" item="user" index="index" separator=" OR ">
-					  	   STAT.CATEGORY = <![CDATA['${user}']]>
+					  	   STAT.CATEGORY = #{user}
 					  </foreach>
-					  , COUNT(1), 0) AS CATEGORY${titleArray.size}
+					  , COUNT(1), 0) AS CATEGORY#{categorySize}
 	  			  </if>
 				  FROM (SELECT CD_DTL_NM
 						     , CD_ORDER

--- a/src/main/resources/oss/fosslight/repository/T2UserMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/T2UserMapper.xml
@@ -42,19 +42,31 @@
                 AND T2.AUTHORITY = #{schValue}
             </if>
         </if> 
-        <choose>
-            <when test="!@oss.fosslight.util.StringUtil@isEmptyTrimmed(sortField) and !@oss.fosslight.util.StringUtil@isEmptyTrimmed(sortOrder) ">
-                <if test="@oss.fosslight.util.StringUtil@equals('userId', sortField)">
-                ORDER BY USER_ID ${sortOrder}
-                </if>
-                <if test="@oss.fosslight.util.StringUtil@equals('userName', sortField)">
-                ORDER BY USER_NAME ${sortOrder}
-                </if>
-            </when>
-            <otherwise>
-                ORDER BY CREATED_DATE DESC
-            </otherwise>
-        </choose> 
+        <if test="@oss.fosslight.util.StringUtil@isEmpty(sortField)">
+        	ORDER BY CREATED_DATE DESC
+        </if>
+        <if test="!@oss.fosslight.util.StringUtil@isEmpty(sortField)">
+        	ORDER BY
+        	<choose>
+        		<when test="@oss.fosslight.util.StringUtil@equals('userId', sortField)">
+        			USER_ID
+        		</when>
+        		<when test="@oss.fosslight.util.StringUtil@equals('userName', sortField)">
+        			USER_NAME
+        		</when>
+        		<otherwise></otherwise>
+        	</choose>
+        	<if test="!@oss.fosslight.util.StringUtil@isEmpty(sortOrder)">
+        		<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('asc', sortOrder)">
+						ASC
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('desc', sortOrder)">
+						DESC
+					</when>
+				</choose>
+        	</if>
+        </if>
     </select>
     <!-- 특정 사용자 가져오기 -->
     <select id="getUser" parameterType="oss.fosslight.domain.T2Users" resultType="oss.fosslight.domain.T2Users"> 

--- a/src/main/resources/oss/fosslight/repository/VulnerabilityHistoryMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/VulnerabilityHistoryMapper.xml
@@ -8,112 +8,114 @@
 	</sql>
 	<!--TODO : Why don't you change camel case to snake case like other files about sidx-->
     <sql id="orderby">
-    	ORDER BY ${sidx} ${sord}
-<!-- 	<choose>
-			<when test="@oss.fosslight.util.StringUtil@equals('REG_DT', sidx)">
-				ORDER BY REG_DT
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('OSS_ID', sidx)">
-				ORDER BY OSS_ID
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('OSS_NAME', sidx)">
-				ORDER BY OSS_NAME
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('OSS_VERSION', sidx)">
-				ORDER BY OSS_VERSION
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('CVE_ID', sidx)">
-				ORDER BY CVE_ID
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE', sidx)">
-				ORDER BY CVSS_SCORE
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('CVE_ID_TO', sidx)">
-				ORDER BY CVE_ID_TO
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE_TO', sidx)">
-				ORDER BY CVSS_SCORE_TO
-			</when>
-		</choose>
-		<choose>
-			<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
-				ASC
-			</when>
-			<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
-				DESC
-			</when>
-		</choose> -->
+    	<if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+    		ORDER BY
+    		<choose>
+				<when test="@oss.fosslight.util.StringUtil@equals('REG_DT', sidx)">
+					REG_DT
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('OSS_ID', sidx)">
+					OSS_ID
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('OSS_NAME', sidx)">
+					OSS_NAME
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('OSS_VERSION', sidx)">
+					OSS_VERSION
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('CVE_ID', sidx)">
+					CVE_ID
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE', sidx)">
+					CAST(CVSS_SCORE AS DECIMAL(10, 1))
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('CVE_ID_TO', sidx)">
+					CVE_ID_TO
+				</when>
+				<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE_TO', sidx)">
+					CAST(CVSS_SCORE_TO AS DECIMAL(10, 1))
+				</when>
+			</choose>
+			<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+				<choose>
+					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+						ASC
+					</when>
+					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+						DESC
+					</when>
+				</choose>
+			</if>
+    	</if>
     </sql>
 
 	<sql id="filters">
-		<foreach collection="filtersMap.rules" item="item">
-			AND
+		AND
+		<foreach collection="filtersMap.rules" item="item" separator="AND">
 			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('ossId', item.field)">
+				<when test='item.field == "ossId"'>
 					OSS_ID
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ossName', item.field)">
+				<when test='item.field == "ossName"'>
 					OSS_NAME
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ossVersion', item.field)">
+				<when test='item.field == "ossVersion"'>
 					OSS_VERSION
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cveId', item.field)">
+				<when test='item.field == "cveId"'>
 					CVE_ID
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cvssScore', item.field)">
+				<when test='item.field == "cvssScore"'>
 					CVSS_SCORE
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cveIdTo', item.field)">
+				<when test='item.field == "cveIdTo"'>
 					CVE_ID_TO
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cvssScoreTo', item.field)">
+				<when test='item.field == "cvssScoreTo"'>
 					CVSS_SCORE_TO
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('regDt', item.field)">
+				<when test='item.field == "regDt"'>
 					DATE_FORMAT(REG_DT, '%Y-%m-%d')
 				</when>
 			</choose>
 			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('eq', item.op)">
+				<when test='item.op == "eq"'>
 					= #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ne', item.op)">
+				<when test='item.op == "ne"'>
 					<![CDATA[<>]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bw', item.op)">
+				<when test='item.op == "bw"'>
 					LIKE CONCAT(#{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bn', item.op)">
+				<when test='item.op == "bn"'>
 					NOT LIKE CONCAT(#{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ew', item.op)">
+				<when test='item.op == "ew"'>
 					LIKE CONCAT('%', #{item.data})
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('en', item.op)">
+				<when test='item.op == "en"'>
 					NOT LIKE CONCAT('%', #{item.data})
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cn', item.op)">
+				<when test='item.op == "cn"'>
 					LIKE CONCAT('%', #{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('nc', item.op)">
+				<when test='item.op == "nc"'>
 					NOT LIKE CONCAT('%', #{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('lt', item.op)">
+				<when test='item.op == "lt"'>
 					<![CDATA[<]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('le', item.op)">
+				<when test='item.op == "le"'>
 					<![CDATA[<=]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('gt', item.op)">
+				<when test='item.op == "gt"'>
 					<![CDATA[>]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ge', item.op)">
+				<when test='item.op == "ge"'>
 					<![CDATA[>=]]> #{item.data}
 				</when>
-				<otherwise>
-
-				</otherwise>
+				<otherwise></otherwise>
 			</choose>
 		</foreach>
     </sql>
@@ -125,7 +127,7 @@
 			NVD_OSS_HIS
 		WHERE 1=1
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if>
     </select>
 	<select id="selectVulnerabilityHistoryList" parameterType="oss.fosslight.domain.VulnerabilityHistory" resultType="oss.fosslight.domain.VulnerabilityHistory">
@@ -141,7 +143,7 @@
 		FROM NVD_OSS_HIS
 		WHERE 1=1
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if>
 		<include refid="orderby"/>
 		<include refid="limitPage"/>

--- a/src/main/resources/oss/fosslight/repository/VulnerabilityMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/VulnerabilityMapper.xml
@@ -9,117 +9,111 @@
 		LIMIT #{startIndex}, #{pageListSize}
 	</sql>
     <sql id="orderby">
-    	<choose>
+    	<if test="!@oss.fosslight.util.StringUtil@isEmpty(sidx)">
+    		<choose>
     		<when test="@oss.fosslight.util.StringUtil@equals('VERSION', sidx)">
-    			ORDER BY A.SEQ ${sord} 
-			 	    , A.MAJOR_VERSION ${sord} 
-			 	    , BINARY ( CASE WHEN A.VERSION REGEXP '^[a-zA-Z]+' THEN VERSION END ) ${sord}
-			 	    , A.ASCII ${sord}
-				    , A.MINOR_VERSION ${sord}
-				    , A.PATCH_VERSION ${sord}
-				    , A.VERSION_LEN ${sord}
-<!-- 			<choose>
-					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
-						ORDER BY A.SEQ asc 
-							, A.MAJOR_VERSION asc
-							, BINARY ( CASE WHEN A.VERSION REGEXP '^[a-zA-Z]+' THEN VERSION END ) asc
-							, A.ASCII asc
-							, A.MINOR_VERSION asc
-							, A.PATCH_VERSION asc
-							, A.VERSION_LEN asc
-					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
-						ORDER BY A.SEQ desc
-							, A.MAJOR_VERSION desc
-							, BINARY ( CASE WHEN A.VERSION REGEXP '^[a-zA-Z]+' THEN VERSION END ) desc
-							, A.ASCII desc
-							, A.MINOR_VERSION desc
-							, A.PATCH_VERSION desc
-							, A.VERSION_LEN desc
-					</when>
-				</choose> -->
+    			<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+    				<choose>
+						<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+							ORDER BY A.SEQ ASC
+									, A.MAJOR_VERSION ASC
+									, BINARY ( CASE WHEN A.VERSION REGEXP '^[a-zA-Z]+' THEN VERSION END ) ASC
+									, A.ASCII ASC
+									, A.MINOR_VERSION ASC
+									, A.PATCH_VERSION ASC
+									, A.VERSION_LEN ASC
+						</when>
+						<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+							ORDER BY A.SEQ DESC
+									, A.MAJOR_VERSION DESC
+									, BINARY ( CASE WHEN A.VERSION REGEXP '^[a-zA-Z]+' THEN VERSION END ) DESC
+									, A.ASCII DESC
+									, A.MINOR_VERSION DESC
+									, A.PATCH_VERSION DESC
+									, A.VERSION_LEN DESC
+						</when>
+					</choose>
+    			</if>
     		</when>
-			<otherwise>ORDER BY ${sidx} ${sord}</otherwise>
-<!-- 		<otherwise>
-				<choose> -->
-					<!--TODO: why is it "product" not "ossName". Need to check the domain of vulnerability.-->
-<!-- 				<when test="@oss.fosslight.util.StringUtil@equals('PRODUCT', sidx)">
-						ORDER BY PRODUCT
-					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('OSS_NICKNAME', sidx)">
-						ORDER BY OSS_NICKNAME
-					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE', sidx)">
-						ORDER BY CVSS_SCORE
-					</when>
-				</choose>
-				<choose>
-					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
-						ASC
-					</when>
-					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
-						DESC
-					</when>
-				</choose>
-			</otherwise> -->
-    	</choose>
+    		<otherwise>
+    			<choose>
+    				<when test="@oss.fosslight.util.StringUtil@equals('PRODUCT', sidx)">
+    					ORDER BY PRODUCT
+    				</when>
+    				<when test="@oss.fosslight.util.StringUtil@equals('OSS_NICKNAME', sidx)">
+    					ORDER BY OSS_NICKNAME
+    				</when>
+    				<when test="@oss.fosslight.util.StringUtil@equals('CVSS_SCORE', sidx)">
+    					ORDER BY CVSS_SCORE
+    				</when>
+    			</choose>
+    			<if test="!@oss.fosslight.util.StringUtil@isEmpty(sord)">
+    				<choose>
+    					<when test="@oss.fosslight.util.StringUtil@equals('asc', sord)">
+    						ASC
+    					</when>
+    					<when test="@oss.fosslight.util.StringUtil@equals('desc', sord)">
+    						DESC
+    					</when>
+    				</choose>
+    			</if>
+    		</otherwise>
+    		</choose>
+    	</if>
     </sql>
 
 	<sql id="filters">
-		<foreach collection="filtersMap.rules" item="item">
-			AND
+		AND
+		<foreach collection="filtersMap.rules" item="item" separator="AND">
 			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('product', item.field)">
+				<when test='item.field == "product"'>
 					PRODUCT
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ossNickname', item.field)">
+				<when test='item.field == "ossNickname"'>
 					OSS_NICKNAME
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('version', item.field)">
+				<when test='item.field == "version"'>
 					VERSION
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cvssScore', item.field)">
-					CVSS_SCORE
-				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cvssScore', item.field)">
+				<when test='item.field == "cvssScore"'>
 					CVSS_SCORE
 				</when>
 			</choose>
 			<choose>
-				<when test="@oss.fosslight.util.StringUtil@equals('eq', item.op)">
+				<when test='item.op == "eq"'>
 					= #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ne', item.op)">
+				<when test='item.op == "ne"'>
 					<![CDATA[<>]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bw', item.op)">
+				<when test='item.op == "bw"'>
 					LIKE CONCAT(#{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('bn', item.op)">
+				<when test='item.op == "bn"'>
 					NOT LIKE CONCAT(#{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ew', item.op)">
+				<when test='item.op == "ew"'>
 					LIKE CONCAT('%', #{item.data})
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('en', item.op)">
+				<when test='item.op == "en"'>
 					NOT LIKE CONCAT('%', #{item.data})
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('cn', item.op)">
+				<when test='item.op == "cn"'>
 					LIKE CONCAT('%', #{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('nc', item.op)">
+				<when test='item.op == "nc"'>
 					NOT LIKE CONCAT('%', #{item.data}, '%')
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('lt', item.op)">
+				<when test='item.op == "lt"'>
 					<![CDATA[<]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('le', item.op)">
+				<when test='item.op == "le"'>
 					<![CDATA[<=]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('gt', item.op)">
+				<when test='item.op == "gt"'>
 					<![CDATA[>]]> #{item.data}
 				</when>
-				<when test="@oss.fosslight.util.StringUtil@equals('ge', item.op)">
+				<when test='item.op == "ge"'>
 					<![CDATA[>=]]> #{item.data}
 				</when>
 				<otherwise>
@@ -168,7 +162,7 @@
 		   AND SCORE.VERSION LIKE CONCAT (#{version},'%')
 		</if>
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if>
 		) A
 	</select>
@@ -211,7 +205,7 @@
 				   AND VERSION LIKE CONCAT (#{version},'%')
 				</if>
 				<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-					${filterCondition}
+					<include refid="filters"/>
 				</if>
 		) A
 		<include refid="orderby"/>
@@ -260,7 +254,7 @@
 			</choose>
 		</if>
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if>
 	</select>
 	
@@ -325,7 +319,7 @@
 		  ) A
 		  WHERE 1 = 1
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if> 
 	</select>
 	
@@ -368,7 +362,7 @@
 		  ) A
 		  WHERE 1 = 1
 		<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-			${filterCondition}
+			<include refid="filters"/>
 		</if> 
 		<include refid="orderby"/>
 		<include refid="limitPage"/>
@@ -475,7 +469,7 @@
 				   AND VERSION LIKE CONCAT (#{version},'%')
 				</if>
 				<if test="!@oss.fosslight.util.StringUtil@isEmpty(filterCondition)">
-					${filterCondition}
+					<include refid="filters"/>
 				</if>
 		) A
 		LEFT JOIN NVD_CVE_V3 CVE


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Load the default comments when confirming packaging from the `email default contents` of `Code Management` and include them in the email.
![image](https://user-images.githubusercontent.com/4284712/167807870-e45e8733-2a31-4f3e-9ab3-3bb63695ecf5.png)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
