### PR TITLE
Hide user email as per option

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/system/user-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/system/user-js.jsp
@@ -254,7 +254,7 @@
 					records:function(obj){return obj.records;}
 				}
 				, colNames: ['AD ID',
-					<c:if test="${ct:getCodeExpString(ct:getConstDef('CD_SYSTEM_SETTING'), ct:getConstDef('CD_HIDE_EMAIL_FLAG')) eq 'N'}">
+					<c:if test="${ct:getCodeExpString(ct:getConstDef('CD_SYSTEM_SETTING'), ct:getConstDef('CD_HIDE_EMAIL_FLAG')) ne 'Y'}">
 					'E-mail',
 					</c:if>
 					'Name', 'Division', 'Registered Date', 'Token', 'Expire Date', 'Token Proc'
@@ -264,7 +264,7 @@
 					, 'Use YN', 'Admin']
 				, colModel: [
 					{name: 'userId', index: 'userId', width: 150, allign: 'center'},
-					<c:if test="${ct:getCodeExpString(ct:getConstDef('CD_SYSTEM_SETTING'), ct:getConstDef('CD_HIDE_EMAIL_FLAG')) eq 'N'}">
+					<c:if test="${ct:getCodeExpString(ct:getConstDef('CD_SYSTEM_SETTING'), ct:getConstDef('CD_HIDE_EMAIL_FLAG')) ne 'Y'}">
 					    {name: 'email', index: 'email', width: 200, allign: 'center'},
 					</c:if>
 					{name: 'userName', index: 'userName', width: 100, allign: 'center', editable: true},


### PR DESCRIPTION
Signed-off-by: Han Min <hm5395@naver.com>

## Description
<!-- 
Please describe what this PR do.
 -->
### Problem
When the value of CD_DTL_EXP is null or Y, the email is hidden.
but I want the email to be hidden Only when CD_DTL_EXP is Y.
![스크린샷 2022-07-22 오전 2 46 48](https://user-images.githubusercontent.com/33304982/180282147-a5781580-4205-4fe9-bf6f-dff0658a924f.png)
<img width="1487" alt="스크린샷 2022-07-22 오전 2 47 00" src="https://user-images.githubusercontent.com/33304982/180282191-bf1a59c5-e944-4ff6-b3e3-9eec41d45ebc.png">


### Solve
I solved the problem using 'ne' function.
so when CD_DTL_EXP is null, admin can see emails.
![스크린샷 2022-07-22 오전 2 46 48](https://user-images.githubusercontent.com/33304982/180282234-dd04b13f-8fd5-4093-9b2f-6ceb123bc77f.png)
<img width="1482" alt="스크린샷 2022-07-22 오전 2 47 56" src="https://user-images.githubusercontent.com/33304982/180282246-7558ed9a-e207-4310-985a-8b27f68aa73b.png">



## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
