### PR TITLE
Fix the bug where password cannot be set when signing up for non-LDAP

### DIFF
--- a/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
@@ -478,6 +478,40 @@ public class ApiProjectController extends CoTopComponent {
 			return null;
 		}
 	}
+
+	@ApiOperation(value = "Project Bom Tab Export Json", notes = "Project > Bom tab Export Json")
+	@ApiImplicitParams({
+			@ApiImplicitParam(name = "_token", value = "token", required = true, dataType = "String", paramType = "header")
+	})
+	@GetMapping(value = {API.FOSSLIGHT_API_PROJECT_BOM_EXPORT_JSON})
+	public CommonResult getPrjBomExportJson(
+			@RequestHeader String _token,
+			@ApiParam(value = "Project id", required = true) @RequestParam(required = true) String prjId) {
+
+		T2Users userInfo = userService.checkApiUserAuth(_token);
+		Map<String, Object> resultMap = new HashMap<String, Object>();
+
+		try {
+			List<String> prjIdList = new ArrayList<String>();
+			prjIdList.add(prjId);
+
+			Map<String, Object> paramMap = new HashMap<String, Object>();
+			paramMap.put("userId", userInfo.getUserId());
+			paramMap.put("userRole", userRole(userInfo));
+			paramMap.put("prjId", prjIdList);
+			paramMap.put("distributionType", "normal");
+
+			boolean searchFlag = apiProjectService.existProjectCnt(paramMap);
+
+			if(searchFlag) {
+				resultMap = apiProjectService.getBomExportJson(prjId);
+			}
+			return responseService.getSingleResult(resultMap);
+		} catch (Exception e) {
+			return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
+					, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+		}
+	}
 	
 	@ApiOperation(value = "Project Bom Compare", notes = "Project > Bom tab Compare")
     @ApiImplicitParams({

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -4366,7 +4366,7 @@ public class CommonFunction extends CoTopComponent {
 	public static List<ProjectIdentification> identificationUnclearObligationCheck(List<ProjectIdentification> list, Map<String, String> errorCodeMap, Map<String, String> warningCodeMap) {
 		List<String> UNCLEAR_OBLIGATION_CODE_LIST = Arrays.asList(new String[] {
 				"LICENSE_NAME.REQUIRED" ,"LICENSE_NAME.UNCONFIRMED", "LICENSE_NAME.INCLUDE_MULTI_OPERATE", "LICENSE_NAME.NOLICENSE", "LICENSE_NAME.INCLUDE_DUAL_OPERATE"
-				, "OSS_NAME.REQUIRED", "OSS_NAME.UNCONFIRMED", "OSS_VERSION.UNCONFIRMED", "OSS_NAME.DEACTIVATED"
+//				, "OSS_NAME.REQUIRED", "OSS_NAME.UNCONFIRMED", "OSS_VERSION.UNCONFIRMED", "OSS_NAME.DEACTIVATED"
 		}) ;
 		
 		List<String> unclearObligationList = new ArrayList<>();

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -4062,74 +4062,80 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String getDiffItemComment(Project beforeBean, Project afterBean) {
+		return getDiffItemComment(beforeBean, afterBean, false);
+	}
+	
+	public static String getDiffItemComment(Project beforeBean, Project afterBean, boolean booleanFlag) {
 		String comment = "";
 		
-		// Project Name
-		if(!beforeBean.getPrjName().equals(afterBean.getPrjName())) {
-			comment += "<p><strong>Project Name</strong><br />";
-			comment += "Before : " + beforeBean.getPrjName() + "<br />";
-			comment += "After : " + afterBean.getPrjName() + "<br /></p>";
-		}
+		if(booleanFlag) {
+			// Project Name
+			if(!beforeBean.getPrjName().equals(afterBean.getPrjName())) {
+				comment += "<p><strong>Project Name</strong><br />";
+				comment += "Before : " + beforeBean.getPrjName() + "<br />";
+				comment += "After : " + afterBean.getPrjName() + "<br /></p>";
+			}
 
-		// Project Version
-		if(!beforeBean.getPrjVersion().equals(afterBean.getPrjVersion())) {
-			comment += "<p><strong>Project Version</strong><br />";
-			comment += "Before : " + beforeBean.getPrjVersion() + "<br />";
-			comment += "After : " + afterBean.getPrjVersion() + "<br /></p>";
-		}
-		
-		// Operating System
-		if(!beforeBean.getOsType().equals(afterBean.getOsType())) {
-			comment += "<p><strong>Operating System</strong><br />";
-			comment += "Before : " + beforeBean.getOsType() + "<br />";
-			comment += "After : " + afterBean.getOsType() + "<br /></p>";
-		}
-		
-		// Distribution Type
-		if(!beforeBean.getDistributionType().equals(afterBean.getDistributionType())) {
-			comment += "<p><strong>Distribution Type</strong><br />";
-			comment += "Before : " + beforeBean.getDistributionType() + "<br />";
-			comment += "After : " + afterBean.getDistributionType() + "<br /></p>";
-		}
-		
-		
-		if(!beforeBean.getNetworkServerType().equals(afterBean.getNetworkServerType())) {
-			comment += "<p><strong>Network Service only?</strong><br />";
-			comment += "Before : " + beforeBean.getNetworkServerType() + "<br />";
-			comment += "After : " + afterBean.getNetworkServerType() + "<br /></p>";
-		}
-		
-		if(!beforeBean.getDistributeTarget().equals(afterBean.getDistributeTarget())) {
-			comment += "<p><strong>Distribution Site</strong><br />";
-			comment += "Before : " + beforeBean.getDistributeTarget() + "<br />";
-			comment += "After : " + afterBean.getDistributeTarget() + "<br /></p>";
-		}
-		
-		if(!beforeBean.getNoticeType().equals(afterBean.getNoticeType())) {
-			comment += "<p><strong>OSS Notice</strong><br />";
-			comment += "Before : " + beforeBean.getNoticeType() + "<br />";
-			comment += "After : " + afterBean.getNoticeType() + "<br /></p>";
-		}
-		
-		if(!beforeBean.getPriority().equals(afterBean.getPriority())) {
-			comment += "<p><strong>Priority</strong><br />";
-			comment += "Before : " + beforeBean.getPriority() + "<br />";
-			comment += "After : " + afterBean.getPriority() + "</p>";
-		}
-		
-		// Project Division
-		if(!beforeBean.getDivision().equals(afterBean.getDivision())) {
-			comment += "<p><strong>Division</strong><br />";
-			comment += "Before : " + CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, beforeBean.getDivision()) + "<br />";
-			comment += "After : " + CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, afterBean.getDivision()) + "<br /></p>";
-		}
-		
-		String before = beforeBean.getComment().replaceAll("(\r\n|\r|\n|\n\r)", "");
-		String after = afterBean.getComment().replaceAll("(\r\n|\r|\n|\n\r)", "");
-		if(!before.equals(after)) {
-			comment += "<p><strong>Additional Information</strong><br />";
-			comment += "Before : " + beforeBean.getComment() + "<br />";
-			comment += "After : " + afterBean.getComment() + "</p>";
+			// Project Version
+			if(!beforeBean.getPrjVersion().equals(afterBean.getPrjVersion())) {
+				comment += "<p><strong>Project Version</strong><br />";
+				comment += "Before : " + beforeBean.getPrjVersion() + "<br />";
+				comment += "After : " + afterBean.getPrjVersion() + "<br /></p>";
+			}
+			
+			// Operating System
+			if(!beforeBean.getOsType().equals(afterBean.getOsType())) {
+				comment += "<p><strong>Operating System</strong><br />";
+				comment += "Before : " + beforeBean.getOsType() + "<br />";
+				comment += "After : " + afterBean.getOsType() + "<br /></p>";
+			}
+			
+			// Distribution Type
+			if(!beforeBean.getDistributionType().equals(afterBean.getDistributionType())) {
+				comment += "<p><strong>Distribution Type</strong><br />";
+				comment += "Before : " + beforeBean.getDistributionType() + "<br />";
+				comment += "After : " + afterBean.getDistributionType() + "<br /></p>";
+			}
+			
+			
+			if(!beforeBean.getNetworkServerType().equals(afterBean.getNetworkServerType())) {
+				comment += "<p><strong>Network Service only?</strong><br />";
+				comment += "Before : " + beforeBean.getNetworkServerType() + "<br />";
+				comment += "After : " + afterBean.getNetworkServerType() + "<br /></p>";
+			}
+			
+			if(!beforeBean.getDistributeTarget().equals(afterBean.getDistributeTarget())) {
+				comment += "<p><strong>Distribution Site</strong><br />";
+				comment += "Before : " + beforeBean.getDistributeTarget() + "<br />";
+				comment += "After : " + afterBean.getDistributeTarget() + "<br /></p>";
+			}
+			
+			if(!beforeBean.getNoticeType().equals(afterBean.getNoticeType())) {
+				comment += "<p><strong>OSS Notice</strong><br />";
+				comment += "Before : " + beforeBean.getNoticeType() + "<br />";
+				comment += "After : " + afterBean.getNoticeType() + "<br /></p>";
+			}
+			
+			if(!beforeBean.getPriority().equals(afterBean.getPriority())) {
+				comment += "<p><strong>Priority</strong><br />";
+				comment += "Before : " + beforeBean.getPriority() + "<br />";
+				comment += "After : " + afterBean.getPriority() + "</p>";
+			}
+			
+			String before = beforeBean.getComment().replaceAll("(\r\n|\r|\n|\n\r)", "");
+			String after = afterBean.getComment().replaceAll("(\r\n|\r|\n|\n\r)", "");
+			if(!before.equals(after)) {
+				comment += "<p><strong>Additional Information</strong><br />";
+				comment += "Before : " + beforeBean.getComment() + "<br />";
+				comment += "After : " + afterBean.getComment() + "</p>";
+			}
+		} else {
+			// Project Division
+			if(!beforeBean.getDivision().equals(afterBean.getDivision())) {
+				comment += "<p><strong>Division</strong><br />";
+				comment += "Before : " + CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, beforeBean.getDivision()) + "<br />";
+				comment += "After : <span style='background-color:yellow'>" + CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, afterBean.getDivision()) + "</span><br /></p>";
+			}
 		}
 		
 		return comment;

--- a/src/main/java/oss/fosslight/common/Url.java
+++ b/src/main/java/oss/fosslight/common/Url.java
@@ -443,6 +443,8 @@ public final class Url {
 		
 		public static final String MAKE_YAML = PATH + "/makeYaml";
 		public static final String PARTNER_DIVISION = PATH + "/updatePartnerDivision";
+
+		public static final String UPDATE_DESCRIPTION = PATH + "/updateDescription";
 	}
 	
 	public static final class USER {

--- a/src/main/java/oss/fosslight/common/Url.java
+++ b/src/main/java/oss/fosslight/common/Url.java
@@ -748,8 +748,11 @@ public final class Url {
 			public static final String FOSSLIGHT_API_MODEL_UPDATE			= "/model_update";
 			
 			/** API Project BOM Tab Export */
-			public static final String FOSSLIGHT_API_PROJECT_BOM_EXPORT	    = "/prj_bom_export"; 
-			
+			public static final String FOSSLIGHT_API_PROJECT_BOM_EXPORT	    = "/prj_bom_export";
+
+			/** API Project BOM Tab Export JSON*/
+			public static final String FOSSLIGHT_API_PROJECT_BOM_EXPORT_JSON	    = "/prj_bom_export_json";
+
 			/** API BOM COMPARE */
 			public static final String FOSSLIGHT_API_PROJECT_BOM_COMPARE		= "/prj_bom_compare";
 			

--- a/src/main/java/oss/fosslight/controller/PartnerController.java
+++ b/src/main/java/oss/fosslight/controller/PartnerController.java
@@ -1268,4 +1268,18 @@ public class PartnerController extends CoTopComponent{
 		
 		return makeJsonResponseHeader();
 	}
+
+	@PostMapping(value = PARTNER.UPDATE_DESCRIPTION)
+	public @ResponseBody ResponseEntity<Object> updateDescription(
+			@RequestBody PartnerMaster partnerMaster
+			, HttpServletRequest req
+			, HttpServletResponse res
+			, Model model){
+		try {
+			partnerService.updateDescription(partnerMaster);
+		} catch (Exception e) {
+			log.error(e.getMessage(), e);
+		}
+		return makeJsonResponseHeader();
+	}
 }

--- a/src/main/java/oss/fosslight/controller/UserController.java
+++ b/src/main/java/oss/fosslight/controller/UserController.java
@@ -94,7 +94,7 @@ public class UserController extends CoTopComponent {
 		
 		String ldapFlag = CoCodeManager.getCodeExpString(CoConstDef.CD_SYSTEM_SETTING, CoConstDef.CD_LDAP_USED_FLAG);
 		
-		if(CoConstDef.FLAG_NO.equals(ldapFlag)) {
+		if(!CoConstDef.FLAG_YES.equals(ldapFlag)) {
 			vo.setPassword(encodePassword((String) validResultMap.get("USER_PW")));
 		}
 		

--- a/src/main/java/oss/fosslight/repository/PartnerMapper.java
+++ b/src/main/java/oss/fosslight/repository/PartnerMapper.java
@@ -146,4 +146,6 @@ public interface PartnerMapper {
 	void updateOssList(ProjectIdentification projectIdentification);
 
 	public int updateDivision(@Param("partnerId") String partnerId, @Param("division") String division);
+
+	void updateDescription(PartnerMaster partnerMaster);
 }

--- a/src/main/java/oss/fosslight/service/ApiProjectService.java
+++ b/src/main/java/oss/fosslight/service/ApiProjectService.java
@@ -37,6 +37,8 @@ public interface ApiProjectService {
 	public List<Map<String, Object>> getBomList(String prjId);
 	
 	public List<Map<String, Object>> setMergeGridData(List<Map<String, Object>> list);
+
+	public Map<String, Object> getBomExportJson(String prjId);
 	
 	public Map<String, Object> getBomCompare(List<Map<String, Object>> beforeBomList, List<Map<String, Object>> afterBomList);
 	

--- a/src/main/java/oss/fosslight/service/PartnerService.java
+++ b/src/main/java/oss/fosslight/service/PartnerService.java
@@ -64,4 +64,6 @@ public interface PartnerService extends HistoryConfig{
 	public int updateDivision(String partnerId, String division);
 
 	public Map<String, List<PartnerMaster>> updatePartnerDivision(PartnerMaster partnerMaster);
+
+	public void updateDescription(PartnerMaster partnerMaster);
 }

--- a/src/main/java/oss/fosslight/service/impl/PartnerServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/PartnerServiceImpl.java
@@ -988,4 +988,10 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		
 		return updatePartnerDivMap;
 	}
+
+	@Override
+	public void updateDescription(PartnerMaster partnerMaster){
+		partnerMapper.updateDescription(partnerMaster);
+	}
+
 }

--- a/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
@@ -1333,14 +1333,23 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				ossComponent.setCopyrightText(String.join("\r\n", copyrightList));
 				addOssComponentCopyright.put(componentKey, copyrightList);
 				
-				if(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE.equals(bean.getObligationType())
-						|| CoConstDef.CD_DTL_NOTICE_TYPE_ACCOMPANIED.equals(ossNotice.getNoticeType())
-						|| hideOssVersionFlag) { // Accompanied with source code 의 경우 source 공개 의무
-					if(!noticeInfo.containsKey(componentKey)) {
-						srcInfo.put(componentKey, ossComponent);
-					}
-				} else {
-					noticeInfo.put(componentKey, ossComponent);
+				switch(CommonFunction.checkObligationSelectedLicense(ossComponent.getOssComponentsLicense())){
+					case CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE: 
+						if(hideOssVersionFlag) {
+							if(!srcInfo.containsKey(componentKey)) srcInfo.put(componentKey, ossComponent);
+						} else {
+							srcInfo.put(componentKey, ossComponent);
+						}
+						
+						break;
+					case CoConstDef.CD_DTL_OBLIGATION_NOTICE: 
+						if(hideOssVersionFlag) {
+							if(!noticeInfo.containsKey(componentKey)) noticeInfo.put(componentKey, ossComponent);
+						} else {
+							noticeInfo.put(componentKey, ossComponent);
+						}
+						
+						break;
 				}
 				
 				if(!licenseInfo.containsKey(license.getLicenseName())) {

--- a/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
@@ -1258,6 +1258,20 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			}
 		}
 		
+		// copyleft에 존재할 경우 notice에서는 출력하지 않고 copyleft로 merge함.
+		if(hideOssVersionFlag) {
+			Map<String, OssComponents> hideOssVersionMergeNoticeInfo = new HashMap<>();
+			Set<String> noticeKeyList = noticeInfo.keySet();
+			
+			for(String key : noticeKeyList) {
+				if(!srcInfo.containsKey(key)) {
+					hideOssVersionMergeNoticeInfo.put(key, noticeInfo.get(key));
+				}
+			}
+			
+			noticeInfo = hideOssVersionMergeNoticeInfo;
+		}
+		
 		// CLASS 파일만 등록한 경우 라이선스 정보만 추가한다.
 		// OSS NAME을 하이픈 ('-') 으로 등록한 경우 (고지문구에 라이선스만 추가)
 		List<OssComponents> addOssComponentList = selfCheckMapper.selectVerificationNoticeClassAppend(ossNotice);
@@ -1322,7 +1336,9 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				if(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE.equals(bean.getObligationType())
 						|| CoConstDef.CD_DTL_NOTICE_TYPE_ACCOMPANIED.equals(ossNotice.getNoticeType())
 						|| hideOssVersionFlag) { // Accompanied with source code 의 경우 source 공개 의무
-					srcInfo.put(componentKey, ossComponent);
+					if(!noticeInfo.containsKey(componentKey)) {
+						srcInfo.put(componentKey, ossComponent);
+					}
 				} else {
 					noticeInfo.put(componentKey, ossComponent);
 				}
@@ -1331,20 +1347,6 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					licenseInfo.put(componentKey, license);
 				}
 			}
-		}
-		
-		// copyleft에 존재할 경우 notice에서는 출력하지 않고 copyleft로 merge함.
-		if(hideOssVersionFlag) {
-			Map<String, OssComponents> hideOssVersionMergeNoticeInfo = new HashMap<>();
-			Set<String> noticeKeyList = noticeInfo.keySet();
-			
-			for(String key : noticeKeyList) {
-				if(!srcInfo.containsKey(key)) {
-					hideOssVersionMergeNoticeInfo.put(key, noticeInfo.get(key));
-				}
-			}
-			
-			noticeInfo = hideOssVersionMergeNoticeInfo;
 		}
 		
 		boolean isTextNotice = "text".equals(ossNotice.getFileType());

--- a/src/main/java/oss/fosslight/service/impl/VulnerabilityServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VulnerabilityServiceImpl.java
@@ -62,6 +62,11 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 			vulnerability.setSord("desc");
 		}
 		
+		String[] nicknameList = ossService.getOssNickNameListByOssName(vulnerability.getProduct());
+		if(nicknameList != null) {
+			vulnerability.setOssNicknames(nicknameList);
+		}
+		
 		int records = vulnerabilityMapper.selectVulnerabilityTotalCount(vulnerability);
 		vulnerability.setTotListSize(records);
 

--- a/src/main/java/oss/fosslight/util/YamlUtil.java
+++ b/src/main/java/oss/fosslight/util/YamlUtil.java
@@ -155,7 +155,7 @@ public class YamlUtil extends CoTopComponent {
 		return checkYamlFormat(list, "");
 	}
 	
-	private static LinkedHashMap<String, List<Map<String, Object>>> checkYamlFormat(List<ProjectIdentification> list, String typeCode) {
+	public static LinkedHashMap<String, List<Map<String, Object>>> checkYamlFormat(List<ProjectIdentification> list, String typeCode) {
 		LinkedHashMap<String, List<Map<String, Object>>> result = new LinkedHashMap<>();
 		
 		for(ProjectIdentification bean : list) {

--- a/src/main/resources/oss/fosslight/repository/PartnerMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/PartnerMapper.xml
@@ -605,7 +605,15 @@
 				</foreach>
 			</if>
 	</delete>
-	
+	<update id="updateDescription" parameterType="oss.fosslight.domain.PartnerMaster">
+		UPDATE
+			PARTNER_MASTER
+		SET
+			DESCRIPTION = #{description}
+		WHERE
+			PARTNER_ID = #{partnerId}
+	</update>
+
 	<update id="deleteMaster" parameterType="oss.fosslight.domain.PartnerMaster">
 	UPDATE
 		PARTNER_MASTER 

--- a/src/main/resources/oss/fosslight/repository/VulnerabilityMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/VulnerabilityMapper.xml
@@ -161,10 +161,22 @@
 		 	<if test="!@oss.fosslight.util.StringUtil@isEmpty(product)">
 		 		<choose>
 					<when test="@oss.fosslight.util.StringUtil@equalsIgnoreCase(ossNameAllSearchFlag,'Y')">
-						AND SCORE.PRODUCT = #{product}
+						AND (SCORE.PRODUCT = #{product}
+						<if test="!@oss.fosslight.util.StringUtil@isEmpty(ossNicknames)">
+					  		<foreach item="item" index="index" collection="ossNicknames">
+								OR SCORE.PRODUCT = #{item}
+							</foreach>
+						</if>
+						)
 					</when>
 					<otherwise>
-						AND SCORE.PRODUCT LIKE CONCAT('%',#{product},'%')
+						AND (SCORE.PRODUCT LIKE CONCAT('%',#{product},'%')
+						<if test="!@oss.fosslight.util.StringUtil@isEmpty(ossNicknames)">
+					  		<foreach item="item" index="index" collection="ossNicknames">
+								OR SCORE.PRODUCT = #{item}
+							</foreach>
+						</if>
+						)
 					</otherwise>
 				 </choose>
 		 	</if>
@@ -202,10 +214,22 @@
 			 	<if test="!@oss.fosslight.util.StringUtil@isEmpty(product)">
 			 		<choose>
 						<when test="@oss.fosslight.util.StringUtil@equalsIgnoreCase(ossNameAllSearchFlag,'Y')">
-							AND SCORE.PRODUCT = #{product}
+							AND (SCORE.PRODUCT = #{product}
+							<if test="!@oss.fosslight.util.StringUtil@isEmpty(ossNicknames)">
+					  			<foreach item="item" index="index" collection="ossNicknames">
+									OR SCORE.PRODUCT = #{item}
+								</foreach>
+							</if>
+							)
 						</when>
 						<otherwise>
-							AND SCORE.PRODUCT LIKE CONCAT('%',#{product},'%')
+							AND (SCORE.PRODUCT LIKE CONCAT('%',#{product},'%')
+							<if test="!@oss.fosslight.util.StringUtil@isEmpty(ossNicknames)">
+					  			<foreach item="item" index="index" collection="ossNicknames">
+									OR SCORE.PRODUCT = #{item}
+								</foreach>
+							</if>
+							)
 						</otherwise>
 					 </choose>
 			 	</if>
@@ -469,10 +493,22 @@
 			 	<if test="!@oss.fosslight.util.StringUtil@isEmpty(product)">
 			 		<choose>
 						<when test="@oss.fosslight.util.StringUtil@equalsIgnoreCase(ossNameAllSearchFlag,'Y')">
-							AND SCORE.PRODUCT = #{product}
+							AND (SCORE.PRODUCT = #{product}
+							<if test="!@oss.fosslight.util.StringUtil@isEmpty(ossNicknames)">
+					  			<foreach item="item" index="index" collection="ossNicknames">
+									OR SCORE.PRODUCT = #{item}
+								</foreach>
+							</if>
+							)
 						</when>
 						<otherwise>
-							AND SCORE.PRODUCT LIKE CONCAT('%',#{product},'%')
+							AND (SCORE.PRODUCT LIKE CONCAT('%',#{product},'%')
+							<if test="!@oss.fosslight.util.StringUtil@isEmpty(ossNicknames)">
+					  			<foreach item="item" index="index" collection="ossNicknames">
+									OR SCORE.PRODUCT = #{item}
+								</foreach>
+							</if>
+							)
 						</otherwise>
 					 </choose>
 			 	</if>

--- a/src/main/resources/static/css/commonIframe.css
+++ b/src/main/resources/static/css/commonIframe.css
@@ -161,6 +161,8 @@ input.cal:focus {background:#fff8ea url("../images/bg_cal.png") no-repeat right 
 .txBlueIt {font-style:italic;font-size:13px;font-weight:600;color:#0070c0;}
 .urlLink {display:block;color:#0070c0 !important;text-decoration:underline !important;}
 .urlLink2 {color:#0070c0 !important;text-decoration:underline !important;}
+.commentContentsArea a {color:#0070c0 !important;text-decoration:underline !important;}
+
 /* ===== Table ===== */
 /* write : 글쓰기 */
 .tbws1 {border:1px solid #cbc7bd;border-radius:5px;overflow:hidden;}

--- a/src/main/resources/static/js/basic.js
+++ b/src/main/resources/static/js/basic.js
@@ -1,6 +1,7 @@
 var lastTab = -1;	//이전 탭 기억변수
 var selectTab = -1;	//현재 탭 기억변수
 var deleteFlag = false;
+var LINKREGEXP = /\[PRJ-\d+\](?!<\/a>)|\[3rd-\d+\](?!<\/a>)/gi;
 
 $( document ).ajaxSend(function( event, jqxhr, settings ) {
   jqxhr.setRequestHeader("AJAX", true);
@@ -110,15 +111,23 @@ $(document).ready(function (){
 	});
 
 	function initTab(){
-		var _defaultTabStr = $("#defaultTabAnchorArr").val()||"";
-				
-		$.each(_defaultTabStr.split(","), function(idx, val){
-			var _gnbHref = $("#header > div > div.gnb a[href$='"+val+"']");
-			
-			if(_gnbHref && _gnbHref.length == 1) {
-				$("#header > div > div.gnb a[href$='"+val+"']").trigger("click");
-			}
-		});
+		var query = window.location.search;
+		var param = new URLSearchParams(query);
+		var id = param.get("id");
+		var prjFlag = param.get("project");
+		if(id != null && prjFlag != null) {
+			createTab(prjFlag == 'true' ? id + "_Project" : id + "_3rdParty",prjFlag == 'true' ? "#/project/edit/" + id : "#/partner/edit/" + id);
+		} else {
+			var _defaultTabStr = $("#defaultTabAnchorArr").val()||"";
+
+			$.each(_defaultTabStr.split(","), function(idx, val){
+				var _gnbHref = $("#header > div > div.gnb a[href$='"+val+"']");
+
+				if(_gnbHref && _gnbHref.length == 1) {
+					$("#header > div > div.gnb a[href$='"+val+"']").trigger("click");
+				}
+			});
+		}
 	}
 	
 	function tabExitHide(){
@@ -2169,3 +2178,24 @@ function nvl(str, defaultStr){
 var searchStringOptions = {searchoptions:{sopt:['cn','eq','ne','bw','bn','ew','en','nc']}};
 var searchNumberOptions = {searchoptions:{sopt:['ge','le','gt','lt','eq']}};
 var searchDateOptions = {searchoptions:{sopt:['eq','lt','le','gt','ge']}};
+
+
+function replaceWithLink(text){
+	return text.replace(LINKREGEXP, findAndReplace);
+}
+
+function findAndReplace(match) {
+	var prj = /PRJ/i;
+	var third = /3rd/i;
+	var arrLink = match.split('-');
+	var id = arrLink[1].substring(0, arrLink[1].length-1);
+	var protocol = window.location.protocol;
+	var host =  window.location.host;
+	var url = protocol + "//" + host;
+	if(prj.test(match)) {
+		url += "/project/view/" + id;
+	} else if(third.test(match)) {
+		url += "/partner/view/" + id;
+	}
+	return "<a href=" + url +" class='urlLink2' target='_blank' onclick='window.open(this.href)'>" +  match + "</a>";
+}

--- a/src/main/resources/static/js/basic_editor.js
+++ b/src/main/resources/static/js/basic_editor.js
@@ -30,6 +30,8 @@ var initSample = ( function() {
 			// TODO we can consider displaying some info box that
 			// without wysiwygarea the classic editor may not work.
 		}
+		var linkText = replaceWithLink(CKEDITOR.instances.editor.getData());
+		CKEDITOR.instances.editor.setData(linkText);
 	};
 
 	function isWysiwygareaAvailable() {
@@ -65,6 +67,8 @@ var initSample2 = ( function() {
 			// TODO we can consider displaying some info box that
 			// without wysiwygarea the classic editor may not work.
 		}
+		var linkText = replaceWithLink(CKEDITOR.instances.editor2.getData());
+		CKEDITOR.instances.editor2.setData(linkText);
 	};
 
 	function isWysiwygareaAvailable() {
@@ -100,6 +104,8 @@ var initSample3 = ( function() {
 			// TODO we can consider displaying some info box that
 			// without wysiwygarea the classic editor may not work.
 		}
+		var linkText = replaceWithLink(CKEDITOR.instances.editor3.getData());
+		CKEDITOR.instances.editor3.setData(linkText);
 	};
 
 	function isWysiwygareaAvailable() {
@@ -116,4 +122,37 @@ var initSample3 = ( function() {
 function resetEditor(instance) {
 	instance.updateElement();
 	instance.setData('');
+}
+
+var initCKEditorNoToolbar = function (id, readOnly) {
+	if(CKEDITOR.instances[id]) {
+		var _editor = CKEDITOR.instances[id];
+		_editor.destroy();
+	}
+	CKEDITOR.replace(id, {customConfig:"/js/customEditorConf_Comment.js", readOnly : readOnly});
+	var linkText = replaceWithLink(CKEDITOR.instances[id].getData());
+	CKEDITOR.instances[id].setData(linkText);
+	return linkText;
+}
+
+var initCKEditorToolbar = function (id) {
+	if(CKEDITOR.instances[id]) {
+		var _editor = CKEDITOR.instances.editor;
+		_editor.destroy();
+	}
+	CKEDITOR.replace(id);
+	var linkText = replaceWithLink(CKEDITOR.instances[id].getData());
+	CKEDITOR.instances[id].setData(linkText);
+	return linkText;
+}
+
+var activeLink = function(){
+	CKEDITOR.on('instanceReady', function (ev) {
+		$('iframe').contents().unbind("click").bind("click",function(e){
+			var url = e.target.href;
+			if (url !== undefined && url !== "") {
+				window.open(url);
+			}
+		});
+	});
 }

--- a/src/main/webapp/WEB-INF/views/admin/license/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/license/edit-js.jsp
@@ -216,7 +216,7 @@
 			loading.show();
 			
 			var editorVal = CKEDITOR.instances.editor.getData();
-			$('input[name=comment]').val(editorVal);
+			$('input[name=comment]').val(replaceWithLink(editorVal));
 
 			var pData = $('#licenseForm').serializeObject();
 			
@@ -295,15 +295,15 @@
 		var contents = $(obj).parent().parent().next().html();
 		CKEDITOR.instances.editor3.setData(contents);
 		//코멘트 수정
-		$('.closeModComment').click(function(){
+		$('.closeModComment').off("click").on("click", function(){
 			$('.commModifyPop').hide();
 			$('#blind_wrap').hide();	
 		});
 		
-		$('.modifyComment').click(function(){
+		$('.modifyComment').off("click").on("click", function(){
 			var editorVal = CKEDITOR.instances.editor3.getData();
 			var register = '${sessUserInfo.userId}';
-			var param = {commId : modifyCommentId, referenceId : data.detail.licenseId, referenceDiv :'30', contents : editorVal};
+			var param = {commId : modifyCommentId, referenceId : data.detail.licenseId, referenceDiv :'30', contents : replaceWithLink(editorVal)};
 			$.ajax({
 				url : '<c:url value="/license/saveComment"/>',
 				type : 'POST',
@@ -346,7 +346,7 @@ var fn_commemt = {
             	referenceDiv : 'license'
             },
             success : function(data){
-                $('#commentListArea').html(data);
+                $('#commentListArea').html(replaceWithLink(data));
             },
             error : function(xhr, ajaxOptions, thrownError){
                 alertify.error('<spring:message code="msg.common.valid2" />', 0);
@@ -383,17 +383,17 @@ var fn_commemt = {
 
         $("#spanBtnArea_"+_commId+" > .btnViewMode").hide();
         $("#spanBtnArea_"+_commId+" > .btnEditMode").show();
-        $("#spanBtnArea_"+_commId+" > .closeModComment").click(function(e){
+        $("#spanBtnArea_"+_commId+" > .closeModComment").off("click").on("click", function(e){
             e.preventDefault();
             fn_commemt.createNonToolbarEditor(_commId);
             $("#spanBtnArea_"+_commId+" > .btnViewMode").show();
             $("#spanBtnArea_"+_commId+" > .btnEditMode").hide();
         });
         
-        $("#spanBtnArea_"+_commId+" > .modifyComment").click(function(e){
+        $("#spanBtnArea_"+_commId+" > .modifyComment").off("click").on("click", function(e){
             e.preventDefault();
             var _referenceId = $('input[name=licenseId]').val();
-            var param = {commId : _commId, contents : _editor.getData(), referenceDiv: '30', referenceId: _referenceId};
+            var param = {commId : _commId, contents : replaceWithLink(_editor.getData()), referenceDiv: '30', referenceId: _referenceId};
 
             $.ajax({
             	url : '<c:url value="/comment/updateComment"/>',

--- a/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/edit-js.jsp
@@ -1700,7 +1700,7 @@
 		loading.show();
 		saveRow();
 		var editorVal = CKEDITOR.instances.editor.getData();
-		$('input[name=comment]').val(editorVal);
+		$('input[name=comment]').val(replaceWithLink(editorVal));
 		$("#ossForm").ajaxForm({
 			url :'<c:url value="/oss/saveAjax"/>',
             type : 'POST',
@@ -1805,15 +1805,15 @@ function modifyComment(obj){
 	CKEDITOR.instances.editor3.setData(contents);
 	
 	//코멘트 수정
-	$('.closeModComment').click(function(){
+	$('.closeModComment').off("click").on("click", function(){
 		$('.commModifyPop').hide();
 		$('#blind_wrap').hide();	
 	});
 	
-	$('.modifyComment').click(function(){
-		var editorVal = CKEDITOR.instances.editor3.getData();
+	$('.modifyComment').off("click").on("click", function(){
+        var editorVal = CKEDITOR.instances.editor3.getData();
 		var register = '${sessUserInfo.userId}';
-		var param = {commId : modifyCommentId, referenceId : data.detail.ossId, referenceDiv :'40', contents : editorVal};
+		var param = {commId : modifyCommentId, referenceId : data.detail.ossId, referenceDiv :'40', contents : replaceWithLink(editorVal)};
 		$.ajax({
 			url : '<c:url value="/oss/saveComment"/>',
 			type : 'POST',
@@ -1988,7 +1988,7 @@ var fn_commemt = {
     						}
     						
     						temp.find('.dateArea').text(data[i].createdDate);
-    						temp.find('.commentContentsArea').html(data[i].contents);
+    						temp.find('.commentContentsArea').html(replaceWithLink(data[i].contents));
     						temp.find('input[name=commId]').val(commId);
     						temp.removeAttr('name');
     					}	
@@ -2029,17 +2029,15 @@ var fn_commemt = {
         $("#spanBtnArea_"+_commId+" > .btnViewMode").hide();
         $("#spanBtnArea_"+_commId+" > .btnEditMode").show();
         
-        $("#spanBtnArea_"+_commId+" > .closeModComment").click(function(e){
-            e.preventDefault();
+        $("#spanBtnArea_"+_commId+" > .closeModComment").off("click").on("click", function(e){
             fn_commemt.createNonToolbarEditor(_commId);
             $("#spanBtnArea_"+_commId+" > .btnViewMode").show();
             $("#spanBtnArea_"+_commId+" > .btnEditMode").hide();
         });
         
-        $("#spanBtnArea_"+_commId+" > .modifyComment").click(function(e){
-            e.preventDefault();
+        $("#spanBtnArea_"+_commId+" > .modifyComment").off("click").on("click", function(e){
             var _referenceId = $('input[name=ossId]').val();
-            var param = {commId : _commId, contents : _editor.getData(), referenceDiv: '40', referenceId: _referenceId};
+            var param = {commId : _commId, contents : replaceWithLink(_editor.getData()), referenceDiv: '40', referenceId: _referenceId};
             $.ajax({
             	url : '<c:url value="/comment/updateComment"/>',
                 type : 'POST',
@@ -2064,6 +2062,7 @@ var fn_commemt = {
     createNonToolbarEditor : function(_commId) {
 
         var _editor = CKEDITOR.instances['comm_editor_'+_commId];
+        var editorVal = _editor.getData();
         if(_editor) {
             _editor.destroy();
         }
@@ -2073,6 +2072,7 @@ var fn_commemt = {
             	customConfig:'<c:url value="/js/customEditorConf_Comment.js"/>'
                     });
         }
+        CKEDITOR.instances['comm_editor_'+_commId].setData(replaceWithLink(editorVal));
     }
 }
 

--- a/src/main/webapp/WEB-INF/views/admin/partner/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/edit-js.jsp
@@ -34,6 +34,13 @@ var saveFlag = false;
 			//bat_evt.init();
 		//}
 		</c:if>
+
+		activeLink();
+		if('${detail.viewOnlyFlag}' == 'Y') {
+			initCKEditorNoToolbar('editor4', true);
+		} else {
+			initCKEditorNoToolbar('editor4', false);
+		}
 		
 		// autoConplete 문제로 인한 처리
 		$("#partnerName").val(partnerData.partnerName);
@@ -565,6 +572,24 @@ var saveFlag = false;
 	var partyValidMsgData_e = []; //초기화
 	var partyDiffMsgData_e = []; //초기화
 	var fn = {
+		editDescription : function(){
+			var linkText = initCKEditorNoToolbar("editor4", false);
+			var data = {"partnerId" : $('input[name=partnerId]').val() , "description" : linkText};
+			$.ajax({
+				url : '<c:url value="/partner/updateDescription"/>',
+				type : 'POST',
+				data : JSON.stringify(data),
+				dataType : 'json',
+				cache : false,
+				contentType : 'application/json',
+				success: function(){
+					alertify.success('<spring:message code="msg.common.success" />');
+				},
+				error : function(){
+					alertify.error('<spring:message code="msg.common.valid2" />', 0);
+				}
+			});
+		},
 		// party 그리드 데이터
 		getPartyGridData : function(){
 			$.ajax({

--- a/src/main/webapp/WEB-INF/views/admin/partner/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/edit.jsp
@@ -141,7 +141,18 @@
 						</c:if>
 						<tr>
 							<th class="dCase"><spring:message code="msg.common.field.description" /></th>
-							<td class="dCase"><textarea class="w100P h150" id="description" name="description" ${confirmStatusDisabled}><c:if test="${not empty detail }">${detail.description }</c:if></textarea></td>
+							<td class="dCase">
+								<div class="grid-container">
+									<div class="grid-width-100">
+										<div id="editor4"><c:if test="${not empty detail }">${detail.description }</c:if></div>
+									</div>
+								</div>
+								<c:if test="${(project.viewOnlyFlag ne 'Y') and (project.copyFlag ne 'Y') and (not empty project.prjId) }">
+									<div class="right mt5">
+										<input id="saveBtn" type='button' value='Save' class='btnCLight red right' style="margin-left:5px;" onclick="fn.editComment();"/>
+									</div>
+								</c:if>
+							</td>
 						</tr>
 						<tr>
 							<th class="dCase"><spring:message code="msg.common.field.Agreement" /><br/><c:if test="${checkFlag}"><a href="javascript:void(0);" class="sampleDown" onclick="fn.sampleDownload('arg')"><span>Sample</span></a></c:if></th>

--- a/src/main/webapp/WEB-INF/views/admin/partner/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/list-js.jsp
@@ -62,6 +62,9 @@
 	}
 	
 	var fn = {
+		unformatter : function(cellvalue, options, rowObject){
+			return cellvalue;
+		},
 		downloadExcel : function(){
 			if(isMaximumRowCheck(totalRow)){
 				var data = $('#3rdSearch').serializeObject();
@@ -106,7 +109,9 @@
 			var display = "";
 			
 			if(cellvalue !="" && cellvalue != undefined){
-				display ="<div style=\"height : 29px; overflow: hidden;\">"+cellvalue+"</div>";
+				var tmpStr = new RegExp();
+				tmpStr = /[<][^>]*[>]/gi;
+				display ="<div style=\"height : 29px; overflow: hidden;\">"+cellvalue.replace(tmpStr , "")+"</div>";
 			}
 			
 			return display;
@@ -317,7 +322,7 @@
 					{name: 'softwareVersion', index: 'softwareVersion', width: 40, align: 'left', sortable : true, hidden:true},
 					{name: 'status', index: 'status', width: 50, align: 'center', formatter: fn.displayStatus, sortable : true},
 					{name: 'deliveryForm', index: 'deliveryForm', width: 50, align: 'center', formatter: fn.displayDeliveryForm, sortable : true},
-					{name: 'description', index: 'description', width: 100, align: 'left', sortable : true},
+					{name: 'description', index: 'description', width: 100, align: 'left', sortable : true, formatter:fn.displayComment, unformatter:fn.unformatter},
 					{name: 'cveId', index: 'cveId', hidden:true},
 					{name: 'cvssScore', index: 'cvssScore', width: 50, align: 'center', formatter:fn.displayVulnerability, unformatter:fn.unformatter, sortable : false},
 					{name: 'division', index: 'division', width: 100, align: 'left', sortable : true},

--- a/src/main/webapp/WEB-INF/views/admin/partner/view-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/view-js.jsp
@@ -23,6 +23,13 @@ var partnerStatus = "${detail.status}";
 
 	$(document).ready(function () {
 		'use strict';
+        if('${detail.viewOnlyFlag}' == 'N') {
+            var copyUrl = "";
+            var protocol = window.location.protocol;
+            var host =  window.location.host;
+            copyUrl = protocol + "//" + host + "/index?id=" + '${detail.partnerId}' + "&project=false";
+            window.location.href = copyUrl;
+        }
 		
 	<c:if test="${empty message}">
 		evt.init();

--- a/src/main/webapp/WEB-INF/views/admin/partner/view.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/view.jsp
@@ -4,6 +4,8 @@
 <!-- wrap -->
 <c:set var="isCommited" value="${detail.status eq 'CONF'}"/>
 <div id="wrapIframe">
+<c:if test="${detail.viewOnlyFlag eq 'Y'}">
+
 	<c:if test="${empty message}">
 		<!---->
 		<div class="projdecTop" style="height:auto;">
@@ -264,6 +266,7 @@
 </c:if>
 <c:if test="${not empty message}">
 	${message}
+</c:if>
 </c:if>
 </div>
 <div id="blind_wrap"></div>

--- a/src/main/webapp/WEB-INF/views/admin/project/AJAX/commentArea.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/AJAX/commentArea.jsp
@@ -17,7 +17,14 @@
 					customConfig:'<c:url value="/js/customEditorConf_Comment.js"/>'
 						});
 			}
-
+			var text = CKEDITOR.instances[this.id].getData();
+			var linkText;
+			if(opener == null) {
+				linkText = replaceWithLink(text);
+			} else {
+				linkText = opener.replaceWithLink(text);
+			}
+			CKEDITOR.instances[this.id].setData(linkText);
 		});
 		
 		CKEDITOR.on('instanceReady', function (ev) {

--- a/src/main/webapp/WEB-INF/views/admin/project/AJAX/commentPopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/AJAX/commentPopup.jsp
@@ -74,22 +74,20 @@
 				}
 				
 				_editor = CKEDITOR.replace('comm_editor_'+_commId);
+				var originComment = CKEDITOR.instances['comm_editor_'+_commId].getData();
 
 				$("#spanBtnArea_"+_commId+" > .btnViewMode").hide();
 				$("#spanBtnArea_"+_commId+" > .btnEditMode").show();
-				$("#spanBtnArea_"+_commId+" > .closeModComment").click(function(e){
-					e.preventDefault();
+				$("#spanBtnArea_"+_commId+" > .closeModComment").off("click").on("click", function(e){
 					fn_commemt.createNonToolbarEditor(_commId);
-					
+					CKEDITOR.instances['comm_editor_' +_commId].setData(originComment);
 					$("#spanBtnArea_"+_commId+" > .btnViewMode").show();
 					$("#spanBtnArea_"+_commId+" > .btnEditMode").hide();
-					$("#spanBtnArea_"+_commId+" > .closeModComment").unbind('click');
 				});
-				
-				$("#spanBtnArea_"+_commId+" > .modifyComment").click(function(e){
-					e.preventDefault();
-					var param = {commId : _commId, contents : _editor.getData(), referenceDiv: _referenceDiv, referenceId: _referenceId};
-					
+
+				$("#spanBtnArea_"+_commId+" > .modifyComment").off("click").on("click", function(e){
+					var param = {commId : _commId, contents : replaceWithLink(_editor.getData()), referenceDiv: _referenceDiv, referenceId: _referenceId};
+
 					$.ajax({
 						url : '<c:url value="/comment/updateComment"/>',
 						type : 'POST',
@@ -102,7 +100,6 @@
 							$("#spanBtnArea_"+_commId+" > .btnEditMode").hide();
 							
 							alertify.success('<spring:message code="msg.common.success" />');
-							$("#spanBtnArea_"+_commId+" > .modifyComment").unbind('click');
 						},
 						error : function(){
 							alertify.error('<spring:message code="msg.common.valid2" />', 0);
@@ -114,6 +111,7 @@
 			},
 			createNonToolbarEditor : function(_commId) {
 				var _editor = CKEDITOR.instances['comm_editor_'+_commId];
+				var editorVal = _editor.getData();
 				
 				if(_editor) {
 					_editor.destroy();
@@ -125,6 +123,7 @@
 						customConfig:'<c:url value="/js/customEditorConf_Comment.js"/>'
 							});
 				}
+				CKEDITOR.instances['comm_editor_'+_commId].setData(replaceWithLink(editorVal));
 			},
 			getMoreCommentList : function(){
 				$.ajax({

--- a/src/main/webapp/WEB-INF/views/admin/project/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/edit-js.jsp
@@ -25,20 +25,15 @@
 	
 	$(document).ready(function() {
 		'use strict';
+		data.init();
 		initSample();
 		initSample2();
-		data.init();
 		evt.init();
 
-        if($('input[name=prjId]').val() == "" || copyFlag == 'Y') {
-            $("#editAdditionalInfomation").hide();
-        } else {
-            if(CKEDITOR.instances.editor) {
-                var _editor = CKEDITOR.instances.editor;
-                _editor.destroy();
-            }
-            CKEDITOR.replace('editor', {customConfig:'<c:url value="/js/customEditorConf_Comment.js"/>'});
-        }
+		activeLink();
+		if('${project.viewOnlyFlag}' == 'Y') {
+            initCKEditorNoToolbar('editor', true);
+		}
 
         var userDivision = $('#division');
         for(var i=0;i<userDivision.children().length;i++){
@@ -551,44 +546,10 @@
 	};
 	
 	var fn = {
-	        editComment : function() {
-	            $("#saveBtn").show();
-	            $("#cancelBtn").show();
-	            $("#editAdditionalInfomation").hide();
-	            if(CKEDITOR.instances.editor) {
-	                var _editor = CKEDITOR.instances.editor;
-	                _editor.destroy();
-	            }
-	            CKEDITOR.replace('editor');
-	            var originComment = CKEDITOR.instances.editor.getData();
-
-	            $("#saveBtn").click(function(e){
-	                e.preventDefault();
-	                if(CKEDITOR.instances.editor) {
-	                    var _editor = CKEDITOR.instances.editor;
-	                    _editor.destroy();
-	                }
-	                CKEDITOR.replace('editor', {customConfig:'<c:url value="/js/customEditorConf_Comment.js"/>'});
-	                $("#saveBtn").hide();
-	                $("#cancelBtn").hide();
-	                $("#editAdditionalInfomation").show();
-	                fn.saveSubmit(false);
-	            });
-
-	            $("#cancelBtn").click( function(e) {
-	                e.preventDefault();
-	                if(CKEDITOR.instances.editor) {
-	                    var _editor = CKEDITOR.instances.editor;
-	                    _editor.destroy();
-	                }
-	                CKEDITOR.replace('editor', {customConfig:'<c:url value="/js/customEditorConf_Comment.js"/>'});
-	                CKEDITOR.instances.editor.setData(originComment);
-	                $("#saveBtn").hide();
-	                $("#cancelBtn").hide();
-	                $("#editAdditionalInfomation").show();
-	                $("#cancelBtn").unbind("click");
-	            });
-	        },
+		editComment : function() {
+			initCKEditorToolbar("editor");
+			fn.saveSubmit(false);
+		},
 		copy : function(){
 			var prjId = $('input[name=prjId]').val();
 			
@@ -1189,7 +1150,7 @@
 					return false;
 				}
 				
-				var param = {referenceId : '${project.prjId}', referenceDiv :'19', contents : editorVal, mailSendType : type};
+				var param = {referenceId : '${project.prjId}', referenceDiv :'19', contents : replaceWithLink(editorVal), mailSendType : type};
 				
 				$.ajax({
 					url : '<c:url value="/project/sendComment"/>',

--- a/src/main/webapp/WEB-INF/views/admin/project/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/edit-js.jsp
@@ -1726,7 +1726,8 @@
 				if($('select[name=osType]').val() == null) {
 					$('select[name=osType]').val("").trigger('change');
 				}
-				
+
+				$('#editor').css("width", $(".miCase").width());
 				$('#editor').html(data.detail.comment);
 				$('select[name=category]').val(data.detail.category).trigger('change');
 				$('select[name=prjDivision]').val(data.detail.prjDivision).trigger('change');
@@ -1836,7 +1837,8 @@
 				if($('select[name=osType]').val() == null) {
 					$('select[name=osType]').val("").trigger('change');
 				}
-				
+
+				$('#editor').css("width", $(".miCase").width());
 				$('#editor').html(data.copy.comment);
 				$('textarea[name=comment]').val(data.copy.comment);
 				$('select[name=category]').val(data.copy.category).trigger('change');

--- a/src/main/webapp/WEB-INF/views/admin/project/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/edit-js.jsp
@@ -1501,7 +1501,7 @@
 							_editor.destroy();
 						}
 						
-						CKEDITOR.replace('editor4', {});
+						CKEDITOR.replace('editor4', {autoGrow_maxHeight:200});
 					</c:if>
 				</c:if>
 

--- a/src/main/webapp/WEB-INF/views/admin/project/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/edit.jsp
@@ -234,7 +234,7 @@
 								</c:if>
 								<div class="grid-container">
 									<div class="grid-width-100">
-										<div id="editor">${project.comment}</div>
+										<div id="editor"></div>
 									</div>
 								</div>
 								<div class="right mt5">

--- a/src/main/webapp/WEB-INF/views/admin/project/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/edit.jsp
@@ -225,22 +225,16 @@
 						<tr>
 							<th class="dCase"><spring:message code="msg.common.field.additionalInformation" /></th>
 							<td class="dCase">
-								<c:if test="${project.viewOnlyFlag ne 'Y'}">
-									<dt id="editAdditionalInfomation" style="height: 15px;">
-										<span class="right">
-											<input type="button" class="editModify btnViewMode" onclick="fn.editComment();"/>
-										</span>
-									</dt>
-								</c:if>
 								<div class="grid-container">
 									<div class="grid-width-100">
 										<div id="editor"></div>
 									</div>
 								</div>
-								<div class="right mt5">
-									<input id="saveBtn" type='button' value='Save' class='btnCLight red right' style="margin-left:5px; display: none;"/>
-									<input id="cancelBtn" type='button' value='Cancel' class='btnCLight darkgray right' style="display: none;"/>
-								</div>
+								<c:if test="${(project.viewOnlyFlag ne 'Y') and (project.copyFlag ne 'Y') and (not empty project.prjId) }">
+									<div class="right mt5">
+										<input id="saveBtn" type='button' value='Save' class='btnCLight red right' style="margin-left:5px;" onclick="fn.editComment();"/>
+									</div>
+								</c:if>
 							</td>
 						</tr>
 						<c:if test="${project.viewOnlyFlag ne 'Y'}">

--- a/src/main/webapp/WEB-INF/views/admin/project/view-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/view-js.jsp
@@ -19,6 +19,13 @@
 	
 	$(document).ready(function() {
 		'use strict';
+        if('${project.viewOnlyFlag}' == 'N') {
+            var copyUrl = "";
+            var protocol = window.location.protocol;
+            var host =  window.location.host;
+            copyUrl = protocol + "//" + host + "/index?id=" + '${project.prjId}' + "&project=true";
+            window.location.href = copyUrl;
+        }
 		
 	<c:if test="${empty message}">
 		//initSample();

--- a/src/main/webapp/WEB-INF/views/admin/project/view.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/view.jsp
@@ -2,6 +2,7 @@
 <%@ include file="/WEB-INF/constants.jsp"%>
 <!-- wrap -->
 <div id="wrapIframe">
+<c:if test="${project.viewOnlyFlag eq 'Y'}">
 	<c:if test="${not empty project.prjId}">
 		<div class="projdecTop">
 			<div class="projectInfo">
@@ -209,6 +210,7 @@
 	<c:if test="${not empty message}">
 		${message}
 	</c:if>
+</c:if>
 	<!---->
 </div>
 <!-- //wrap -->

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
@@ -57,7 +57,7 @@
 					cache : false,
 					data : {prjId : prjId},
 					success : function(detailResult){
-						$("#divViewMode").html(detailResult);
+						$("#divViewMode").html(replaceWithLink(detailResult));
 						$("#divViewMode").show();
 						$("#divEditMode").hide();
 					},
@@ -143,7 +143,7 @@
 		// 저장
 		saveSubmit : function(){
 			var editorVal = CKEDITOR.instances.editor.getData();
-			$('input[name=comment]').val(editorVal);
+			$('input[name=comment]').val(replaceWithLink(editorVal));
 			
 			$("#projectForm").ajaxForm({
 				url : '<c:url value="/selfCheck/saveAjax"/>',


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
New 
- Replace PRJ-{ID}, 3rd-{ID} with a link.
- API > Return bom as json.

Bug Fix
- Fix the bug where password cannot be set when signing up for non-LDAP.
- Self-check > Notice > Fix the bug where the copyleft table is displayed even when there is no copyleft.

Chore
- Fix the height of the row of the 3rd party list.
- Mark obligation as unclear only when there is an error in the license in self-check

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
