### PR TITLE
Add a flag to use the license's internal url

### DIFF
--- a/db/initdb.d/fosslight_create.sql
+++ b/db/initdb.d/fosslight_create.sql
@@ -2380,6 +2380,7 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('909', '940', 'External Service Flag', '', 'N', 5, 'Y'),
 	('909', '950', 'External Analysis Flag', '', 'N', 6, 'Y'),
 	('909', '960', 'Hide email in user list', '', 'N', 7, 'Y'),
+	('909', '970', 'Use license internal url', '', 'N', 8, 'N'),
 	('910', '100', 'Provider Url', '', '', 1, 'Y'),
 	('911', '100', 'Mail Server', '', '', 100, 'Y'),
 	('911', '101', 'Email Address', '', '', 101, 'Y'),

--- a/src/main/java/oss/fosslight/common/CoConstDef.java
+++ b/src/main/java/oss/fosslight/common/CoConstDef.java
@@ -147,7 +147,8 @@ public class CoConstDef {
 	public static final String CD_NOTICE_HTML_STR				= "HTML";
 	public static final String CD_DTL_NOTICE_HTML				= "100";
 	public static final String CD_DTL_NOTICE_TEXT				= "101";
-	public static final String CD_DTL_NOTICE_SPDX				= "102";	
+	public static final String CD_DTL_NOTICE_SPDX				= "102";
+	public static final String CD_NOTICE_INTERNAL_URL			= "970";
 	
 	/** System Setting Code List End */
 	

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -2656,16 +2656,18 @@ public class CommonFunction extends CoTopComponent {
 			
 			if(!isEmpty(licenseName)) {
 				String fileName = licenseName.replaceAll(" ", "_").replaceAll("/", "_") + ".html";
-				
-				if(distributionFlag) {
+				boolean DEFAULT_URL_FLAG = !CoConstDef.FLAG_YES.equals(CoCodeManager.getCodeExpString(CoConstDef.CD_SYSTEM_SETTING, CoConstDef.CD_NOTICE_INTERNAL_URL));
+				if (DEFAULT_URL_FLAG) {
+					return licenseMaster.getWebpage();
+				} else if (distributionFlag) {
 					String distributeUrl = CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTE_CODE, CoConstDef.CD_DTL_DISTRIBUTE_LGE);
 					distributeUrl += filePath + "/" + fileName;
-					
+
 					return distributeUrl;
 				} else {
 					String domain = licenseMaster.getDomain();
 					String fileUrl = domain + filePath + "/" + fileName;
-					
+
 					return fileUrl;
 				}
 			}

--- a/src/main/webapp/WEB-INF/views/admin/license/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/license/edit.jsp
@@ -94,11 +94,14 @@
 								<input id="webpageAdd" type="button" value="+ Add" class="btnCLight gray" />
 							</td>
 						</tr>
-						<c:if test="${not empty licenseInfo.internalUrl}">
-						<tr>
-							<th class="dCase"><spring:message code="msg.common.field.internalURL" /></th>
-							<td class="dCase"><a href="${licenseInfo.internalUrl}" target="_blank">${licenseInfo.internalUrl}</a></td>
-						</tr>
+						<c:if test="${ct:getCodeExpString(ct:getConstDef('CD_SYSTEM_SETTING'), ct:getConstDef('CD_NOTICE_INTERNAL_URL')) eq 'Y'}">
+							<c:if test="${not empty licenseInfo.internalUrl}">
+								<tr>
+									<th class="dCase"><spring:message code="msg.common.field.internalURL"/></th>
+									<td class="dCase"><a href="${licenseInfo.internalUrl}"
+														 target="_blank">${licenseInfo.internalUrl}</a></td>
+								</tr>
+							</c:if>
 						</c:if>
 						<tr>
 							<th class="dCase"><spring:message code="msg.common.field.userGuide" /></th>


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
### Add a flag to use the license's internal url.
If you need to output the url of the license (ex. Simple NOTICE issuance), the website value is output.
However, if this flag is `Y`, the `internal url `is output instead of the license `website`.
![image](https://user-images.githubusercontent.com/4284712/179751678-5c3ebf39-6728-4466-b9da-0fc2e5757d62.png)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
