### PR TITLE
Fix download location check function

### DIFF
--- a/src/main/java/oss/fosslight/domain/CoMailManager.java
+++ b/src/main/java/oss/fosslight/domain/CoMailManager.java
@@ -1402,9 +1402,7 @@ public class CoMailManager extends CoTopComponent {
 								)
 						)
 				{
-					String linkUrl = CommonFunction.emptyCheckProperty("server.domain", "http://fosslight.org");
-					linkUrl += "/oss/edit/" + bean.getParamOssId();
-					_s = "<a href='"+linkUrl+"' target='_blank'>" + _s + "</a>";
+					_s = "<a href='javascript:void(0);' style='font-size:16px;' onclick='fn.sentMailMoveTab(&#39;"+ossInfo.getOssName()+"&#39;);'>" + _s + "</a>";
 				}
 			}
 			
@@ -1412,7 +1410,27 @@ public class CoMailManager extends CoTopComponent {
 		}
 		
 		if(title.indexOf("${OSS ID}") > -1) {
-			title = StringUtil.replace(title, "${OSS ID}", avoidNull(bean.getParamOssId()));
+			if(isMailBodySubject 
+					&& (
+							CoConstDef.CD_MAIL_TYPE_OSS_REGIST.equals(bean.getMsgType()) 
+							|| CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION.equals(bean.getMsgType())
+							|| CoConstDef.CD_MAIL_TYPE_OSS_UPDATE.equals(bean.getMsgType())
+							|| CoConstDef.CD_MAIL_TYPE_ADDNICKNAME_UPDATE.equals(bean.getMsgType())
+							|| CoConstDef.CD_MAIL_TYPE_OSS_CHANGE_NAME.equals(bean.getMsgType())
+							|| CoConstDef.CD_MAIL_TYPE_OSS_DEACTIVATED.equals(bean.getMsgType())
+							|| CoConstDef.CD_MAIL_TYPE_OSS_ACTIVATED.equals(bean.getMsgType())
+
+							)
+					)
+			{
+				String _s = "OSS-" + avoidNull(bean.getParamOssId());
+				String linkUrl = CommonFunction.emptyCheckProperty("server.domain", "http://fosslight.org");
+				linkUrl += "/oss/edit/" + bean.getParamOssId();
+				_s = "<a href='"+linkUrl+"' style='font-size:16px;' target='_blank'>" + _s + "</a>";
+				title = StringUtil.replace(title, "OSS-${OSS ID}", _s);
+			} else {
+				title = StringUtil.replace(title, "${OSS ID}", avoidNull(bean.getParamOssId()));
+			}
 		}
 		
 		// 삭제된 이메일에 대한 정보

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2144,6 +2144,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						if(!isEmpty(checkName)) {
 							bean.setCheckOssList("Y");
 						} else {
+							String key = avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion());
+							if(CoCodeManager.OSS_INFO_UPPER.containsKey(key.toUpperCase())) {
+								continue;
+							}
 //							OssMaster ossBean = new OssMaster();
 //							ossBean.setOssName(bean.getOssName());
 //							if(checkExistsOssByname(ossBean) > 0) {
@@ -2217,7 +2221,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					}
 					
 					if(downloadlocationUrl.startsWith("www.")) {
-						downloadlocationUrl = downloadlocationUrl.substring(5, downloadlocationUrl.length());
+						downloadlocationUrl = downloadlocationUrl.substring(4, downloadlocationUrl.length());
 					}
 					
 					if(downloadlocationUrl.contains(".git")) {

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -3556,6 +3556,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
  		if(dbInfoList != null && !dbInfoList.isEmpty()) {
  			for(String key : dbInfoList) {
+ 				key = key.toUpperCase();
  				if(!dbPartnerUseFlag && key.startsWith(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER)) {
  					// 3rd의 경우 라이선스를 무시하고 key를 생성하기 때문에 중복되는 경우가 있음
  					if(!dbPartnerList.contains(key)) {

--- a/src/main/resources/oss/fosslight/repository/OssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/OssMapper.xml
@@ -1696,8 +1696,8 @@
 		    ON OM.OSS_ID = DOWN.OSS_ID
 		 WHERE OM.OSS_NAME != #{ossName}
 		   AND (
-		   		   OM.DOWNLOAD_LOCATION LIKE CONCAT('%', #{downloadLocation})
-		    	OR DOWN.DOWNLOAD_LOCATION LIKE CONCAT('%', #{downloadLocation})
+		   		   SUBSTRING_INDEX(SUBSTRING_INDEX(OM.DOWNLOAD_LOCATION, '//', -1), 'www.', -1) = #{downloadLocation}
+		    	OR SUBSTRING_INDEX(SUBSTRING_INDEX(DOWN.DOWNLOAD_LOCATION, '//', -1), 'www.', -1) = #{downloadLocation}
 		       )
 		 GROUP BY OM.OSS_NAME
 	</select>
@@ -1785,8 +1785,8 @@
 		    ON OM.OSS_ID = DOWN.OSS_ID
 		 WHERE OM.OSS_NAME = #{ossName}
 		   AND ( 
-		   		OM.DOWNLOAD_LOCATION LIKE CONCAT('%', #{downloadLocation})
-		    	OR DOWN.DOWNLOAD_LOCATION LIKE CONCAT('%', #{downloadLocation})
+		   		SUBSTRING_INDEX(SUBSTRING_INDEX(OM.DOWNLOAD_LOCATION, '//', -1), 'www.', -1) = #{downloadLocation}
+		    	OR SUBSTRING_INDEX(SUBSTRING_INDEX(DOWN.DOWNLOAD_LOCATION, '//', -1), 'www.', -1) = #{downloadLocation}
 		       )
 	</select>
 	

--- a/src/main/webapp/WEB-INF/views/admin/oss/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/list-js.jsp
@@ -43,6 +43,18 @@
 				initParam.ignoreSearchFlag = "Y";
 			}
 
+			var sentMailparam = $('.scrl > ul > li:eq(3) > input', window.parent.document)[0];
+			sentMailParam = $(sentMailparam).val();
+			
+			if(sentMailParam){
+				$("input[name=ossName]").val(sentMailParam.trim());
+				initParam.ignoreSearchFlag = "N";
+				initParam = serializeObjectHelper();
+
+				var sentMailParam2 = $('.scrl > ul > li:eq(3) > input', window.parent.document)[0];
+				$(sentMailParam2).val("");
+			}
+			
 			$('#search').on('click',function(e){
 				e.preventDefault();
 

--- a/src/main/webapp/WEB-INF/views/admin/system/sentMail-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/system/sentMail-js.jsp
@@ -22,6 +22,12 @@
 		},
 		searchDatePick : function(element) {
 		    $(element).datepicker();
+		},
+		sentMailMoveTab : function(data){
+			var leftMenu = $('.scrl > ul > li:eq(3) > a', window.parent.document)[0];
+			var param = $('.scrl > ul > li:eq(3) > input', window.parent.document)[0];
+			$(param).val(data);
+			$(leftMenu)[0].click();
 		}
 	};
 	

--- a/src/main/webapp/WEB-INF/views/template/layout/admin/header.jsp
+++ b/src/main/webapp/WEB-INF/views/template/layout/admin/header.jsp
@@ -56,7 +56,7 @@
 							<li><a href="#<c:url value="/statistics/view"/>" class="add-tab">Statistics</a></li>
 					</c:if>
 					<li><a href="#<c:url value="/license/list"/>" class="add-tab">License List</a></li>
-					<li><a href="#<c:url value="/oss/list"/>" class="add-tab">OSS List</a></li>
+					<li><a href="#<c:url value="/oss/list"/>" class="add-tab">OSS List</a><input type="hidden" name="sentMailParam"></li>
 					<c:if test="${projectFlag}">
 						<li><a href="#<c:url value="/project/list"/>" class="add-tab">Project List</a></li>
 					</c:if>


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Fix the bug that matches even if the Download location is not the same when clicking Check OSS Name.
- Change the link in the OSS registration and modification mail.
- Add the OSS rename record to the history list.
- Fix the bug where OSS Notice is not issued when project copy (Packaging confirm).
    -  Fix the bug that changes to N/A even if OSS Notice is checked as General when copying a Packaging: N/A project.
    
## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
