### PR TITLE
Highlight Oss data failed to save in red

### DIFF
--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -1009,7 +1009,7 @@ public class OssController extends CoTopComponent{
 			, HttpServletRequest req
 			, HttpServletResponse res
 			, Model model) {
-		List<Map<String, String>> ossDataMapList = new ArrayList<>();
+		List<Map<String, Object>> ossDataMapList = new ArrayList<>();
 		Map<String, Object> resMap = new HashMap<>();
 
 		if (ossMasters.isEmpty()) {
@@ -1020,7 +1020,7 @@ public class OssController extends CoTopComponent{
 
 		boolean licenseCheck;
 		for (OssMaster oss : ossMasters) {
-			Map<String, String> ossDataMap = new HashMap<>();
+			Map<String, Object> ossDataMap = new HashMap<>();
 			oss.setOssCopyFlag(CoConstDef.FLAG_NO);
 			oss.setRenameFlag(CoConstDef.FLAG_NO);
 			oss.setAddNicknameYn(CoConstDef.FLAG_YES); // Append nickname only
@@ -1035,16 +1035,14 @@ public class OssController extends CoTopComponent{
 			int licenseCount = 1;
 			if (declaredLicenses == null || declaredLicenses.isEmpty()) {
 				log.debug("DeclaredLicenses is null:" + oss.getOssName());
-				ossDataMap.put("gridId", oss.getGridId());
-				ossDataMap.put("status", "X (Required missing)");
+				ossDataMap = ossService.getOssDataMap(oss.getGridId(), false, "X (Required missing)");
 				ossDataMapList.add(ossDataMap);
 				continue;
 			}
 
 			if (Objects.isNull(oss.getOssName()) || StringUtil.isBlank(oss.getOssName())) {
 				log.debug("OSS name is required.");
-				ossDataMap.put("gridId", oss.getGridId());
-				ossDataMap.put("status", "X (Required missing)");
+				ossDataMap = ossService.getOssDataMap(oss.getGridId(), false, "X (Required missing)");
 				ossDataMapList.add(ossDataMap);
 				continue;
 			}
@@ -1091,8 +1089,7 @@ public class OssController extends CoTopComponent{
 			}
 			if (licenseCheck) {
 				log.debug("Add failed due to declared license:" + oss.getOssName());
-				ossDataMap.put("gridId", oss.getGridId());
-				ossDataMap.put("status", "X (Unconfirmed license)");
+				ossDataMap = ossService.getOssDataMap(oss.getGridId(), false, "X (Unconfirmed license)");
 				ossDataMapList.add(ossDataMap);
 				continue;
 			}
@@ -1111,8 +1108,7 @@ public class OssController extends CoTopComponent{
 			boolean checkDuplicated = true;
 			if (ossService.checkExistsOss(oss) != null) {
 				log.debug("Same OSS, version already exists.:" + oss.getOssName() + " v" + oss.getOssVersion());
-				ossDataMap.put("gridId", oss.getGridId());
-				ossDataMap.put("status", "X (Duplicated Version)");
+				ossDataMap = ossService.getOssDataMap(oss.getGridId(), false, "X (Duplicated Version)");
 				ossDataMapList.add(ossDataMap);
 				checkDuplicated = false;
 			} else {
@@ -1122,8 +1118,7 @@ public class OssController extends CoTopComponent{
 				OssMaster checkName = ossService.checkExistsOssNickname2(nameCheck);
 				if (checkName != null) {
 					log.debug(oss.getOssName() + " is stored as a nick in " + checkName.getOssName());
-					ossDataMap.put("gridId", oss.getGridId());
-					ossDataMap.put("status", "X (Duplicated : " + oss.getOssName() + ")");
+					ossDataMap = ossService.getOssDataMap(oss.getGridId(), false, "X (Duplicated : " + oss.getOssName() + ")");
 					ossDataMapList.add(ossDataMap);
 					checkDuplicated = false;
 				}
@@ -1137,8 +1132,7 @@ public class OssController extends CoTopComponent{
 					OssMaster checkNick = ossService.checkExistsOssNickname(nickCheck);
 					if (checkNick != null) {
 						log.debug(nick + " is stored as a nick or name in " + checkNick.getOssName());
-						ossDataMap.put("gridId", oss.getGridId());
-						ossDataMap.put("status", "X (Duplicated : " + nick + ")");
+						ossDataMap = ossService.getOssDataMap(oss.getGridId(), false, "X (Duplicated : " + nick + ")");
 						ossDataMapList.add(ossDataMap);
 						checkDuplicated = false;
 						break;
@@ -1150,8 +1144,7 @@ public class OssController extends CoTopComponent{
 				Map<String, Object> result = ossService.saveOss(oss);
 				result = ossService.sendMailForSaveOss(result);
 				if (result.get("resCd").equals("10")) {
-					ossDataMap.put("gridId", oss.getGridId());
-					ossDataMap.put("status", "O");
+					ossDataMap = ossService.getOssDataMap(oss.getGridId(), true, "O");
 					ossDataMapList.add(ossDataMap);
 				}
 			}

--- a/src/main/java/oss/fosslight/service/OssService.java
+++ b/src/main/java/oss/fosslight/service/OssService.java
@@ -9,6 +9,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
 
+import com.github.jsonldjava.utils.Obj;
 import oss.fosslight.config.HistoryConfig;
 import oss.fosslight.domain.*;
 
@@ -126,4 +127,6 @@ public interface OssService extends HistoryConfig{
 	Map<String, Object> sendMailForSaveOss(Map<String, Object> resMap);
 
 	List<String> getDeactivateOssList();
+
+	Map<String, Object> getOssDataMap(String gridId, boolean status, String msg);
 }

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -3625,4 +3625,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public List<String> getDeactivateOssList() {
 		return ossMapper.getDeactivateOssList();
 	}
+
+	@Override
+	public Map<String, Object> getOssDataMap(String gridId, boolean status, String msg) {
+		Map<String, Object> ossDataMap = new HashMap<>();
+		ossDataMap.put("gridId", gridId);
+		ossDataMap.put("status", status);
+		ossDataMap.put("msg", msg);
+
+		return ossDataMap;
+	}
+
 }

--- a/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/ossBulkReg-js.jsp
@@ -6,6 +6,7 @@
     var withStatus;
     var loadedInfo;
     var ossData = [];
+    var failOss = [];
     var isClicked = false;
     var postData; /**list data for sending to server*/
     var stringDataForValid = ['ossName','ossVersion','copyright','homepage','downloadLocation'
@@ -186,6 +187,7 @@
                     cache : false,
                     dataType: "json",
                     success: (data) => {
+                        failOss = []
                         _mainLastsel = -1;
                         if (data['res'] == true && data['value'] != []) {
                             loadedInfo = data['value'];
@@ -240,6 +242,7 @@
             loadComplete: function(data) {
                 _mainLastsel = -1;
                 selectMarkWhenPageChange();
+                makeBackGroundColor();
             },
             ondblClickRow: function(rowid,iRow,iCol,e) {
                 if(rowid) {
@@ -297,6 +300,7 @@
                 $("#list").jqGrid('clearGridData');
                 selectedIds = new Set()
                 ossData = []
+                failOss = []
                 if (data['res'] == true){
                     jsonData = data['value'];
                     makeOssDTOList();
@@ -399,6 +403,14 @@
             }
         }
     }
+    /**
+     * change background color of failed oss row
+     * */
+    function makeBackGroundColor(){
+        for (const failOssGridId of failOss) {
+            $("#list").jqGrid("setRowData", failOssGridId, false, {'background' : "rgba(255, 0, 0, 0.3)"});
+        }
+    }
 
     const OssBulkGridStatusMessageManager = {
         cleanStatusMessages: function () {
@@ -407,8 +419,12 @@
             });
         },
         setStatusMessages: function (results) {
-            for (const result of results)
-                $("#list").jqGrid("getLocalRow", result.gridId).status = result.status;
+            for (const result of results){
+                $("#list").jqGrid("getLocalRow", result.gridId).status = result.msg;
+                if (!result.status) {
+                    failOss.push(result.gridId);
+                }
+            }
             $("#list").trigger('reloadGrid', [{ page: 1}]);
         }
     };


### PR DESCRIPTION
## Summary
Change background color of oss that failed to save in bulk registration.
## Description
<!-- 
Please describe what this PR do.
 -->
1. Add `failOss` variable in `ossBulkReg-js.jsp` to save failed data as list.
2. Modified response body of "/oss/bulkRegAjax" API.
* Previous response body
```json
{
    "res":true,
    "value":[
        {
	    "gridId": "1", 
            "status": "O"
        },
        {
	    "gridId": "2", 
	    "status": "X (error message)", 
        }
    ]
}
```
* After response body
```json
{
    "res":true,
    "value":[
        {
	    "gridId": "1", 
            "status": true,
            "msg": "O"
        },
        {
	    "gridId": "2", 
	    "status": false,
	    "msg": "X (error message)"
        }
    ]
}
```

## Result
### Previous UI
![fosslight-previous-ui](https://user-images.githubusercontent.com/68562176/194705296-2a728869-598d-4aa6-977c-7bf56d880e20.png)

### Current UI
https://user-images.githubusercontent.com/68562176/194705385-5f4b1289-773c-4e95-948a-2488acde8af6.mov

## Process
(Add `failOss` variable to save failed data as list)
1. Import excel.
2. Initalize `failOss`.
4. Save oss data in bulk.
5. Save failed data in `failOss` while checking results in loop(Check for failure with the `status` variable).
6. Change the background color of failed data rows in `failOss` loop in `makeBackgroundColor()` function.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
