### PR TITLE
Make it search even if space is included at the beginning and end of the word in the OSS List

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/oss/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/list-js.jsp
@@ -36,20 +36,29 @@
 			$('select[name=modifier]').val('${searchBean.modifier}').trigger('change');
 			
 			initParam = serializeObjectHelper();
-			
+
 			var defaultSearchFlag = "${searchBean.defaultSearchFlag}";
 			if(defaultSearchFlag != 'Y') {
 				// just make grid ui
 				initParam.ignoreSearchFlag = "Y";
 			}
-			
+
 			$('#search').on('click',function(e){
 				e.preventDefault();
-				
+
+				var searchOSSName = $("input[type=text][name=ossName]").val();
+				$("input[type=text][name=ossName]").val(searchOSSName.trim());
+
+				var searchLicenseName = $("input[type=text][name=licenseName]").val();
+				$("input[type=text][name=licenseName]").val(searchLicenseName.trim());
+
+				var searchHomepage = $("input[type=text][name=homepage]").val();
+				$("input[type=text][name=homepage]").val(searchHomepage.trim());
+
 				var postData = serializeObjectHelper();
 				postData.ignoreSearchFlag = "N";
 				$("#list").jqGrid('setGridParam', {postData:postData, page : 1}).trigger('reloadGrid');
-				
+
 			});
 			
 			$(".cal").on("keyup", function(e){


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
### Changes
In the **OSS List**, even if a space is included at the beginning and end of `Homepage`, `OSS Name`, and `License Name`, make it searchable.

#### Problem
If there is a space before or after a word, the search is not performed properly.

https://user-images.githubusercontent.com/33304982/180017622-55ca4555-7c01-4d3c-ae44-c65710ebe227.mp4



#### Solve
I used a function 'trim()' to remove a space before or after a word


https://user-images.githubusercontent.com/33304982/180018497-957fb694-896a-479d-a2e9-cd6899c75846.mp4


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
