### PR TITLE
Increase the height of oss version list table in  oss version list popup

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/oss/viewpopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/viewpopup.jsp
@@ -61,6 +61,12 @@
 							var isSelectedRow = false;
 							
 							if(data.records > 0) {
+								if(data.records < 11) {
+									$(".jqGridSet").height(30*data.records + 60);
+								} else {
+									$(".jqGridSet").height(360);
+								}
+
 								var rowIdx = 0, rows = this.rows, rowsCount = rows.length, row, rowid, rowData, className;
 								
 								for(var _idx=0;_idx<rowsCount;_idx++) {
@@ -202,11 +208,11 @@
 	<body>
 		<div id="wrap" style="padding-top: 10px;">
 			<div  align="center" >
-			<div class="jqGridSet" style="overflow: auto; width: 90%; height: 150px;">
+			<div class="jqGridSet" style="overflow: auto; width: 850px; height: 150px;">
 				<table id="_ossList"><tr><td></td></tr></table>
 			</div>
 			</div>
-			<div id="ossDetailInfo" style="padding: 10%;">
+			<div id="ossDetailInfo" style="padding: 3% 6% 6% 6%;">
 			</div>
 		<c:if test="${ct:isAdmin()}">
 			<input type="hidden" id="viewPopupOssId" name="viewPopupOssId"/>


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Project Identification or 3rd party > double click "ID" of oss > display popup with oss version list table and detail information
Increase the height of oss version list table.

AS-IS : 
![image](https://user-images.githubusercontent.com/102017711/188099553-cca54fd5-2a91-4088-8dff-313b5abd19f7.png)

TO-BE : 
![image](https://user-images.githubusercontent.com/102017711/188099480-bda3eeb3-d378-4987-9cdc-f583a37f5310.png)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
