### PR TITLE
Increase the length of the name field 

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/partner/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/edit.jsp
@@ -230,7 +230,7 @@
 										${ct:genOption(ct:getConstDef("CD_USER_DIVISION"))}
 									</select>
 								</span>
-								<span class="selectSet w220">
+								<span class="selectSet w350">
 									<strong for="userName" title="selected value">Select User</strong>
 									<select id="userName">
 									</select>
@@ -252,7 +252,7 @@
 									</c:when>
 									<c:otherwise>
 										<span class="pd5">@</span>
-										<input type="text" id="emailTemp" style="width:196px !important" value="" onKeypress="fn.CheckChar()"  placeholder="Input your Email Domain" />
+										<input type="text" id="emailTemp" style="width:326px !important" value="" onKeypress="fn.CheckChar()"  placeholder="Input your Email Domain" />
 									</c:otherwise>
 								</c:choose>
 								<input id="addEmail" type="button" value="+ Add" class="btnCLight gray" />
@@ -271,7 +271,7 @@
 										</c:if>
 									</select>
 								</span>
-								<span><input type="text" id="listId" name="listId" style="width:220px" placeholder="Input ID you want to copy"/></span>
+								<span><input type="text" id="listId" name="listId" style="width:350px" placeholder="Input ID you want to copy"/></span>
 								<input id="addList" type="button" value="+ Add" class="btnCLight gray" />
 							</div>
 							<div class="multiTxtSet2" id="nameSpace">
@@ -298,7 +298,7 @@
 							<th class="dCase txStr"><spring:message code="msg.common.field.creator" /></th>
 							<td class="dCase">
 								<div class="required">
-									<input type="text" name="creatorNm" class="autoComCreatorDivision w350" value="" ${(ct:isAdmin() and detail.status ne 'CONF') ? '' : 'disabled="disabled"'} />
+									<input type="text" name="creatorNm" class="autoComCreatorDivision w600" value="" ${(ct:isAdmin() and detail.status ne 'CONF') ? '' : 'disabled="disabled"'} />
 									<input type="hidden" name="creator" <c:if test="${not empty detail }">value='${detail.creator}'</c:if>/>
 									<span class="retxt">This field is required.</span>
 								</div>
@@ -308,7 +308,7 @@
 							<th class="dCase txStr"><spring:message code="msg.common.field.division" /></th>
 							<td class="dCase">
 								<div class="pb5">
-									<span class="selectSet w350">
+									<span class="selectSet w600">
 										<strong for="division" title="Watcher part selected value">Select Division</strong>
 										<select id="division" name="division" ${ct:isAdmin() ? '' : 'disabled="disabled"'} >
 											<option value=""></option>
@@ -322,7 +322,7 @@
                             <th class="dCase  txStr"><spring:message code="msg.common.field.reviewer" /></th>
                             <td class="dCase">
                                 <div class="required">
-                                    <input type="text" name="reviewerName" class="w350" value="${detail.reviewerName}" disabled="disabled"/>
+                                    <input type="text" name="reviewerName" class="w600" value="${detail.reviewerName}" disabled="disabled"/>
                                 </div>
                             </td>
                         </tr>


### PR DESCRIPTION
## Description
3rd Party's Basic Information > Increase the length of the name field. (Realated issue: #460 )

The requirements were:
- In the Watcher column, increase the length of the red box below to the size of the green box.
- Increase the length of the Creator and Reviewer by the red box.

But, I don't know the exact size of the box. 
SoI arbitrarily increased the size of the boxes

#### AS-IS
![image](https://user-images.githubusercontent.com/26705587/181473076-8ef2a09e-7c7f-4a06-ba9f-d99b5e76be6d.png)
![image](https://user-images.githubusercontent.com/26705587/181473262-7bddbd4d-596f-494d-be94-2cfc1904cec5.png)

#### TO-BE
![image](https://user-images.githubusercontent.com/26705587/181474800-0d2311fb-66fb-4df0-88a9-e00f66ef78b7.png)
![image](https://user-images.githubusercontent.com/26705587/181479666-900ae215-861c-495a-8dba-d525c2d1e358.png)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [X] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
