### PR TITLE
Change the UI for self-check upload

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
@@ -824,14 +824,19 @@
             var value = $("[name='"+name+"']:checked").val()
             var key = name.split("_")[1];
 
+            var srcR1 = document.getElementById("srcR1");
+            var srcUploadUrl = document.getElementById("2");
+
             switch(value){
                 case "1":
-                    $('#uploadGroup').show();
-                    $('#wgetUrl_' + key).hide();
+                    $('.uploadSet').show();
+                    $('.wgetUrl').hide();
+                    srcUploadUrl.checked = false;
                     break;
                 case "2":
-                    $('#uploadGroup').hide();
+                    $('.uploadSet').hide();
                     $('#wgetUrl_' + key).show();
+                    srcR1.checked = false;
                     break;
                 default:
                     break;

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
@@ -81,7 +81,8 @@
 		<div id="ossList" class="tabContent">
 			<fieldset class="editSearchUp grayBox singleLine mt20">
 				<div class="sukind">
-					<span class="radioSet srcBtn"><input type="radio" id="srcR1" name="srcSelectOption" onchange="src_fn.changeSelectOption()" value="1" checked/><label for="srcR1">Upload Analysis Result</label></span>
+					<span class="radioSet srcBtn"><input type="radio" id="srcR1" name="srcSelectOption" onchange="fn.changeSelectOption(this)" value="1" checked/><label for="srcR1">Upload Analysis Result</label></span>
+					<span class="radioSet srcBtn"><input type="radio" id="2" name="selectOption_${i}" onchange="fn.changeSelectOption(this)" value="2" <c:if test="${ct:getCodeExpString(ct:getConstDef('CD_SYSTEM_SETTING'), ct:getConstDef('CD_EXTERNAL_ANALYSIS_USED_FLAG')) eq 'N'}"></c:if>/><label for="2">URL </label></span>
 				</div>
 					<form id="srcUploadForm" class="srcBtn">
 						<input type="hidden" id="srcCsvFileId" value="${project.srcCsvFileId }">
@@ -90,7 +91,7 @@
 							<dd>
 								<div class="basicCase">
 									<div class="uploadTit">
-										<span class="checkSet"><label for="2">Please select a file to upload</label></span>	
+										<span class="checkSet"><label for="2">Please select a file to upload</label></span>
 									</div>
 									<div class="uploadGroup">
 										<div class="uploadSet">
@@ -118,8 +119,7 @@
 											</div>
 										</div>
 										<br/>
-										<span><input type="radio" id="2" name="selectOption_${i}" onchange="fn.changeSelectOption(this)" value="2" <c:if test="${ct:getCodeExpString(ct:getConstDef('CD_SYSTEM_SETTING'), ct:getConstDef('CD_EXTERNAL_ANALYSIS_USED_FLAG')) eq 'N'}">disabled</c:if>/><label for="2">URL </label></span>
-										<div id="wgetUrl_${i}" style="width: 500px; display: none;"><input type="text" style="width:70%" id="sendWgetUrl" name="sendWgetUrl" /><input type="button" value="send" class="btnColor red btnExpor srcBtn" onclick=src_fn.uploadOSSByUrl() /></div>
+										<div id="wgetUrl_${i}" class="wgetUrl" style="width: 500px; display: none;"><input type="text" style="width:70%" id="sendWgetUrl" name="sendWgetUrl" /><input type="button" value="send" class="btnColor red btnExpor srcBtn" onclick=src_fn.uploadOSSByUrl() /></div>
 									</div>
 								</div>
 							</dd>


### PR DESCRIPTION
Signed-off-by: suhwan-cheon <soo7652@naver.com>

## Description
- Change the UI for self-check upload (#485)

- when url radio button is disabled
<img width="672" alt="스크린샷 2022-05-22 오전 3 12 15" src="https://user-images.githubusercontent.com/52690419/169664384-14c9efa6-ad25-4673-b92c-1d18da602368.png">

- when url radio button is abled
<img width="486" alt="스크린샷 2022-05-22 오전 3 13 05" src="https://user-images.githubusercontent.com/52690419/169664391-299852ae-5f70-4349-aa89-72d6a25a092a.png">

- I changed the first radio button - onchange method in edit.jsp during the modification, and I am worried about that part.
Because I don't fully understand the code. 😭
- So if you have any problems, please reply! I'll fix it quickly🏃


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
