### PR TITLE
Caching Dependencies to speed up workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -73,6 +73,9 @@ jobs:
         with:
           time: '30s'
 
+      - name: Grant permission for db data
+        run: sudo chmod -R 755 db/data/
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -74,13 +74,14 @@ jobs:
           time: '30s'
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
- 
+          cache: gradle
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
- 
+
       - name: Test with Gradle
         run: ./gradlew --info test
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -76,9 +76,9 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 11
-          distribution: temurin
-          cache: gradle
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: adopt
           cache: gradle
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: adopt
+          distribution: temurin
           cache: gradle
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,7 +63,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build the stack
         run: docker-compose up -d db

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -43,10 +43,10 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: 11
-        distribution: temurin
-        cache: gradle
-        
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'gradle'
+
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: 11
-        distribution: adopt
+        distribution: temurin
         cache: gradle
         
     - name: Grant execute permission for gradlew

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -38,7 +38,7 @@ jobs:
     needs: update-changelog
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
         
     - name: Set up JDK 11
       uses: actions/setup-java@v3

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -41,17 +41,18 @@ jobs:
     - uses: actions/checkout@v2
         
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: 11
+        distribution: adopt
+        cache: gradle
         
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       
     - name: Build with Gradle
       run: ./gradlew build --exclude-task test
-         
+
     - name: Rename package
       run: mv build/libs/FOSSLight*.war FOSSLight.war
       


### PR DESCRIPTION
Signed-off-by: jongwooo <han980817@gmail.com>
Issue #605 

## Description
I updated workflows to apply **dependency caching**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Java projects can run faster on GitHub Actions by enabling dependency caching on the [setup-java](https://github.com/actions/setup-java) action. `setup-java` supports caching for both Gradle and Maven projects.

The following example enables caching for a Java project with Gradle:

```yaml
steps:
- uses: actions/checkout@v3
- uses: actions/setup-java@v3
  with:
    java-version: '11'
    distribution: 'temurin'
    cache: 'gradle'
- run: ./gradlew build
```

> It’s literally a one line change to pass the`cache: gradle` input parameter.

## References
[actions/setup-java#caching-packages-dependencies](https://github.com/actions/setup-java#caching-packages-dependencies)
[How to build Gradle projects with GitHub Actions](https://tomgregory.com/build-gradle-projects-with-github-actions/#5_Enable_Gradle_caching)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
