### PR TITLE
Modify reloaded identification tab after 'change license' or 'change nickname' to you're working on.

### DIFF
--- a/src/main/resources/messages/message_en_US.properties
+++ b/src/main/resources/messages/message_en_US.properties
@@ -122,7 +122,6 @@ msg.project.check.oss.name=There exists another OSS which has same download loca
 msg.project.check.oss.name.success=Successfully changed OSS name <br> into OSS table
 msg.project.check.license=License detected based on OSS Name, Version, and Download location. To change the license, click the "Change License" button.
 msg.project.check.license.success=Successfully changed OSS License <br> into OSS table
-msg.project.entered.first.tab=It moves to the tab you entered first.
 msg.project.notice.save=Notice file was not saved. Please click the \\'Save\\' button first.
 msg.project.obligation.unclear=Obligation is unclear
 msg.project.copy.confirm.status.fail.identification=The project was created with Identification Progress status due to error.

--- a/src/main/resources/messages/message_ko_KR.properties
+++ b/src/main/resources/messages/message_ko_KR.properties
@@ -122,7 +122,6 @@ msg.project.check.oss.name=동일한 Download Location으로 등록된 OSS가 �
 msg.project.check.oss.name.success=선택한 OSS 이름으로 변경되었습니다.
 msg.project.check.license=OSS Name, Version, Download location을 기반으로 검출된 License 입니다. License를 변경하시려면 Change License 버튼을 클릭하세요.
 msg.project.check.license.success=선택한 라이선스로 변경되었습니다.
-msg.project.entered.first.tab=이전 탭으로 이동합니다.
 msg.project.notice.save=Notice file이 저장되지 않았습니다. 먼저 \\'Save\\' 버튼을 클릭해주세요.
 msg.project.obligation.unclear=Obligation is unclear
 msg.project.copy.confirm.status.fail.identification=에러로 인해 Identification Progress 상태로 프로젝트 생성되었습니다.

--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
@@ -182,12 +182,37 @@
 											if(!failFlag){
 												var successMsg = '<spring:message code="msg.project.check.license.success" />';
 
+												/**
+												 * identifcaiton tab order you're working on
+												 */
+												var identificationTabOrder;
+
+												/**
+												 * params["referenceDiv"] is id of identification type
+												 * 3RD, SRC, BIN, BIN-Android, BOM
+												 * 10 (3RD) -> tab index: 0
+												 * 11 (SRC) -> tab index: 1
+												 * 15 (BIN) -> tab index: 2
+												 * 14 (ANDROID) -> tab index: 3
+												 * 13 (BOM) -> tab index: 4
+												 */
+												switch(rowdata["referenceDiv"]) {
+												    case "10":    identificationTabOrder = "0";    break;
+												    case "11":    identificationTabOrder = "1";    break;
+												    case "15":    identificationTabOrder = "2";    break;
+												    case "14":    identificationTabOrder = "3";    break;
+												    case "13":    identificationTabOrder = "4";    break;
+												}
+
 												<c:if test="${projectInfo.targetName eq 'identification' || projectInfo.targetName eq 'partner'}">
 												successMsg += '<br>(<spring:message code="msg.project.entered.first.tab" />)';
 												</c:if>
 
+												/**
+												 * reload identication tab you're working on
+												 */
+												opener.location.href = `/project/identification/\${rowdata["refPrjId"]}/\${identificationTabOrder}`
 												alertify.success(successMsg, 5); // 5sec동안 message 출력
-												opener.location.reload();
 											}
 
 											$('#loading_wrap_popup').hide();

--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
@@ -204,10 +204,6 @@
 												    case "13":    identificationTabOrder = "4";    break;
 												}
 
-												<c:if test="${projectInfo.targetName eq 'identification' || projectInfo.targetName eq 'partner'}">
-												successMsg += '<br>(<spring:message code="msg.project.entered.first.tab" />)';
-												</c:if>
-
 												/**
 												 * reload identication tab you're working on
 												 */

--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
@@ -139,10 +139,6 @@
 												    case "13":    identificationTabOrder = "4";    break;
 												}
 
-												<c:if test="${projectInfo.targetName eq 'identification' || projectInfo.targetName eq 'partner'}">
-												successMsg += '<br>(<spring:message code="msg.project.entered.first.tab" />)';
-												</c:if>
-
 												/**
 												 * reload identication tab you're working on
 												 */

--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
@@ -116,13 +116,38 @@
 										if(result.length == idArry.length){
 											if(!failFlag){
 												var successMsg = '<spring:message code="msg.project.check.oss.name.success" />';
-												
+
+												/**
+												 * identifcaiton tab order you're working on
+												 */
+												var identificationTabOrder;
+
+												/**
+												 * params["referenceDiv"] is id of identification type
+												 * 3RD, SRC, BIN, BIN-Android, BOM
+												 * 10 (3RD) -> tab index: 0
+												 * 11 (SRC) -> tab index: 1
+												 * 15 (BIN) -> tab index: 2
+												 * 14 (ANDROID) -> tab index: 3
+												 * 13 (BOM) -> tab index: 4
+												 */
+												switch(rowdata["referenceDiv"]) {
+												    case "10":    identificationTabOrder = "0";    break;
+												    case "11":    identificationTabOrder = "1";    break;
+												    case "15":    identificationTabOrder = "2";    break;
+												    case "14":    identificationTabOrder = "3";    break;
+												    case "13":    identificationTabOrder = "4";    break;
+												}
+
 												<c:if test="${projectInfo.targetName eq 'identification' || projectInfo.targetName eq 'partner'}">
 												successMsg += '<br>(<spring:message code="msg.project.entered.first.tab" />)';
 												</c:if>
-												
+
+												/**
+												 * reload identication tab you're working on
+												 */
+												opener.location.href = `/project/identification/\${rowdata["refPrjId"]}/\${identificationTabOrder}`
 												alertify.success(successMsg, 5); // 5sec동안 message 출력
-												opener.location.reload();
 											}
 											
 											$('#loading_wrap_popup').hide();


### PR DESCRIPTION
Signed-off-by: Dongwon Kim [freshtuna@kakao.com](mailto:freshtuna@kakao.com)

## Description
1. This PR modify reloaded identification tab after 'change license' or 'change nickname' to you're working on
2. This PR remove 'msg.project.entered.first.tab' message. Because the popup doesn't disappear after clicking change button

## The cause of issue #457 
I think that a behavior (there is a problem of moving to the previous tab after Change License) **is depends on which tab you clicked in Identification column of project**.

Suppose you clicked BOM tab in Identification column. 
1. Identification iframe loaded with BOM tab
3. Change tab to SRC or BIN
4. click 'update OSS name' or 'update OSS license' button, and popup window is created
5. if you  update OSS name or license in popups successfully, it reload Identification tab of BOM regardless of where you're working on(SRC, BIN)

So, I think **The cause of behavior is identification iframe is not refreshed, when tab is changed**. 
As a result, if you  update OSS name or license in popups successfully, it will reload tab you first clicked (to create identificiation iframe).

##  My solution
Not reload (  `opener.location.reload()` ) iframe. 

Modify iframe address directly like `opener.location.href = identification address with tab you're working on`
using **referenceDiv** variable.

## After code modification
**Identification iframe loaded with SRC tab**
![스크린샷 2022-07-13 오후 12 26 27](https://user-images.githubusercontent.com/33149791/178646498-a7a5bcde-4762-4c19-94c1-f7514bfcb413.png)

**Change tab SRC to BIN and save and click 'update OSS license' button**
<img src="https://user-images.githubusercontent.com/33149791/178647122-a2d77bcd-95c4-40ec-b619-db1e6b392cff.png" alt="drawing" width="400"/>

**Popup window is created and update license**
<img src="https://user-images.githubusercontent.com/33149791/178647355-15d84621-c3b8-4373-b86a-d07641b83dfb.png" alt="drawing" width="400"/>

**After update, current working tab BIN is reloaded.**
<img src="https://user-images.githubusercontent.com/33149791/178647454-2c001670-61db-4644-b290-6cf1dbb74130.png" alt="drawing" width="400"/>

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Comments
Hi, my name is dongwon kim and i interested in backend development using spring.
I researched #457, but i think this solution may not be best. 
And my english is not good 😢, may be hard to understand about my request.
So, I welcome any opinions and questions with my request. thanks🙏









