### PR TITLE
Show the user's name, when Mouse hover

### DIFF
--- a/src/main/webapp/WEB-INF/views/template/layout/admin/header.jsp
+++ b/src/main/webapp/WEB-INF/views/template/layout/admin/header.jsp
@@ -34,7 +34,7 @@
 		</div>
 		<div class="userLogout">
 			<input type="hidden" id="defaultTabAnchorArr" value="${sessUserInfo.defaultTabAnchor}" />
-			<span class="configurationSpan"><a href="#<c:url value="/configuration/edit"/>" class="add-tab" title="User Settings"><span><img src="${ctxPath}/images/settings.png" alt="FOSSLight Hub" width="14" height="14" /></span>&nbsp;&nbsp;${sessUserInfo.userName}</a></span>
+			<span class="configurationSpan"><a href="#<c:url value="/configuration/edit"/>" class="add-tab" title="${sessUserInfo.userName}"><span><img src="${ctxPath}/images/settings.png" alt="FOSSLight Hub" width="14" height="14" /></span>&nbsp;&nbsp;${sessUserInfo.userName}</a></span>
 			<span class="userLogoutSpan"><a href="<c:url value="/session/logout-proc"/>" class="userLogoutA">Logout</a></span>
 			<p style="margin-top: 20px;"><marquee behavior="scroll" direction="left">${ct:getCodeExpString(ct:getConstDef('CD_MARQUEE'), ct:getConstDef('CD_DTL_CONTENTS'))}</marquee></p>
 		</div>


### PR DESCRIPTION
## Description
#### Related issue: #458
#### Requirement:
when user mouse hover over the name at the top of the left menu, show the user's name instead of User Settings.

#### AS-IS
![image](https://user-images.githubusercontent.com/26705587/182015279-3d982c18-ad8c-4452-b188-e7a001feb1b8.png)

#### TO-BE
![image](https://user-images.githubusercontent.com/26705587/182015264-fca163e2-4793-440a-a097-7f1f1022232c.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
