### PR TITLE
Add triming logic to list attributes in OSS Bulk

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
@@ -109,7 +109,6 @@
      * replace stringData wtih listData in 3 rows (ossNicknames, declaredLicenses, detectedLicenses)
      * */
     function dataValidCheck(mainData) {
-
         mainData.forEach((row) => {
             stringDataForValid.forEach((strData) => {
                 ossData[row["gridId"]][strData] = row[strData].trim();
@@ -121,6 +120,7 @@
                     ossData[row["gridId"]][listData] = []
                 } else {
                     ossData[row["gridId"]][listData] = ossData[row["gridId"]][listData].split(",")
+                        .map(item => item.trim()).filter(item => item.length);
                 }
             })
         })


### PR DESCRIPTION
## Description
**This PR add triming logic to listable attributes in frontend.**
As a result,  elements of listable attributes are trimmed before bulk request.

## Target
**listable attributes** 
- ossNicknames
- declaredLicenses
- detectedLicenses

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)