### PR TITLE
Show detail failure messages in OSS bulk feature.

### DIFF
--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -1009,8 +1009,16 @@ public class OssController extends CoTopComponent{
 			boolean[] check = new boolean[declaredLicenses.size() + 1];
 			List<OssLicense> ossLicenses = new ArrayList<>();
 			int licenseCount = 1;
-			if (declaredLicenses == null) {
+			if (declaredLicenses == null || declaredLicenses.isEmpty()) {
 				log.warn("DeclaredLicenses is null:" + oss.getOssName());
+				ossDataMap.put("gridId", oss.getGridId());
+				ossDataMap.put("status", "X (Required missing)");
+				ossDataMapList.add(ossDataMap);
+				continue;
+			}
+
+			if (Objects.isNull(oss.getOssName()) || oss.getOssName().isBlank()) {
+				log.warn("OSS name is required.");
 				ossDataMap.put("gridId", oss.getGridId());
 				ossDataMap.put("status", "X (Required missing)");
 				ossDataMapList.add(ossDataMap);

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -1010,7 +1010,7 @@ public class OssController extends CoTopComponent{
 			List<OssLicense> ossLicenses = new ArrayList<>();
 			int licenseCount = 1;
 			if (declaredLicenses == null || declaredLicenses.isEmpty()) {
-				log.warn("DeclaredLicenses is null:" + oss.getOssName());
+				log.debug("DeclaredLicenses is null:" + oss.getOssName());
 				ossDataMap.put("gridId", oss.getGridId());
 				ossDataMap.put("status", "X (Required missing)");
 				ossDataMapList.add(ossDataMap);
@@ -1018,7 +1018,7 @@ public class OssController extends CoTopComponent{
 			}
 
 			if (Objects.isNull(oss.getOssName()) || oss.getOssName().isBlank()) {
-				log.warn("OSS name is required.");
+				log.debug("OSS name is required.");
 				ossDataMap.put("gridId", oss.getGridId());
 				ossDataMap.put("status", "X (Required missing)");
 				ossDataMapList.add(ossDataMap);
@@ -1030,7 +1030,7 @@ public class OssController extends CoTopComponent{
 				licenseMaster.setLicenseName(licenseName);
 				LicenseMaster existsLicense = licenseService.checkExistsLicense(licenseMaster);
 				if (existsLicense == null) {
-					log.info("Unconfirmed license:" + licenseName);
+					log.debug("Unconfirmed license:" + licenseName);
 					licenseCheck = true;
 					break;
 				}
@@ -1060,13 +1060,13 @@ public class OssController extends CoTopComponent{
 				licenseMaster.setLicenseName(licenseName);
 				LicenseMaster existsLicense = licenseService.checkExistsLicense(licenseMaster);
 				if (existsLicense == null) {
-					log.info("Unconfirmed license:" + licenseName);
+					log.debug("Unconfirmed license:" + licenseName);
 					licenseCheck = true;
 					break;
 				}
 			}
 			if (licenseCheck) {
-				log.warn("Add failed due to declared license:" + oss.getOssName());
+				log.debug("Add failed due to declared license:" + oss.getOssName());
 				ossDataMap.put("gridId", oss.getGridId());
 				ossDataMap.put("status", "X (Unconfirmed license)");
 				ossDataMapList.add(ossDataMap);
@@ -1086,7 +1086,7 @@ public class OssController extends CoTopComponent{
 
 			boolean checkDuplicated = true;
 			if (ossService.checkExistsOss(oss) != null) {
-				log.warn("Same OSS, version already exists.:" + oss.getOssName() + " v" + oss.getOssVersion());
+				log.debug("Same OSS, version already exists.:" + oss.getOssName() + " v" + oss.getOssVersion());
 				ossDataMap.put("gridId", oss.getGridId());
 				ossDataMap.put("status", "X (Duplicated Version)");
 				ossDataMapList.add(ossDataMap);
@@ -1097,7 +1097,7 @@ public class OssController extends CoTopComponent{
 				nameCheck.setOssNameTemp(oss.getOssName());
 				OssMaster checkName = ossService.checkExistsOssNickname2(nameCheck);
 				if (checkName != null) {
-					log.warn(oss.getOssName() + " is stored as a nick in " + checkName.getOssName());
+					log.debug(oss.getOssName() + " is stored as a nick in " + checkName.getOssName());
 					ossDataMap.put("gridId", oss.getGridId());
 					ossDataMap.put("status", "X (Duplicated : " + oss.getOssName() + ")");
 					ossDataMapList.add(ossDataMap);
@@ -1112,7 +1112,7 @@ public class OssController extends CoTopComponent{
 					nickCheck.setOssNameTemp(oss.getOssName());
 					OssMaster checkNick = ossService.checkExistsOssNickname(nickCheck);
 					if (checkNick != null) {
-						log.warn(nick + " is stored as a nick or name in " + checkNick.getOssName());
+						log.debug(nick + " is stored as a nick or name in " + checkNick.getOssName());
 						ossDataMap.put("gridId", oss.getGridId());
 						ossDataMap.put("status", "X (Duplicated : " + nick + ")");
 						ossDataMapList.add(ossDataMap);

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -2699,54 +2699,44 @@ public class ExcelUtil extends CoTopComponent {
 	public static OssMaster getOssDataByColumn(Iterator<Cell> cellIterator) {
 		OssMaster ossMaster = new OssMaster();
 		int colIndex = 0;
+		int nullCol = 0;
 		for (; cellIterator.hasNext(); colIndex++) {
 			Cell cell = (Cell) cellIterator.next();
 			String value = getCellData(cell);
+			if (value == null || value.trim().isEmpty()) {
+				nullCol++;
+				continue;
+			}
 			if (colIndex == 0) {
-				if (value == null || value.trim().isEmpty()) {
-					log.debug("OSS Name must not be null.");
-					return null;
-				} else {
-					ossMaster.setOssName(value);
-				}
+				ossMaster.setOssName(value);
 			} else if (colIndex == 1) {
-				if (value == null || value.trim().isEmpty()) continue;
 				String[] nicknames = StringUtil.delimitedStringToStringArray(value, ",");
 				ossMaster.setOssNicknames(nicknames);
 			} else if (colIndex == 2) {
-				if (value == null || value.trim().isEmpty()) continue;
 				ossMaster.setOssVersion(value);
 			} else if (colIndex == 3) {
-				if (value == null || value.trim().isEmpty()) {
-					log.debug("Declared License must not be null.");
-					return null;
-				}
 				ossMaster.setDeclaredLicense(value);
 			} else if (colIndex == 4) {
-				if (value == null || value.trim().isEmpty()) continue;
 				ossMaster.setDetectedLicense(value);
 			} else if (colIndex == 5) {
-				if (value == null || value.trim().isEmpty()) continue;
 				ossMaster.setCopyright(value);
 				ossMaster.setOssCopyright(value);
 			} else if (colIndex == 6) {
-				if (value == null || value.trim().isEmpty()) continue;
 				String homepage = value.replaceAll("(\r\n|\r|\n|\n\r)", "");
 				ossMaster.setHomepage(homepage);
 			} else if (colIndex == 7) {
-				if (value == null || value.trim().isEmpty()) continue;
 				String location = value.replaceAll("(\r\n|\r|\n|\n\r)", "");
 				ossMaster.setDownloadLocation(location);
 			} else if (colIndex == 8) {
-				if (value == null || value.trim().isEmpty()) continue;
 				ossMaster.setSummaryDescription(value);
 			} else if (colIndex == 9) {
-				if (value == null || value.trim().isEmpty()) continue;
 				ossMaster.setAttribution(value);
 			} else if (colIndex == 10) {
-				if (value == null || value.trim().isEmpty()) continue;
 				ossMaster.setComment(value);
 			}
+		}
+		if (nullCol == 11) {
+			return null;
 		}
 		return ossMaster;
 	}

--- a/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
@@ -165,7 +165,7 @@
         if (isClicked == false) {
             isClicked = true;
             $("#btn").click(() => {
-
+                OssBulkGridStatusMessageManager.cleanStatusMessages();
                 target.jqGrid('saveRow', _mainLastsel);
 
                 // load all rowIds checked in grid
@@ -189,7 +189,7 @@
                         _mainLastsel = -1;
                         if (data['res'] == true && data['value'] != []) {
                             loadedInfo = data['value'];
-                            checkLoaded();
+                            OssBulkGridStatusMessageManager.setStatusMessages(loadedInfo);
                             alertify.alert('<spring:message code="msg.common.success" />', function(){});
                         } else if (data['res'] == false) {
                             showErrorMsg();
@@ -219,7 +219,7 @@
                 { name: 'summaryDescription', index:'summaryDescription', width: 150, align: 'left', editable:false},
                 { name: 'attribution', index:'attribution', width: 150, align: 'left', editable:false},
                 { name: 'comment', index:'comment', width: 150, align: 'left', editable:false},
-                { name: 'status', index:'status', width: 150, align: 'left'}
+                { name: 'status', index:'status', width: 500, align: 'left'}
             ],
             viewrecords: true,
             rowNum: ${ct:getConstDef("DISP_PAGENATION_DEFAULT")},
@@ -399,4 +399,17 @@
             }
         }
     }
+
+    const OssBulkGridStatusMessageManager = {
+        cleanStatusMessages: function () {
+            $("#list").jqGrid("getGridParam", "data").forEach(row => {
+                row.status = ""
+            });
+        },
+        setStatusMessages: function (results) {
+            for (const result of results)
+                $("#list").jqGrid("getLocalRow", result.gridId).status = result.status;
+            $("#list").trigger('reloadGrid', [{ page: 1}]);
+        }
+    };
 </script>

--- a/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
@@ -89,7 +89,7 @@
     function stubColData(){
         for(var i=0; i<jsonData.length ; i++ ){
             withStatus = jsonData[i]['oss'];
-            withStatus['status'] = jsonData[i]['status'];
+            withStatus.gridId = i;
             $('#list').jqGrid('addRowData', i, withStatus);
         }
         $("#list").trigger('reloadGrid');
@@ -112,15 +112,15 @@
 
         mainData.forEach((row) => {
             stringDataForValid.forEach((strData) => {
-                ossData[row["id"]][strData] = row[strData].trim();
+                ossData[row["gridId"]][strData] = row[strData].trim();
             })
 
             listDataForValid.forEach((listData) => {
-                ossData[row["id"]][listData] = row[listData].trim()
-                if (ossData[row["id"]][listData] == "") {
-                    ossData[row["id"]][listData] = []
+                ossData[row["gridId"]][listData] = row[listData].trim()
+                if (ossData[row["gridId"]][listData] == "") {
+                    ossData[row["gridId"]][listData] = []
                 } else {
-                    ossData[row["id"]][listData] = ossData[row["id"]][listData].split(",")
+                    ossData[row["gridId"]][listData] = ossData[row["gridId"]][listData].split(",")
                 }
             })
         })
@@ -204,13 +204,13 @@
         $("#list").jqGrid({
             datatype: "local",
             data : jsonData,
-            colNames:['id', 'OSS Name','Nickname','Version','Declared License','Detected License','Copyright',
+            colNames:['gridId', 'OSS Name','Nickname','Version','Declared License','Detected License','Copyright',
                 'Homepage','Download URL',  'Summary Description', 'Attribution','Comment', 'Status'],
             colModel: [
-                { name: 'id', 	index: 'id', width: 75, key:true, hidden: true, editable:false},
-                {name: 'ossName', index: 'ossName', width: 200, align: 'left', editable:false},
-                {name: 'ossNicknames', index: 'ossNickNames', width: 200, align: 'left', editable:false},
-                {name: 'ossVersion', index: 'ossVersion', width: 75, align: 'left', editable:false},
+                { name: 'gridId', index: 'gridId', width: 75, key:true, hidden: true, editable:false},
+                { name: 'ossName', index: 'ossName', width: 200, align: 'left', editable:false},
+                { name: 'ossNicknames', index: 'ossNickNames', width: 200, align: 'left', editable:false},
+                { name: 'ossVersion', index: 'ossVersion', width: 75, align: 'left', editable:false},
                 { name: 'declaredLicenses', index: 'declaredLicenses', width: 300, align: 'left', editable:false},
                 { name: 'detectedLicenses', index: 'detectedLicenses', width: 300, align: 'left', editable:false},
                 { name: 'ossCopyright', index: 'copyright', width: 200, align: 'left', editable:false},


### PR DESCRIPTION
## Description #665 
### Main changes
- This PR adds detail failure message to OSS bulk items.
    - Required missing
    - Duplicated (nickname or OSS name)
    - Unconfirmed license
    - Duplicated Version
### Sub changes
- This PR moves status attribute to first

## AS-IS
![스크린샷 2022-09-13 오후 3 24 04](https://user-images.githubusercontent.com/33149791/191671241-b874be9c-0fd9-4011-a922-405a94da294a.png)
It shows only status fail or success, not includes fail reasons.

## TO-BE
![스크린샷 2022-09-22 오후 1 35 25](https://user-images.githubusercontent.com/33149791/191671565-59deb474-ba00-45dc-a355-82e2044d29cc.png)

![스크린샷 2022-09-22 오후 1 33 58](https://user-images.githubusercontent.com/33149791/191660728-14cd7479-e028-4c55-9561-d11c71d08a75.png)
It shows not only status fail or success, but also fail reasons.


