### PR TITLE
Fix bugs that do not run with docker-compose on Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN chmod +x /app/wait-for
 RUN chmod +x /app/verify/verify
 
 RUN apt-get update && apt-get install -y netcat
+RUN ln -s /bin/sh bash
 WORKDIR /app
 
 CMD ["java" , "-jar", "FOSSLight.war", "--root.dir=/data/fosslight", "--server.port=8180"]

--- a/db/wait-for
+++ b/db/wait-for
@@ -22,6 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+VERSION="2.2.3"
+
 set -- "$@" -- "$TIMEOUT" "$QUIET" "$PROTOCOL" "$HOST" "$PORT" "$result"
 TIMEOUT=15
 QUIET=0
@@ -39,6 +41,7 @@ Usage:
   $0 host:port|url [-t timeout] [-- command args]
   -q | --quiet                        Do not output any status messages
   -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -v | --version                      Show the version of this tool
   -- COMMAND ARGS                     Execute command with args after the test finishes
 USAGE
   exit "$exitcode"
@@ -52,13 +55,15 @@ wait_for() {
         exit 1
       fi
       ;;
-    wget)
+    http)
       if ! command -v wget >/dev/null; then
-        echoerr 'nc command is missing!'
+        echoerr 'wget command is missing!'
         exit 1
       fi
       ;;
   esac
+
+  TIMEOUT_END=$(($(date +%s) + TIMEOUT))
 
   while :; do
     case "$PROTOCOL" in
@@ -91,15 +96,13 @@ wait_for() {
       exit 0
     fi
 
-    if [ "$TIMEOUT" -le 0 ]; then
-      break
+    if [ $TIMEOUT -ne 0 -a $(date +%s) -ge $TIMEOUT_END ]; then
+      echo "Operation timed out" >&2
+      exit 1
     fi
-    TIMEOUT=$((TIMEOUT - 1))
 
     sleep 1
   done
-  echo "Operation timed out" >&2
-  exit 1
 }
 
 while :; do
@@ -113,6 +116,10 @@ while :; do
     HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
     PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
     shift 1
+    ;;
+    -v | --version)
+    echo $VERSION
+    exit
     ;;
     -q | --quiet)
     QUIET=1


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Fix bugs that do not run with docker-compose on Windows. 
- Update [wait-for](https://github.com/eficode/wait-for) to 2.2.3

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
