### PR TITLE
Fix bug where CVE-ID is returned as duplicate in API > Vulnerability.

### DIFF
--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -599,6 +599,10 @@ public class OssController extends CoTopComponent{
 					if(ossMaster.getOssNicknames() != null) {
 						if(orgNickNames.length != ossMaster.getOssNicknames().length) {
 							ossNameCheck = true;
+						} else {
+							if(!Arrays.equals(orgNickNames, ossMaster.getOssNicknames())){
+								ossNameCheck = true;
+							}
 						}
 					} else {
 						ossNameCheck = true;

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -595,18 +595,17 @@ public class OssController extends CoTopComponent{
 				String[] orgNickNames = ossService.getOssNickNameListByOssName(orgBean.getOssNameTemp());
 				if(orgNickNames != null && orgNickNames.length > 0) {
 					boolean ossNameCheck = false;
-					String targetName = "";
 					
-					for(String n : orgNickNames) {
-						if(ossMaster.getOssName().equalsIgnoreCase(n)) {
+					if(ossMaster.getOssNicknames() != null) {
+						if(orgNickNames.length != ossMaster.getOssNicknames().length) {
 							ossNameCheck = true;
-							targetName = n;
-							break;
 						}
+					} else {
+						ossNameCheck = true;
 					}
 					
-					if(ossNameCheck && !isEmpty(targetName)) {
-						return makeJsonResponseHeader(false, "duplicatedNick", MessageFormat.format(validator.getCustomMessage("OSS_NAME.DUPLICATEDNICK"), targetName, orgBean.getOssId(), orgBean.getOssId(), orgBean.getOssName()));
+					if(ossNameCheck) {
+						return makeJsonResponseHeader(false, "duplicatedNick", MessageFormat.format(validator.getCustomMessage("OSS_NAME.DUPLICATEDNICK"), ossMaster.getOssName(), orgBean.getOssId(), orgBean.getOssId(), orgBean.getOssName()));
 					}
 				}
 				

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -6,6 +6,7 @@
 package oss.fosslight.controller;
 
 import java.lang.reflect.Type;
+import java.text.MessageFormat;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -589,6 +590,26 @@ public class OssController extends CoTopComponent{
 			if(orgBean != null && !ossMaster.getOssName().equalsIgnoreCase(orgBean.getOssNameTemp())) {
 				List<String> orgNickList = new ArrayList<>();
 				List<String> delNickList = new ArrayList<>();
+				
+				// 기존 oss name 이 변경되었고, 변경된 oss name 이 기존 oss name 의 nick name 인 경우 제외
+				String[] orgNickNames = ossService.getOssNickNameListByOssName(orgBean.getOssNameTemp());
+				if(orgNickNames != null && orgNickNames.length > 0) {
+					boolean ossNameCheck = false;
+					String targetName = "";
+					
+					for(String n : orgNickNames) {
+						if(ossMaster.getOssName().equalsIgnoreCase(n)) {
+							ossNameCheck = true;
+							targetName = n;
+							break;
+						}
+					}
+					
+					if(ossNameCheck && !isEmpty(targetName)) {
+						return makeJsonResponseHeader(false, "duplicatedNick", MessageFormat.format(validator.getCustomMessage("OSS_NAME.DUPLICATEDNICK"), targetName, orgBean.getOssId(), orgBean.getOssId(), orgBean.getOssName()));
+					}
+				}
+				
 				// oss name이 변경 되었고, 변경 후 oss name이 이미 등록되어 있는 경우
 				Map<String, List<String>> diffMap = new HashMap<>();
 				String[] orgNicks = ossService.getOssNickNameListByOssName(ossMaster.getOssName());

--- a/src/main/java/oss/fosslight/service/impl/ApiVulnerabilityServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiVulnerabilityServiceImpl.java
@@ -5,6 +5,7 @@
 
 package oss.fosslight.service.impl;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +33,19 @@ public class ApiVulnerabilityServiceImpl implements ApiVulnerabilityService {
 		paramMap.put("ossVersion", version);
 		paramMap.put("ossNicknames", nicknameList);
 		
-		return apiVulnerabilityMapper.selectNvdList(paramMap);
+		List<Map<String, Object>> nvdList = apiVulnerabilityMapper.selectNvdList(paramMap);
+		List<String> duplicatedStr = new ArrayList<String>();
+		List<Map<String, Object>> duplicatedNvdList = new ArrayList<Map<String, Object>>();
+		
+		for(Map<String, Object> nvd : nvdList) {
+			String s = (String) nvd.get("cveId");
+			if(!duplicatedStr.contains(s)) {
+				duplicatedStr.add(s);
+				duplicatedNvdList.add(nvd);
+			}
+		}
+		
+		return duplicatedNvdList;
 	}
 	
 	public List<Map<String, Object>> selectMaxScoreNvdInfo(String product, String version){

--- a/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
@@ -1590,6 +1590,8 @@
 				
 				renameFlag = 'N';
 				$('input[name=renameFlag]').val(renameFlag);
+			} else if(json.validMsg == "duplicatedNick"){
+				alertify.alert(json.resultData, function(){});
 			} else if(json.resultData) {
 				var _alertMsg  = '<spring:message code="msg.oss.nickname.exists"/>';
 					_alertMsg += '<br><br>' + 'When registering a new OSS or adding a version, it is not possible to delete the nickname of the existing OSS.';


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Fix the bug where OSS Name is stored as duplicate.
- Fix bug where CVE-ID is returned as duplicate in API > Vulnerability. (This bug is reproduced when the OSS version is blank.)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
