### PR TITLE
Remove version diff notification popup when deleting OSS

### DIFF
--- a/src/main/java/oss/fosslight/validation/custom/T2CoOssValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoOssValidator.java
@@ -436,7 +436,7 @@ public class T2CoOssValidator extends T2CoValidator {
 					}
 					
 					param.setDownloadLocation(location.trim());
-					Map<String, Object> paramMap = ossService.checkExistsOssDownloadLocationWithOssName(param);
+					Map<String, Object> paramMap = ossService.checkExistsOssDownloadLocation(param);
 					List<OssMaster> list = (List<OssMaster>) paramMap.get("downloadLocation");
 					
 					if(list != null && !list.isEmpty()) {
@@ -467,7 +467,7 @@ public class T2CoOssValidator extends T2CoValidator {
 				}
 				
 				param.setHomepage(ossBean.getHomepage().trim());
-				Map<String, Object> paramMap = ossService.checkExistsOssHomepageWithOssName(param);
+				Map<String, Object> paramMap = ossService.checkExistsOssHomepage(param);
 				List<OssMaster> list = (List<OssMaster>) paramMap.get("homepage");
 				
 				if(list != null && !list.isEmpty()) {
@@ -640,7 +640,7 @@ public class T2CoOssValidator extends T2CoValidator {
 					}
 					
 					param.setDownloadLocation(location.trim());
-					Map<String, Object> paramMap = ossService.checkExistsOssDownloadLocationWithOssName(param);
+					Map<String, Object> paramMap = ossService.checkExistsOssDownloadLocation(param);
 					List<OssMaster> list = (List<OssMaster>) paramMap.get("downloadLocation");
 					
 					if(list != null && !list.isEmpty()) {
@@ -673,7 +673,7 @@ public class T2CoOssValidator extends T2CoValidator {
 				}
 				
 				param.setHomepage(analysisBean.getHomepage().trim());
-				Map<String, Object> paramMap = ossService.checkExistsOssHomepageWithOssName(param);
+				Map<String, Object> paramMap = ossService.checkExistsOssHomepage(param);
 				List<OssMaster> list = (List<OssMaster>) paramMap.get("homepage");
 				
 				if(list != null && !list.isEmpty()) {

--- a/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
@@ -1685,17 +1685,10 @@
 		} else if(json.isValid == 'true') {
 			var v_flag = checkVdiff();
 
-			if(v_flag == "Y"){
-				alertify.confirm('<spring:message code="msg.oss.confirm.ossVersion" />', function (e) {
-					if (e) {
-						checkExistOssConf();
-					} else {
-						return false;
-					}
-				});
-			}else if(v_flag == ""){
+			if(v_flag == ""){
 				alertify.error('<spring:message code="msg.common.valid2" />', 0);
 				return;
+				
 			}else{
 				checkExistOssConf();
 			}


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Remove version diff notification popup when deleting OSS.
- Fix the bug where the "OSS With similar link already exists" message, which compares the Homepage/Download location created in OSS with the one stored in OSS, is displayed even for links that are not similar.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
