### PR TITLE
open oss details window in oss version information

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/oss/AJAX/ossDetailview.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/AJAX/ossDetailview.jsp
@@ -27,7 +27,10 @@ function showLicenseText(target) {
 				<tbody>
 					<tr>
 						<th class="dCase txStr"><spring:message code="msg.common.field.OSS.name" /></th>
-						<td class="dCase">${ossInfo.ossName}</td>
+						<td class="dCase">
+							<a href=<c:url value='/oss/edit/${ossInfo.ossId}'/> target="_blank" class="urlLink"
+							   onClick="window.open(this.href, 'OSS_'+${ossInfo.ossId},'width=1100, height=900, toolbar=no, location=no, left=-2000, top=0'); return false;">${ossInfo.ossName}</a>
+						</td>
 					</tr>
 					<tr>
 						<th class="dCase"><spring:message code="msg.common.field.nickname" /></th>


### PR DESCRIPTION
add function to modify/view oss details information in the oss version information window

## Description
<!-- 
Please describe what this PR do.
 -->
step :
identification > select ID column > open new window of the list of oss version information > select "OSS Name" > open the oss details window(admin can edit the information)

oss version information window : 
![image](https://user-images.githubusercontent.com/102017711/176096542-47bc7849-a4c7-41d7-851e-5151d5c0a3a9.png)

oss details window
![image](https://user-images.githubusercontent.com/102017711/176096612-a900ade8-8cdb-4b48-ba3d-f3c75eb1b6c1.png)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
