### PR TITLE
When 3rd party confirm, remove default comment in comment history

### DIFF
--- a/src/main/java/oss/fosslight/controller/PartnerController.java
+++ b/src/main/java/oss/fosslight/controller/PartnerController.java
@@ -839,8 +839,7 @@ public class PartnerController extends CoTopComponent{
 				String _tempComment = avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_DEFAULT_CONTENTS, CoConstDef.CD_MAIL_TYPE_PARTER_CONF));
 
 				if(!isEmpty(userComment)) {
-					userComment = avoidNull(userComment) + "<br />" + _tempComment;
-					mailbean.setComment(userComment);
+					mailbean.setComment(avoidNull(userComment) + "<br />" + _tempComment);
 				} else{
 					mailbean.setComment(_tempComment);
 				}


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Case : 3rd party confirm
If there are reviewer's comments, save only reviewer's comment in comment history without default comment.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
