### PR TITLE
Self-check >  Add SPDX as well as FOSSLight Report to the export button download

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
@@ -47,6 +47,13 @@
 		fn.appendEditVisible($("#append"));
 		fn.initNotice();
 	});
+
+    // close exportlist
+    $(document).click(function(e){
+        if(!$("#ExportContainer").has(e.target).length) {
+            $("#ExportList").hide();
+        }
+    });
 	
 	var fn_self ={
 		modeChange : function(prjId, type) {
@@ -867,7 +874,31 @@
                     alertify.error('<spring:message code="msg.common.valid2" />', 0);
                 }
             });
-        }
+        },
+
+        exportList:function(){
+            var buttonId = event.target.id;
+            var exportListId = "#" + $("#" + buttonId).siblings("div").attr("id");
+            if ($(exportListId).css('display')=='none') {
+                $(exportListId).show();
+            }else{
+                $(exportListId).hide();
+            }
+            $(exportListId).menu();
+        },
+        selectDownloadFile : function() {
+            var targetFileId = event.target.id;
+            var parentId = $("#" + targetFileId).closest("div").attr("id")
+            // download file
+            if (targetFileId === "report_sub") src_fn.downloadExcel();
+            else if (targetFileId === "Spreadsheet_sub") fn.downloadSpdxSpreadSheetExcel();
+            else if (targetFileId === "RDF_sub") fn.downloadSpdxRdf();
+            else if (targetFileId === "TAG_sub") fn.downloadSpdxTag();
+            else if (targetFileId === "JSON_sub") fn.downloadSpdxJson();
+            else if (targetFileId === "YAML_sub") fn.downloadSpdxYaml();
+            // hide list
+            $("#" + parentId).hide();
+        },
 	};
 
 	// 데이타

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
@@ -139,7 +139,17 @@
 	            <input id="delete" type="button" value="Delete" class="btnColor left selfCheckDelete" /><!-- 2018-07-19 choye 추가 class에  selfCheckDelete -->
 	            <span class="right">
 	            <a class="iconSet help left" id="helpLink_vulerabiityExport" style="display: none; position:relative; cursor: pointer; right:10px;"></a>
-	                <input type="button" value="Export" onclick="src_fn.downloadExcel()" class="btnColor red btnExpor srcBtn" />
+	                <div id="ExportContainer" class="inblock " style="vertical-align:top; position: relative;">
+						<input id="Export" type="button" value="Export" class="btnColor red btnExport" onclick="fn.exportList()"/>
+						<div id="ExportList" class="w200 tright" style="display: none; position: absolute; z-index: 1; right: 0;" onclick="fn.selectDownloadFile()">
+							<a id="report_sub" style="display: block;">FOSSLight Report (Spreadsheet)</a>
+							<a id="Spreadsheet_sub" style="display: block;">SPDX (Spreadsheet)</a>
+							<a id="RDF_sub" style="display: block;">SPDX (RDF)</a>
+							<a id="TAG_sub" style="display: block;">SPDX (TAG)</a>
+							<a id="JSON_sub" style="display: block;">SPDX (JSON)</a>
+							<a id="YAML_sub" style="display: block;">SPDX (YAML)</a>
+						</div>
+					</div>
 	                <input type="button" value="Bulk Edit" onclick="fn.bulkEdit()" class="btnColor red"/>
 	                <input type="button" value="Yaml" class="btnColor red btnExport" onclick="fn.downloadYaml()"/>
 	                <input type="button" value="Check OSS Name" onclick="src_fn.CheckOssViewPage()" class="btnColor red btnExpor srcBtn" style="width: 115px;" />


### PR DESCRIPTION
Signed-off-by: Dabeen Jeong <hello70825@gmail.com>

## Description
AS-IS
![image](https://user-images.githubusercontent.com/79046106/189518077-01ac53b2-3c27-467a-8f18-e237ba15e634.png)
If user clicks Export button, user can download only FOSSLight Report

TO-BE
![image](https://user-images.githubusercontent.com/79046106/189518063-bdd8c68b-17e0-4a8c-ab74-55f67b717efb.png)
If user clicks Export button, then user can select file to download.  
Spdx files are the same as Spdx files from Notice Tab


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
