### PR TITLE
Fix comment in Self-check to remove newline

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
@@ -829,15 +829,15 @@
 
             switch(value){
                 case "1":
-                    $('.checksrcR1').show();
-                    $('.check2').hide();
+                    $('.checksrcR1').closest('span').show();
+                    $('.check2').closest('span').hide();
                     $('.uploadSet').show();
                     $('.wgetUrl').hide();
                     srcUploadUrl.checked = false;
                     break;
                 case "2":
-                    $('.checksrcR1').hide();
-                    $('.check2').show();
+                    $('.checksrcR1').closest('span').hide();
+                    $('.check2').closest('span').show();
                     $('.uploadSet').hide();
                     $('#wgetUrl_' + key).show();
                     srcR1.checked = false;

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
@@ -92,7 +92,7 @@
 								<div class="basicCase">
 									<div class="uploadTitCheckSet">
 										<span class="checkSet"><label class="checksrcR1">Please select a file to upload</label></span>
-										<span class="checkSet"><label class="check2" style="display:none;">Enter the link of the source to be analyzed</label></span>
+										<span class="checkSet" style="display:none;"><label class="check2">Enter the link of the source to be analyzed</label></span>
 									</div>
 									<div class="uploadGroup">
 										<div class="uploadSet">


### PR DESCRIPTION
Signed-off-by: Daeeun Ko <7273322@naver.com>

## Description
This PR removes newline in Self-check comment.

### As Is
![image](https://user-images.githubusercontent.com/27201209/179671958-48777e48-3bd7-4424-98a4-f91c13e077a4.png)

### To Be
![image](https://user-images.githubusercontent.com/27201209/179674058-4a08c107-4a4c-4a2f-b202-da0516ca4cc1.png)

## The cause of issue
If user click the radio button, comment(span.checkSet > label) element's display is changed. But checkSet element(span.checkSet) is still there. And the checkSet elemnet have a padding(padding-right:5px;). It causes unnecessary space.
![image](https://user-images.githubusercontent.com/27201209/179683456-9822bfae-6019-4fe6-932f-bd625b3dd4ed.png)

## Changes
1. Modify the targets that are changed by radio button. label ➡ .checkSet
2. Move display style(display: none;) label to checkSet

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
