### PR TITLE
Fix a bug where only 1 Vulnerability list is shown when there is no version in OSS detail page

### DIFF
--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -296,21 +296,14 @@ public class OssController extends CoTopComponent{
 		List<Vulnerability> vulnInfoList = ossService.getOssVulnerabilityList2(ossMaster);
 		
 		if(vulnInfoList != null && !vulnInfoList.isEmpty()) {
-			if(ossMaster.getOssVersion().equals("-") && vulnInfoList.size() >= 2) {
-				List<Vulnerability> newVulnInfoList = new ArrayList<>();
-				for(int i=0; i<2; i++) {
-					newVulnInfoList.add(vulnInfoList.get(i));
-				}
-				model.addAttribute("vulnListMore", "vulnListMore");
-				model.addAttribute("vulnInfoList", toJson(newVulnInfoList));
-			}else if(!ossMaster.getOssVersion().equals("-") && vulnInfoList.size() >= 5) {
+			if(vulnInfoList.size() >= 5) {
 				List<Vulnerability> newVulnInfoList = new ArrayList<>();
 				for(int i=0; i<5; i++) {
 					newVulnInfoList.add(vulnInfoList.get(i));
 				}
 				model.addAttribute("vulnListMore", "vulnListMore");
 				model.addAttribute("vulnInfoList", toJson(newVulnInfoList));
-			}else {
+			} else {
 				model.addAttribute("vulnInfoList", toJson(vulnInfoList));
 			}
 		}

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -374,7 +374,6 @@ public class OssController extends CoTopComponent{
 		return OSS.EDIT_JSP;
 	}
 	
-	@SuppressWarnings("unchecked")
 	@PostMapping(value=OSS.SAVE_AJAX)
 	public @ResponseBody ResponseEntity<Object> saveAjax(
 			@ModelAttribute OssMaster ossMaster
@@ -382,6 +381,7 @@ public class OssController extends CoTopComponent{
 			, HttpServletResponse res
 			, Model model){
 		Map<String, Object> resMap = ossService.saveOss(ossMaster);
+		resMap = ossService.sendMailForSaveOss(resMap);
 		return makeJsonResponseHeader(resMap);
 	}
 	
@@ -1096,6 +1096,7 @@ public class OssController extends CoTopComponent{
 			}
 			if (checkDuplicated) {
 				Map<String, Object> result = ossService.saveOss(oss);
+				result = ossService.sendMailForSaveOss(result);
 				if (result.get("resCd").equals("10")) {
 					Map<String, String> ossNameMap = new HashMap<>();
 					ossNameMap.put("ossName", oss.getOssName());

--- a/src/main/java/oss/fosslight/service/OssService.java
+++ b/src/main/java/oss/fosslight/service/OssService.java
@@ -122,4 +122,6 @@ public interface OssService extends HistoryConfig{
 	List<Vulnerability> getOssVulnerabilityList2(OssMaster ossMaster);
 
 	List<String> getOssNicknameListWithoutOwn(OssMaster ossMaster, List<String> checkList, List<String> duplicatedList);
+
+	Map<String, Object> sendMailForSaveOss(Map<String, Object> resMap);
 }

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2482,7 +2482,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		return map;
 	}
 
+	@Transactional
 	@Override
+	@CacheEvict(value="autocompleteCache", allEntries=true)
 	public Map<String, Object> saveOss(OssMaster ossMaster) {
 		String resCd = "00";
 		String result = null;
@@ -2602,79 +2604,25 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			h.sethAction(action);
 			historyService.storeData(h);
 
-			// Send mail
-			String mailType = "";
-			if (CoConstDef.FLAG_YES.equals(ossMaster.getRenameFlag())) {
-				mailType = CoConstDef.CD_MAIL_TYPE_OSS_CHANGE_NAME;
-			} else if (isNew) {
-				mailType = isNewVersion
-						? CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION
-						: CoConstDef.CD_MAIL_TYPE_OSS_REGIST;
-			} else {
-				mailType = isChangedName
-						? CoConstDef.CD_MAIL_TYPE_OSS_CHANGE_NAME
-						: CoConstDef.CD_MAIL_TYPE_OSS_UPDATE;
-
-				if (isDeactivateFlag) {
-					mailType = CoConstDef.CD_MAIL_TYPE_OSS_DEACTIVATED;
-				}
-
-				if (isActivateFlag) {
-					mailType = CoConstDef.CD_MAIL_TYPE_OSS_ACTIVATED;
-				}
-			}
-			try {
-				CoMail mailBean = new CoMail(mailType);
-				mailBean.setParamOssId(ossId);
-				mailBean.setComment(ossMaster.getComment());
-
-				if (!isNew && !isDeactivateFlag) {
-					mailBean.setCompareDataBefore(beforeBean);
-					mailBean.setCompareDataAfter(afterBean);
-				} else if (isNewVersion) {
-					mailBean.setParamOssInfo(ossMaster);
-				}
-				CoMailManager.getInstance().sendMail(mailBean);
-
-			} catch (Exception e) {
-				log.error("Failed to send mail:" + e.getMessage());
-			}
-
-			if (!isNew && CoConstDef.FLAG_YES.equals(ossMaster.getRenameFlag())) {
-				if (updateOssNameVersionDiffMergeObject != null) {
-					List<OssMaster> beforeOssNameVersionMergeList = updateOssNameVersionDiffMergeObject.get("before");
-					List<OssMaster> afterOssNameVersionMergeList = updateOssNameVersionDiffMergeObject.get("after");
-
-					if (afterOssNameVersionMergeList != null) {
-						for (int i = 0; i < afterOssNameVersionMergeList.size(); i++) {
-							History history = work(afterOssNameVersionMergeList.get(i));
-							action = CoConstDef.ACTION_CODE_UPDATE;
-							history.sethAction(action);
-							historyService.storeData(history);
-
-							try {
-								mailType = CoConstDef.CD_MAIL_TYPE_OSS_CHANGE_NAME;
-								CoMail mailBean = new CoMail(mailType);
-								mailBean.setComment(ossMaster.getComment());
-								mailBean.setParamOssId(afterOssNameVersionMergeList.get(i).getOssId());
-								mailBean.setCompareDataBefore(beforeOssNameVersionMergeList.get(i));
-								mailBean.setCompareDataAfter(afterOssNameVersionMergeList.get(i));
-								CoMailManager.getInstance().sendMail(mailBean);
-							} catch (Exception e) {
-								log.error("Failed to send mail:" + e.getMessage());
-							}
-						}
-					}
-				}
-			}
-			resCd = "10";
-			putSessionObject("defaultLoadYn", true); // 화면 로드 시 default로 리스트 조회 여부 flag
+		} catch (RuntimeException e) {
+			log.error(e.getMessage(), e);
+			throw new RuntimeException(e.getMessage(), e);
 		} catch (Exception e) {
 			log.error("OSS " + action + "Failed.", e);
 			log.error(e.getMessage(), e);
+		} finally {
+			resMap.put("ossMaster", ossMaster);
+			resMap.put("ossId", ossId);
+			resMap.put("isNew", isNew);
+			resMap.put("isNewVersion", isNewVersion);
+			resMap.put("isChangedName", isChangedName);
+			resMap.put("isDeactivateFlag", isDeactivateFlag);
+			resMap.put("isActivateFlag", isActivateFlag);
+			if(beforeBean != null) resMap.put("beforeBean", beforeBean);
+			if(afterBean != null) resMap.put("afterBean", afterBean);
+			if(updateOssNameVersionDiffMergeObject != null) resMap.put("updateOssNameVersionDiffMergeObject", updateOssNameVersionDiffMergeObject);
 		}
-		resMap.put("resCd", resCd);
-		resMap.put("ossId", ossId);
+		
 		return resMap;
 	}
 
@@ -3581,5 +3529,93 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		}
 		
 		return duplicatedList;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Map<String, Object> sendMailForSaveOss(Map<String, Object> resMap) {
+		OssMaster ossMaster = (OssMaster) resMap.get("ossMaster");
+		String ossId = (String) resMap.get("ossId");
+		boolean isNew = (boolean) resMap.get("isNew");
+		boolean isNewVersion = (boolean) resMap.get("isNewVersion");
+		boolean isChangedName = (boolean) resMap.get("isChangedName");
+		boolean isDeactivateFlag = (boolean) resMap.get("isDeactivateFlag");
+		boolean isActivateFlag = (boolean) resMap.get("isActivateFlag");
+		
+		Map<String, List<OssMaster>> updateOssNameVersionDiffMergeObject = null;
+		if(resMap.containsKey("updateOssNameVersionDiffMergeObject")) updateOssNameVersionDiffMergeObject = (Map<String, List<OssMaster>>) resMap.get("updateOssNameVersionDiffMergeObject");
+		
+		String mailType = "";
+		
+		if (CoConstDef.FLAG_YES.equals(ossMaster.getRenameFlag())) {
+			mailType = CoConstDef.CD_MAIL_TYPE_OSS_CHANGE_NAME;
+		} else if (isNew) {
+			mailType = isNewVersion
+					? CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION
+					: CoConstDef.CD_MAIL_TYPE_OSS_REGIST;
+		} else {
+			mailType = isChangedName
+					? CoConstDef.CD_MAIL_TYPE_OSS_CHANGE_NAME
+					: CoConstDef.CD_MAIL_TYPE_OSS_UPDATE;
+
+			if (isDeactivateFlag) {
+				mailType = CoConstDef.CD_MAIL_TYPE_OSS_DEACTIVATED;
+			}
+
+			if (isActivateFlag) {
+				mailType = CoConstDef.CD_MAIL_TYPE_OSS_ACTIVATED;
+			}
+		}
+		try {
+			CoMail mailBean = new CoMail(mailType);
+			mailBean.setParamOssId(ossId);
+			mailBean.setComment(ossMaster.getComment());
+
+			if (!isNew && !isDeactivateFlag) {
+				mailBean.setCompareDataBefore((OssMaster) resMap.get("beforeBean"));
+				mailBean.setCompareDataAfter((OssMaster) resMap.get("afterBean"));
+			} else if (isNewVersion) {
+				mailBean.setParamOssInfo(ossMaster);
+			}
+			CoMailManager.getInstance().sendMail(mailBean);
+
+		} catch (Exception e) {
+			log.error("Failed to send mail:" + e.getMessage());
+		}
+
+		if (!isNew && CoConstDef.FLAG_YES.equals(ossMaster.getRenameFlag())) {
+			if (updateOssNameVersionDiffMergeObject != null) {
+				List<OssMaster> beforeOssNameVersionMergeList = updateOssNameVersionDiffMergeObject.get("before");
+				List<OssMaster> afterOssNameVersionMergeList = updateOssNameVersionDiffMergeObject.get("after");
+
+				if (afterOssNameVersionMergeList != null) {
+					for (int i = 0; i < afterOssNameVersionMergeList.size(); i++) {
+						History history = work(afterOssNameVersionMergeList.get(i));
+						history.sethAction(CoConstDef.ACTION_CODE_UPDATE);
+						historyService.storeData(history);
+
+						try {
+							mailType = CoConstDef.CD_MAIL_TYPE_OSS_CHANGE_NAME;
+							CoMail mailBean = new CoMail(mailType);
+							mailBean.setComment(ossMaster.getComment());
+							mailBean.setParamOssId(afterOssNameVersionMergeList.get(i).getOssId());
+							mailBean.setCompareDataBefore(beforeOssNameVersionMergeList.get(i));
+							mailBean.setCompareDataAfter(afterOssNameVersionMergeList.get(i));
+							CoMailManager.getInstance().sendMail(mailBean);
+						} catch (Exception e) {
+							log.error("Failed to send mail:" + e.getMessage());
+						}
+					}
+				}
+			}
+		}
+		
+		putSessionObject("defaultLoadYn", true); // 화면 로드 시 default로 리스트 조회 여부 flag
+		
+		resMap.clear();
+		resMap.put("resCd", "10");
+		resMap.put("ossId", ossId);
+		
+		return resMap;
 	}
 }

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2603,7 +2603,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 			h.sethAction(action);
 			historyService.storeData(h);
-
+			resCd = "10";
 		} catch (RuntimeException e) {
 			log.error(e.getMessage(), e);
 			throw new RuntimeException(e.getMessage(), e);
@@ -2622,7 +2622,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			if(afterBean != null) resMap.put("afterBean", afterBean);
 			if(updateOssNameVersionDiffMergeObject != null) resMap.put("updateOssNameVersionDiffMergeObject", updateOssNameVersionDiffMergeObject);
 		}
-		
+		resMap.put("resCd", resCd);
 		return resMap;
 	}
 
@@ -3611,11 +3611,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		}
 		
 		putSessionObject("defaultLoadYn", true); // 화면 로드 시 default로 리스트 조회 여부 flag
-		
-		resMap.clear();
-		resMap.put("resCd", "10");
 		resMap.put("ossId", ossId);
-		
 		return resMap;
 	}
 }

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2606,7 +2606,6 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			resCd = "10";
 		} catch (RuntimeException e) {
 			log.error(e.getMessage(), e);
-			throw new RuntimeException(e.getMessage(), e);
 		} catch (Exception e) {
 			log.error("OSS " + action + "Failed.", e);
 			log.error(e.getMessage(), e);

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -1175,7 +1175,8 @@ public class ExcelUtil extends CoTopComponent {
     				}
     				
     				// empty row check
-    				if(isEmpty(bean.getOssName()) && isEmpty(bean.getOssVersion()) && isEmpty(subBean.getLicenseName()) && isEmpty(bean.getBinaryName()) && isEmpty(bean.getFilePath())) {
+    				if(isEmpty(bean.getOssName()) && isEmpty(bean.getOssVersion()) && isEmpty(subBean.getLicenseName()) && isEmpty(bean.getBinaryName()) && isEmpty(bean.getFilePath())
+    						&& isEmpty(bean.getDownloadLocation()) && isEmpty(bean.getHomepage()) && isEmpty(bean.getCopyrightText())) {
     					continue;
     				}
     
@@ -1479,8 +1480,8 @@ public class ExcelUtil extends CoTopComponent {
     			OssComponents bean = new OssComponents();
     			// android bin의 경우 binary name을 무조건 수정할 수 있다.
     			// [MC요청] 2. Project List – OSS List에서 Binary DB 검색 결과 제공
-    			// BIN[Android] binary name 수정 불가(최종변경)
-    			//bean.setCustomBinaryYn(CoConstDef.FLAG_YES);
+    			// BIN[Android] binary name 수정 가능(최종변경)
+    			bean.setCustomBinaryYn(CoConstDef.FLAG_YES);
     			
     			// 기본정보
     			bean.setOssName(ossNameCol < 0 ? "" : getCellData(row.getCell(ossNameCol)));
@@ -1492,10 +1493,6 @@ public class ExcelUtil extends CoTopComponent {
     			bean.setDownloadLocation(downloadLocationCol < 0 ? "" : getCellData(row.getCell(downloadLocationCol)));
     			bean.setCopyrightText(copyrightTextCol < 0 ? "" : getCellData(row.getCell(copyrightTextCol)));
     			bean.setComments(commentCol < 0 ? "" : getCellData(row.getCell(commentCol)));
-    			
-    			if(isEmpty(bean.getBinaryName())) {
-    				continue;
-    			}
     			
     			// android 의 경우는 list에는 포함시키고 exclude하는 것으로 변경
     			// 기존 레포트에서 load on product 칼럼이 있는 경우, X선택된 row는 제외
@@ -1526,7 +1523,11 @@ public class ExcelUtil extends CoTopComponent {
     				bean.setCopyrightText("");
     			}
     
-    
+    			if(isEmpty(bean.getBinaryName()) && isEmpty(bean.getOssName()) && isEmpty(bean.getOssVersion()) && isEmpty(subBean.getLicenseName()) && isEmpty(bean.getFilePath()) 
+    					&& isEmpty(bean.getDownloadLocation()) && isEmpty(bean.getHomepage()) && isEmpty(bean.getCopyrightText())) {
+    				continue;
+    			}
+    			
     			// homepage와 download location이 http://로 시작하지 않을 경우 자동으로 체워줌(* download location의 경우 git으로 시작 시 http://를 붙이지 않음.)
 //    			if(!isEmpty(bean.getHomepage()) 
 //    					&& !(bean.getHomepage().toLowerCase().startsWith("http://") 

--- a/src/main/resources/oss/fosslight/repository/OssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/OssMapper.xml
@@ -2120,7 +2120,12 @@
 	</select>
 	
 	<select id="getOssVulnerabilityList2" parameterType="oss.fosslight.domain.OssMaster" resultType="oss.fosslight.domain.Vulnerability">
-		SELECT DATA.PRODUCT
+		<if test="@oss.fosslight.util.StringUtil@equals('-', ossVersion)">
+			SELECT T1.PRODUCT, T1.CVSS_SCORE, T1.CVE_ID, T1.VULN_SUMMARY, T1.MODI_DATE
+			FROM
+			(
+		</if>
+				SELECT DATA.PRODUCT
 					 , DATA.VERSION
 					 , CVE.CVSS_SCORE
 					 , CVE.CVE_ID
@@ -2145,8 +2150,12 @@
 				 	   ) DATA
 				 INNER JOIN NVD_CVE_V3 CVE
 				    ON DATA.CVE_ID = CVE.CVE_ID
-		ORDER BY CVSS_SCORE DESC, MODI_DATE DESC
-		LIMIT 5
+		<if test="@oss.fosslight.util.StringUtil@equals('-', ossVersion)">
+			) T1
+			GROUP BY T1.PRODUCT, T1.CVSS_SCORE, T1.CVE_ID, T1.VULN_SUMMARY, T1.MODI_DATE
+		</if>
+			ORDER BY CVSS_SCORE DESC, MODI_DATE DESC
+			LIMIT 5
 	</select>
 	
 	<select id="selectMultiOssList" parameterType="oss.fosslight.domain.OssMaster" resultType="string">

--- a/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
@@ -2599,7 +2599,7 @@
 		, T1.REFERENCE_DIV
 		, T1.COMPONENT_IDX
 		, T1.OSS_ID
-		, IFNULL((SELECT NICK.OSS_NAME FROM OSS_NICKNAME NICK WHERE NICK.OSS_NICKNAME = T1.OSS_NAME), T1.OSS_NAME) AS OSS_NAME
+		, T1.OSS_NAME
 		, T1.OSS_VERSION
 		, T1.DOWNLOAD_LOCATION
 		, T1.HOMEPAGE
@@ -2868,7 +2868,7 @@
 	
 	<update id="updatePartnerOssList" parameterType="oss.fosslight.domain.OssComponents">
 		/* ProjectMapper.updatePartnerOssList */
-		UPDATE OSS_COMPONENTS SET EXCLUDE_YN = #{excludeYn} WHERE COMPONENT_ID = #{componentId};
+		UPDATE OSS_COMPONENTS SET OSS_NAME = #{ossName}, EXCLUDE_YN = #{excludeYn} WHERE COMPONENT_ID = #{componentId};
 	</update>
 	<delete id="deleteOssComponentsWithIds" parameterType="oss.fosslight.domain.OssComponents">
 	/* ProjectMapper.deleteComponents */
@@ -2942,7 +2942,7 @@
 					, #{referenceDiv}	
 					, (SELECT IFNULL(MAX(COMPONENT_IDX), 0) + 1 FROM OSS_COMPONENTS OC WHERE REFERENCE_ID=#{referenceId} AND REFERENCE_DIV=#{referenceDiv})
 					, OSS_ID
-					, OSS_NAME
+					, #{ossName}
 					, OSS_VERSION	
 					, DOWNLOAD_LOCATION	
 					, HOMEPAGE	


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Fix the bug where OSS information is blank in mail when saving OSS.
-  Change the condition to check empty row when uploading OSS Report
    - AS-IS: If OSS Name, OSS version, License, binary name and file path are blank.
    - TO-BE : If OSS Name, OSS version, License, binary name, file path, Download location, Homepage and Copyright is blank.
- Fix a bug where only 1 Vulnerability list is shown when there is no version in OSS detail page.
- Project - Identification > 3rd Party Tab > Change nickname to OSS NAME when clicking Save.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
