### PR TITLE
Export button depends on project identification status

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
@@ -778,17 +778,22 @@
 					</span>
 					<input type="hidden" id="mergeYn"  style="display: none;"/>
                     <span class="right">
-                        <div id="ExportContainer" class="inblock" style="vertical-align:top; position: relative;">
-							<input id="Export" type="button" value="Export" class="btnColor red btnExport" onclick="bom_fn.exportList()"/>
-							<div id="ExportList" class="w200 tright" style="display: none; position: absolute; z-index: 1; right: 0;" onclick="bom_fn.selectDownloadFile()">
-								<a id="report_sub" style="display: block;">FOSSLight Report (Spreadsheet)</a>
-								<a id="Spreadsheet_sub" style="display: block;">SPDX (Spreadsheet)</a>
-								<a id="RDF_sub" style="display: block;">SPDX (RDF)</a>
-								<a id="TAG_sub" style="display: block;">SPDX (TAG)</a>
-								<a id="JSON_sub" style="display: block;">SPDX (JSON)</a>
-								<a id="YAML_sub" style="display: block;">SPDX (YAML)</a>
+						<c:if test="${project.identificationStatus ne 'CONF'}">
+							<input type="button" value="Export" class="btnColor red btnExport" onclick="bom_fn.downloadExcel()"/>
+						</c:if>
+						<c:if test="${project.identificationStatus eq 'CONF'}">
+							<div id="ExportContainer" class="inblock" style="vertical-align:top; position: relative;">
+								<input id="Export" type="button" value="Export" class="btnColor red btnExport" onclick="bom_fn.exportList()"/>
+								<div id="ExportList" class="w200 tright" style="display: none; position: absolute; z-index: 1; right: 0;" onclick="bom_fn.selectDownloadFile()">
+									<a id="report_sub" style="display: block;">FOSSLight Report (Spreadsheet)</a>
+									<a id="Spreadsheet_sub" style="display: block;">SPDX (Spreadsheet)</a>
+									<a id="RDF_sub" style="display: block;">SPDX (RDF)</a>
+									<a id="TAG_sub" style="display: block;">SPDX (TAG)</a>
+									<a id="JSON_sub" style="display: block;">SPDX (JSON)</a>
+									<a id="YAML_sub" style="display: block;">SPDX (YAML)</a>
+								</div>
 							</div>
-						</div>
+						</c:if>
                         <input type="button" value="Yaml" class="btnColor red btnExport" onclick="com_fn.downloadYaml('BOM')"/>
                         <c:if test="${project.dropYn ne 'Y'}">
 	                        <input id="bomResetUp" type="button" value="Reset" class="btnColor btnReset idenReset" />


### PR DESCRIPTION
## Description

1) Rollback getVerificationSPDX_SpreadSheetExcelPost code

2) Export button depends on identification status
- project identification status is CONF (confirm)
![image](https://user-images.githubusercontent.com/79046106/192133983-d3278821-39af-4f57-9924-c5f9f05e7229.png)
If user clicks export button, then user can select a file to download

- project identification status is not CONF
![image](https://user-images.githubusercontent.com/79046106/192134000-ff7428a2-424f-4688-a119-b0914cd40524.png)
If user clicks export button, then user immediately can download FOSSLight Report


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
