### PR TITLE
Add project bom tab export json to the API

### DIFF
--- a/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
@@ -478,6 +478,40 @@ public class ApiProjectController extends CoTopComponent {
 			return null;
 		}
 	}
+
+	@ApiOperation(value = "Project Bom Tab Export Json", notes = "Project > Bom tab Export Json")
+	@ApiImplicitParams({
+			@ApiImplicitParam(name = "_token", value = "token", required = true, dataType = "String", paramType = "header")
+	})
+	@GetMapping(value = {API.FOSSLIGHT_API_PROJECT_BOM_EXPORT_JSON})
+	public CommonResult getPrjBomExportJson(
+			@RequestHeader String _token,
+			@ApiParam(value = "Project id", required = true) @RequestParam(required = true) String prjId) {
+
+		T2Users userInfo = userService.checkApiUserAuth(_token);
+		Map<String, Object> resultMap = new HashMap<String, Object>();
+
+		try {
+			List<String> prjIdList = new ArrayList<String>();
+			prjIdList.add(prjId);
+
+			Map<String, Object> paramMap = new HashMap<String, Object>();
+			paramMap.put("userId", userInfo.getUserId());
+			paramMap.put("userRole", userRole(userInfo));
+			paramMap.put("prjId", prjIdList);
+			paramMap.put("distributionType", "normal");
+
+			boolean searchFlag = apiProjectService.existProjectCnt(paramMap);
+
+			if(searchFlag) {
+				resultMap = apiProjectService.getBomExportJson(prjId);
+			}
+			return responseService.getSingleResult(resultMap);
+		} catch (Exception e) {
+			return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
+					, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+		}
+	}
 	
 	@ApiOperation(value = "Project Bom Compare", notes = "Project > Bom tab Compare")
     @ApiImplicitParams({

--- a/src/main/java/oss/fosslight/common/Url.java
+++ b/src/main/java/oss/fosslight/common/Url.java
@@ -746,8 +746,11 @@ public final class Url {
 			public static final String FOSSLIGHT_API_MODEL_UPDATE			= "/model_update";
 			
 			/** API Project BOM Tab Export */
-			public static final String FOSSLIGHT_API_PROJECT_BOM_EXPORT	    = "/prj_bom_export"; 
-			
+			public static final String FOSSLIGHT_API_PROJECT_BOM_EXPORT	    = "/prj_bom_export";
+
+			/** API Project BOM Tab Export JSON*/
+			public static final String FOSSLIGHT_API_PROJECT_BOM_EXPORT_JSON	    = "/prj_bom_export_json";
+
 			/** API BOM COMPARE */
 			public static final String FOSSLIGHT_API_PROJECT_BOM_COMPARE		= "/prj_bom_compare";
 			

--- a/src/main/java/oss/fosslight/service/ApiProjectService.java
+++ b/src/main/java/oss/fosslight/service/ApiProjectService.java
@@ -37,6 +37,8 @@ public interface ApiProjectService {
 	public List<Map<String, Object>> getBomList(String prjId);
 	
 	public List<Map<String, Object>> setMergeGridData(List<Map<String, Object>> list);
+
+	public Map<String, Object> getBomExportJson(String prjId);
 	
 	public Map<String, Object> getBomCompare(List<Map<String, Object>> beforeBomList, List<Map<String, Object>> afterBomList);
 	

--- a/src/main/java/oss/fosslight/util/YamlUtil.java
+++ b/src/main/java/oss/fosslight/util/YamlUtil.java
@@ -155,7 +155,7 @@ public class YamlUtil extends CoTopComponent {
 		return checkYamlFormat(list, "");
 	}
 	
-	private static LinkedHashMap<String, List<Map<String, Object>>> checkYamlFormat(List<ProjectIdentification> list, String typeCode) {
+	public static LinkedHashMap<String, List<Map<String, Object>>> checkYamlFormat(List<ProjectIdentification> list, String typeCode) {
 		LinkedHashMap<String, List<Map<String, Object>>> result = new LinkedHashMap<>();
 		
 		for(ProjectIdentification bean : list) {


### PR DESCRIPTION
Signed-off-by: Dabeen Jeong <hello70825@gmail.com>

## Description
Add project BOM tab export json to the API.  
Json format is the same as adding Vulnerability to the format of the yaml file.
  
![image](https://user-images.githubusercontent.com/79046106/185775498-c26ac148-74a8-486a-a568-6c122bc7a45c.png)

### 

<!-- 
Please describe what this PR do.
 -->


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)