### PR TITLE
When issuing a Notice in Self-check, load and include the OSS link instead of the Homepage by loading the Download location

### DIFF
--- a/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
@@ -548,6 +548,11 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				ossComponent.get(i).setComponentIdx(componentIdx);
 				String _componentId = ossComponent.get(i).getReferenceId() + "-" + ossComponent.get(i).getReferenceDiv() + "-" + ossComponent.get(i).getComponentIdx();
 				
+				OssMaster ossInfo = CoCodeManager.OSS_INFO_UPPER.get((ossComponent.get(i).getOssName() +"_"+ avoidNull(ossComponent.get(i).getOssVersion())).toUpperCase());
+				if(ossInfo != null) {
+					ossComponent.get(i).setObligationType(ossInfo.getObligationType());
+				}
+				
 				selfCheckMapper.insertSrcOssList(ossComponent.get(i));
 				deleteRows.add(componentIdx);
 				
@@ -1082,8 +1087,14 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		Map<String, List<String>> componentAttribution = new HashMap<>();
 		
 		OssComponents ossComponent;
+		String ossInfoUpperKey = "";
 		
 		for(OssComponents bean : ossComponentList) {
+			ossInfoUpperKey = (bean.getOssName() + "_" + avoidNull(bean.getOssVersion())).toUpperCase();
+			if(CoCodeManager.OSS_INFO_UPPER.containsKey(ossInfoUpperKey) && isEmpty(bean.getHomepage())) {
+				bean.setHomepage(CoCodeManager.OSS_INFO_UPPER.get(ossInfoUpperKey).getHomepage());
+			}
+			
 			String componentKey = (hideOssVersionFlag
 									? bean.getOssName() 
 									: bean.getOssName() + "|" + bean.getOssVersion()).toUpperCase();
@@ -1263,6 +1274,13 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		if(addOssComponentList != null) {
 			for(OssComponents bean : addOssComponentList) {
+				if("-".equals(bean.getOssName()) || !CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(bean.getOssName().toUpperCase())
+						|| !CoCodeManager.OSS_INFO_UPPER.containsKey((bean.getOssName() + "_" + avoidNull(bean.getOssVersion())).toUpperCase())) {
+					if(!isEmpty(bean.getDownloadLocation()) && isEmpty(bean.getHomepage())) {
+						bean.setHomepage(bean.getDownloadLocation());
+					}
+				}
+				
 				String componentKey = (hideOssVersionFlag
 											? bean.getOssName() 
 											: bean.getOssName() + "|" + bean.getOssVersion()).toUpperCase();


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
> When issuing a Notice in Self-check, load and include the OSS link instead of the Homepage by loading the Download location.

If Unconfirmed OSS OR Unconfirmed version OR OSS Name is -
- AS-IS: Issue OSS Notice with information written on the row.
     - Problem: Clicking the OSS name in OSS Notice does not work because there is no Homepage column.
- TO-BE: In this case, print the download location in the Homepage of the OSS Notice.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
