### PR TITLE
Remove the limit on the number of rows for the bulk edit button

### DIFF
--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -2041,7 +2041,7 @@ public class OssController extends CoTopComponent{
 		return makeJsonResponseHeader(false, "false");
 	}
 	
-	@GetMapping(value=OSS.OSS_BULK_EDIT_POPUP, produces = "text/html; charset=utf-8")
+	@PostMapping(value=OSS.OSS_BULK_EDIT_POPUP)
 	public String bulkEditPopup(HttpServletRequest req, HttpServletResponse res, 
 			@RequestParam(value="rowId", required=true)String rowId,
 			@RequestParam(value="target", required=true)String target,

--- a/src/main/java/oss/fosslight/repository/OssMapper.java
+++ b/src/main/java/oss/fosslight/repository/OssMapper.java
@@ -235,5 +235,5 @@ public interface OssMapper {
 
 	List<String> selectMultiOssList(OssMaster ossMaster);
 
-	List<OssMaster> getDeactivateOssList();
+	List<String> getDeactivateOssList();
 }

--- a/src/main/java/oss/fosslight/service/OssService.java
+++ b/src/main/java/oss/fosslight/service/OssService.java
@@ -125,5 +125,5 @@ public interface OssService extends HistoryConfig{
 
 	Map<String, Object> sendMailForSaveOss(Map<String, Object> resMap);
 
-	List<OssMaster> getDeactivateOssList();
+	List<String> getDeactivateOssList();
 }

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -3615,7 +3615,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	}
 
 	@Override
-	public List<OssMaster> getDeactivateOssList() {
+	public List<String> getDeactivateOssList() {
 		return ossMapper.getDeactivateOssList();
 	}
 }

--- a/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
@@ -1648,7 +1648,8 @@ public class T2CoProjectValidator extends T2CoValidator {
 			}
 
 			// check deactivate oss info
-			List<OssMaster> deactivateOssList = ossService.getDeactivateOssList();
+			List<String> deactivateOssList = ossService.getDeactivateOssList();
+			deactivateOssList.replaceAll(String::toUpperCase);
 			
 			// checkBasicError : REQUIRED, LENGTH, FORMAT 만 체크!
 			for (ProjectIdentification bean : ossComponetList) {
@@ -1802,23 +1803,18 @@ public class T2CoProjectValidator extends T2CoValidator {
 							}
 						}
 					} else {
-						OssMaster om = null;
+						boolean deactivateFlag = false;
 						
 						if(!isEmpty(bean.getOssName())) {
-							for(OssMaster deactivateOm : deactivateOssList) {
-								if(deactivateOm.getOssName().toUpperCase().equals(bean.getOssName().toUpperCase())) {
-									om = deactivateOm;
-									break;
-								}
+							if(deactivateOssList.contains(bean.getOssName().toUpperCase())) {
+								deactivateFlag = true;
 							}
 							
-							if(om != null) {
-								if(CoConstDef.FLAG_YES.equals(om.getDeactivateFlag())){
-									if (CommonFunction.isAdmin()) {
-										errMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
-									} else {
-										diffMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
-									}
+							if(deactivateFlag) {
+								if (CommonFunction.isAdmin()) {
+									errMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
+								} else {
+									diffMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
 								}
 							}
 						}

--- a/src/main/resources/oss/fosslight/repository/OssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/OssMapper.xml
@@ -2171,7 +2171,11 @@
 		HAVING COUNT(T1.OSS_NAME) > 1
 	</select>
 	
-	<select id="getDeactivateOssList" resultType="oss.fosslight.domain.OssMaster">
-		SELECT * FROM OSS_MASTER WHERE USE_YN = 'Y' AND DEACTIVATE_FLAG = 'Y'
+	<select id="getDeactivateOssList" resultType="string">
+		SELECT OSS_NAME 
+		FROM OSS_MASTER 
+		WHERE USE_YN = 'Y' 
+		AND DEACTIVATE_FLAG = 'Y'
+		GROUP BY OSS_NAME
 	</select>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/admin/partner/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/edit-js.jsp
@@ -1917,20 +1917,25 @@ var saveFlag = false;
 	        if(rowCheckedArr.length > 0){
 	            fn_grid_com.totalGridSaveMode(targetGird);
 	            
-	            var bulkEditArr = gridList.jqGrid("getGridParam", "selarrrow");
-	            var url = '<c:url value="/oss/ossBulkEditPopup?rowId=' + rowCheckedArr + '&target=' + targetGird + '"/>';
-	            
 	            var _popup = null;
 
 	            if(_popup == null || _popup.closed){
-	                _popup = window.open(url, "bulkEditViewPartnerPopup", "width=850, height=380, toolbar=no, location=no, left=100, top=100, resizable=yes");
+	                _popup = window.open("", "bulkEditViewPartnerPopup", "width=850, height=380, toolbar=no, location=no, left=100, top=100, resizable=yes");
 
+	                $("#partnerBulkEditForm > input[name=rowId]").val(rowCheckedArr);
+					$("#partnerBulkEditForm > input[name=target]").val(targetGird);
+					$("#partnerBulkEditForm").submit();
+	                
 	                if(!_popup || _popup.closed || typeof _popup.closed=='undefined') {
 	                    alertify.alert('<spring:message code="msg.common.window.allowpopup" />', function(){});
 	                }
 	            } else {
 	                _popup.close();
-	                _popup = window.open(url, "bulkEditViewPartnerPopup", "width=850, height=380, toolbar=no, location=no, left=100, top=100, resizable=yes");
+	                _popup = window.open("", "bulkEditViewPartnerPopup", "width=850, height=380, toolbar=no, location=no, left=100, top=100, resizable=yes");
+
+	                $("#partnerBulkEditForm > input[name=rowId]").val(rowCheckedArr);
+					$("#partnerBulkEditForm > input[name=target]").val(targetGird);
+					$("#partnerBulkEditForm").submit();
 	            }
 	        }else{
 	            alertify.alert('<spring:message code="msg.oss.select.ossTable" />', function(){});

--- a/src/main/webapp/WEB-INF/views/admin/partner/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/edit.jsp
@@ -494,3 +494,7 @@
 		<input type="button" value="OK" class="btnColor red modifyComment" />
 	</div>
 </div>
+<form id="partnerBulkEditForm" method="POST" action="<c:url value="/oss/ossBulkEditPopup"/>" target="bulkEditViewPartnerPopup">
+	<input type="hidden" name="rowId" value=""/>
+	<input type="hidden" name="target" value=""/>
+</form>

--- a/src/main/webapp/WEB-INF/views/admin/project/common-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/common-js.jsp
@@ -1243,19 +1243,25 @@ var com_fn = {
         if(rowCheckedArr.length > 0){
             fn_grid_com.totalGridSaveMode(targetGird);
 
-            var url = '<c:url value="/oss/ossBulkEditPopup?rowId=' + rowCheckedArr + '&target=' + targetGird + '"/>';
-
 			var _popup = null;
 			
             if(_popup == null || _popup.closed){
-                _popup = window.open(url, "bulkEditViewProjectPopup", "width=850, height=430, toolbar=no, location=no, left=100, top=100, resizable=yes");
+            	_popup = window.open("", "bulkEditViewProjectPopup", "width=850, height=430, toolbar=no, location=no, left=100, top=100, resizable=yes");
+
+            	$("#bulkEditForm > input[name=rowId]").val(rowCheckedArr);
+				$("#bulkEditForm > input[name=target]").val(targetGird);
+				$("#bulkEditForm").submit();
 
                 if(!_popup || _popup.closed || typeof _popup.closed=='undefined') {
                     alertify.alert('<spring:message code="msg.common.window.allowpopup" />', function(){});
                 }
             } else {
                 _popup.close();
-                _popup = window.open(url, "bulkEditViewProjectPopup", "width=850, height=430, toolbar=no, location=no, left=100, top=100, resizable=yes");
+                _popup = window.open("", "bulkEditViewProjectPopup", "width=850, height=430, toolbar=no, location=no, left=100, top=100, resizable=yes");
+
+                $("#bulkEditForm > input[name=rowId]").val(rowCheckedArr);
+				$("#bulkEditForm > input[name=target]").val(targetGird);
+				$("#bulkEditForm").submit();
             }
         }else{
             alertify.alert('<spring:message code="msg.oss.select.ossTable" />', function(){});

--- a/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
@@ -895,4 +895,7 @@
 		<input type="button" value="OK" class="btnColor red sheetApply" onclick="src_fn.getSheetData()">
 	</div>
 </div>
-
+<form id="bulkEditForm" method="POST" action="<c:url value="/oss/ossBulkEditPopup"/>" target="bulkEditViewProjectPopup">
+	<input type="hidden" name="rowId" value=""/>
+	<input type="hidden" name="target" value=""/>
+</form>

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
@@ -805,20 +805,25 @@
 	        if(rowCheckedArr.length > 0){
 	            fn_grid_com.totalGridSaveMode(targetGird);
 	            
-	            var bulkEditArr = gridList.jqGrid("getGridParam", "selarrrow");
-	            var url = '<c:url value="/oss/ossBulkEditPopup?rowId=' + rowCheckedArr + '&target=selfCheck"/>';
-	            
 	            var _popup = null;
 	            
 	            if(_popup == null || _popup.closed){
-	                _popup = window.open(url, "bulkEditViewSelfPopup", "width=850, height=350, toolbar=no, location=no, left=100, top=100, resizable=yes");
+	                _popup = window.open("", "bulkEditViewSelfPopup", "width=850, height=415, toolbar=no, location=no, left=100, top=100, resizable=yes");
 
+	                $("#selfBulkEditForm > input[name=rowId]").val(rowCheckedArr);
+					$("#selfBulkEditForm > input[name=target]").val(targetGird);
+					$("#selfBulkEditForm").submit();
+	                
 	                if(!_popup || _popup.closed || typeof _popup.closed=='undefined') {
 	                    alertify.alert('<spring:message code="msg.common.window.allowpopup" />', function(){});
 	                }
 	            } else {
 	                _popup.close();
-	                _popup = window.open(url, "bulkEditViewSelfPopup", "width=850, height=350, toolbar=no, location=no, left=100, top=100, resizable=yes");
+	                _popup = window.open("", "bulkEditViewSelfPopup", "width=850, height=415, toolbar=no, location=no, left=100, top=100, resizable=yes");
+
+	                $("#selfBulkEditForm > input[name=rowId]").val(rowCheckedArr);
+					$("#selfBulkEditForm > input[name=target]").val(targetGird);
+					$("#selfBulkEditForm").submit();
 	            }
 	        }else{
 	            alertify.alert('<spring:message code="msg.oss.select.ossTable" />', function(){});

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit.jsp
@@ -334,4 +334,8 @@
 		<input type="button" value="OK" class="btnColor red sheetApply" onclick="src_fn.getSheetData()">
 	</div>
 </div>
+<form id="selfBulkEditForm" method="POST" action="<c:url value="/oss/ossBulkEditPopup"/>" target="bulkEditViewSelfPopup">
+	<input type="hidden" name="rowId" value=""/>
+	<input type="hidden" name="target" value=""/>
+</form>
 <!-- //wrap -->


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Reduce the loading speed when entering the Identification tab by changing the Deactivate OSS check method.
- Remove the limit on the number of rows for the bulk edit button. 
     - Change Bulk edit to GET -> POST so that many rows can be edited at once.
 
## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
