### PR TITLE
Add license text files to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL maintainer="FOSSLight <fosslight-dev@lge.com>"
 COPY --from=build /home/gradle/src/build/libs/*.war /app/FOSSLight.war
 COPY ./verify/verify /app/verify/verify
 COPY ./db/wait-for /app/wait-for
-COPY ./docs /app/docs
+COPY ./LICENSES /app/LICENSES
 
 ADD ./src/main/resources/template /app/template
 


### PR DESCRIPTION
Signed-off-by: jongwooo <han980817@gmail.com>
Pull request #675, #699 
Issue #601 

## Description

```diff
- COPY ./docs /app/docs
+ COPY ./LICENSES /app/LICENSES
```

Remove unused folder and add **license text files** to Docker image.

## References

- [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
