### PR TITLE
Increase the length of the project's name field

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/project/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/edit.jsp
@@ -244,7 +244,7 @@
 											${ct:genOption(ct:getConstDef("CD_USER_DIVISION"))}
 										</select>
 									</span>
-									<span class="selectSet w220">
+									<span class="selectSet w350">
 										<strong for="prjUserId" title="Watcher name selected value">Select User</strong>
 										<select id="prjUserId" name="prjUserId">
 										</select>
@@ -267,7 +267,7 @@
 										</c:when>
 										<c:otherwise>
 											<span class="pd5">@</span>
-											<input type="text" id="emailTemp" style="width:196px !important" value="" onKeypress="fn.CheckChar()"  placeholder="Input your Email Domain" />
+											<input type="text" id="emailTemp" style="width:326px !important" value="" onKeypress="fn.CheckChar()"  placeholder="Input your Email Domain" />
 										</c:otherwise>
 									</c:choose>
 									<input id="addEmail" type="button" value="+ Add" class="btnCLight gray" />
@@ -286,7 +286,7 @@
 											</c:if>											
 										</select>
 									</span>
-									<span><input type="text" id="listId" name="listId" style="width:220px" placeholder="Input ID you want to copy"/></span>
+									<span><input type="text" id="listId" name="listId" style="width:350px" placeholder="Input ID you want to copy"/></span>
 									<input id="addList" type="button" value="+ Add" class="btnCLight gray" />
 								</div>
 								<div id="multiDiv" class="multiTxtSet2">
@@ -300,7 +300,7 @@
 							<th class="dCase  txStr"><spring:message code="msg.common.field.creator" /></th>
 							<td class="dCase">
 								<div class="required">
-									<input type="text" name="creatorNm" class="autoComCreatorDivision w350" value="" ${ct:isAdmin() ? '' : 'disabled="disabled"'} />
+									<input type="text" name="creatorNm" class="autoComCreatorDivision w600" value="" ${ct:isAdmin() ? '' : 'disabled="disabled"'} />
 									<span class="retxt">This field is required.</span>
 									<input type="hidden" name="creator" <c:if test="${not empty project }">value='${project.creator}'</c:if>/>
 								</div>
@@ -324,7 +324,7 @@
                             <th class="dCase  txStr"><spring:message code="msg.common.field.reviewer" /></th>
                             <td class="dCase">
                                 <div class="required">
-                                    <input type="text" name="reviewer" class="w350" value="${project.reviewerName}" disabled="disabled"/>
+                                    <input type="text" name="reviewer" class="w600" value="${project.reviewerName}" disabled="disabled"/>
                                 </div>
                             </td>
                         </tr>


### PR DESCRIPTION
Signed-off-by: Han Min <hm5395@naver.com>

## Description
<!-- 
Please describe what this PR do.
 -->
Requirement:
1. In the Watcher column, increase the length of the red box below to the size of the green box.
2. Increase the length of the Creator and Reviewer by the red box.

### Before
![스크린샷 2022-07-30 오후 9 38 54](https://user-images.githubusercontent.com/33304982/181914876-67d5dfaf-bbe1-48a1-8a18-2d82860ba389.png)

### After
I have increased the size of the name field than before.
![스크린샷 2022-07-30 오후 9 39 15](https://user-images.githubusercontent.com/33304982/181914897-ee4c4d3e-7786-4546-b9a4-63d2667d2f6a.png)




## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
