### PR TITLE
Show "Double click" when mouse hovers on project name

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
@@ -996,7 +996,9 @@
 		}, changeDivisionCancel : function(){
 			$("#changeDivisionPop select[name=division] option").remove();
 			$('#changeDivisionPop').hide();
-		}
+		}, toolTipDoubleclick: function () {
+                    return 'title="' + "Double click" + '"';
+            }
 	};
 	
 	// jqGrid
@@ -1018,7 +1020,7 @@
 				           , 'Vulnera<br/>bility', 'Division', 'Creator', 'Created Date', 'Updated Date', 'Reviewer', 'Additional<br>Information', 'distributionTypeOfCodeDtlExp', 'statusRequestYn', 'priority'],
 				colModel: [
 					{name: 'prjId', index: 'prjId', width: 50, align: 'center', sorttype: 'int'},
-					{name: 'prjName', index: 'prjName', width: 200, align: 'left'},
+					{name: 'prjName', index: 'prjName', width: 200, align: 'left',cellattr:fn.toolTipDoubleclick},
 					{name: 'prjVersion', index: 'prjVersion', width: 50, align: 'left',hidden:true},
 					{name: 'status', index: 'status', width: 50, align: 'center', formatter: fn.displayStatus, unformatter: fn.unformatter, cellattr: fn.cellattrStatus, sortable : true},
 					{name: 'identificationStatus', index: 'identificationStatus', width: 200, align: 'left', formatter: fn.displayIdentification, unformatter: fn.unformatter, sortable : true, title:false},


### PR DESCRIPTION
## Description
<!-- 
 -->
If user hover the mouse over the 'project name' in the 'project list', show tooltip text "Double click"
![projectName mouse hoverd, show Double Click](https://user-images.githubusercontent.com/91003734/179013483-6dd22307-1884-47ed-83b4-cf0f58382a8f.PNG)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
