### PR TITLE
Add priority to the status tooltip of the Project List

### DIFF
--- a/src/main/resources/static/css/commonIframe.css
+++ b/src/main/resources/static/css/commonIframe.css
@@ -300,7 +300,7 @@ input.btnCLightAnalysis {height:20px;padding-bottom:1px;line-height:auto;}
 .iconSet.nick.dummy {width:25px;height:12px;background-position:-265px -170px;vertical-align:middle;} /* 20161025 by sw-yun empty */
 .iconSet.trd {width:28px;height:16px;background-position:right -60px;vertical-align:middle;} /* 2018-06-12 by mj-cho */
 .iconSt.drop {background-color:#a39d9b;background-position:-155px -225px;} /* 2021-01-26 */
-.priority {display:inline-block;width:15px;height:15px;background:red;}
+.priority {display:inline-block;width:15px;height:15px;}
 .priority.priority_1 {background:#FEAEC9;}
 .priority.priority_2 {background:#FFFCB7;}
 /*

--- a/src/main/resources/static/css/commonIframe.css
+++ b/src/main/resources/static/css/commonIframe.css
@@ -299,7 +299,10 @@ input.btnCLightAnalysis {height:20px;padding-bottom:1px;line-height:auto;}
 .iconSet.nick {width:25px;height:12px;background-position:-215px -150px;vertical-align:middle;} /* 20161025 by mj-cho */
 .iconSet.nick.dummy {width:25px;height:12px;background-position:-265px -170px;vertical-align:middle;} /* 20161025 by sw-yun empty */
 .iconSet.trd {width:28px;height:16px;background-position:right -60px;vertical-align:middle;} /* 2018-06-12 by mj-cho */
-.iconSt.drop {background-color:#a39d9b;background-position:-155px -225px;} /* 2021-01-26 */ 
+.iconSt.drop {background-color:#a39d9b;background-position:-155px -225px;} /* 2021-01-26 */
+.priority {display:inline-block;width:15px;height:15px;background:red;}
+.priority.priority_1 {background:#FEAEC9;}
+.priority.priority_2 {background:#FFFCB7;}
 /*
 .iconSt {display:inline-block;width:15px;height:15px;line-height:1000%;font-size:0;overflow:hidden;border:1px solid;border-radius:20px;}
 .iconSt.draft {border-color:#c0ad10;background:#fce41a;}

--- a/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
@@ -963,7 +963,7 @@
 			var chk = $("#list").jqGrid("getGridParam", "selarrrow").length;
 
 			if(chk > 0){
-				$("#changeDivisionSelect").find("strong").text($("#changeDivisionPop select[name=division] option:first").text());
+				$(".selectSet").find("strong").text($("#changeDivisionPop select[name=division] option:first").text());
 				$("#changeDivisionPop").show();
 			} else {
 				alertify.alert('<spring:message code="msg.project.watcher.selectlist" />', function(){});

--- a/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
@@ -38,10 +38,10 @@
 	                   +"<dl><dt><span class=\"iconSt request\">Request</span>Request</dt></dl><br>"
 	                   +"<dl><dt><span class=\"iconSt review\">Review</span>Review</dt></dl><br>"
 	                   +"<dl><dt><span class=\"iconSt complete\">Complete</span>Complete</dt></dl><br>"
-	                   +"<dl><dt><span class=\"iconSt drop\">Drop</span>Drop</dt></dl><br>" 
-                       +"<dl><dt><span class=\"priority priority_1\"></span>Priority1</dt></dl><br>"
-                       +"<dl><dt><span class=\"priority priority_2\"></span>Priority2</dt></dl><br>"
-	                   +"</div>",
+	                   +"<dl><dt><span class=\"iconSt drop\">Drop</span>Drop</dt></dl><br>"
+					   +"<dl><dt><span class=\"priority priority_1\"></span>Priority1</dt></dl><br>"
+					   +"<dl><dt><span class=\"priority priority_2\"></span>Priority2</dt></dl><br>"
+					   +"</div>",
 	    tooltipCont1 : "<div class=\"tooltipData\">"
 		               +"<dl><dt><span class=\"downSet btnReport\">FOSSLight Report</span>FOSSLight Report</dt></dl><br>"
 		               +"<dl><dt><span class=\"downSet btnNotice\">OSS Notice</span>OSS Notice</dt></dl><br>"
@@ -963,7 +963,7 @@
 			var chk = $("#list").jqGrid("getGridParam", "selarrrow").length;
 
 			if(chk > 0){
-				$(".selectSet").find("strong").text($("#changeDivisionPop select[name=division] option:first").text());
+				$("#changeDivisionSelect").find("strong").text($("#changeDivisionPop select[name=division] option:first").text());
 				$("#changeDivisionPop").show();
 			} else {
 				alertify.alert('<spring:message code="msg.project.watcher.selectlist" />', function(){});

--- a/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
@@ -39,9 +39,9 @@
 	                   +"<dl><dt><span class=\"iconSt review\">Review</span>Review</dt></dl><br>"
 	                   +"<dl><dt><span class=\"iconSt complete\">Complete</span>Complete</dt></dl><br>"
 	                   +"<dl><dt><span class=\"iconSt drop\">Drop</span>Drop</dt></dl><br>"
-					   +"<dl><dt><span class=\"priority priority_1\"></span>Priority1</dt></dl><br>"
-					   +"<dl><dt><span class=\"priority priority_2\"></span>Priority2</dt></dl><br>"
-					   +"</div>",
+	                   +"<dl><dt><span class=\"priority priority_1\"></span>Priority1</dt></dl><br>"
+	                   +"<dl><dt><span class=\"priority priority_2\"></span>Priority2</dt></dl><br>"
+	                   +"</div>",
 	    tooltipCont1 : "<div class=\"tooltipData\">"
 		               +"<dl><dt><span class=\"downSet btnReport\">FOSSLight Report</span>FOSSLight Report</dt></dl><br>"
 		               +"<dl><dt><span class=\"downSet btnNotice\">OSS Notice</span>OSS Notice</dt></dl><br>"

--- a/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/list-js.jsp
@@ -38,7 +38,9 @@
 	                   +"<dl><dt><span class=\"iconSt request\">Request</span>Request</dt></dl><br>"
 	                   +"<dl><dt><span class=\"iconSt review\">Review</span>Review</dt></dl><br>"
 	                   +"<dl><dt><span class=\"iconSt complete\">Complete</span>Complete</dt></dl><br>"
-	                   +"<dl><dt><span class=\"iconSt drop\">Drop</span>Drop</dt></dl><br>"
+	                   +"<dl><dt><span class=\"iconSt drop\">Drop</span>Drop</dt></dl><br>" 
+                       +"<dl><dt><span class=\"priority priority_1\"></span>Priority1</dt></dl><br>"
+                       +"<dl><dt><span class=\"priority priority_2\"></span>Priority2</dt></dl><br>"
 	                   +"</div>",
 	    tooltipCont1 : "<div class=\"tooltipData\">"
 		               +"<dl><dt><span class=\"downSet btnReport\">FOSSLight Report</span>FOSSLight Report</dt></dl><br>"


### PR DESCRIPTION
## Description
The project list shows priority through the background color of Status column.
Red means Priority1, and yellow means Priority2.
However, it was impossible to know the meaning of these colors.
So I added the information of each color in the tooltip.
(Related issue: https://github.com/fosslight/fosslight/issues/581)

![image](https://user-images.githubusercontent.com/98736689/180949733-4c3da93e-c968-46c7-9bdd-d1102e357761.png)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
