### PR TITLE
Use setup-qemu-action to build multi-arch images

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -103,6 +103,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -117,6 +120,12 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: |
+            linux/arm64/v8
+            linux/arm/v7
+            linux/ppc64le
+            linux/s390x
+            linux/amd64
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/fosslight:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN gradle build --no-daemon --exclude-task test
 
 
 # Create the containerized app
-FROM openjdk:11-jre-slim-buster
+FROM adoptopenjdk/openjdk11:jre-11.0.15_10-ubuntu
 LABEL maintainer="FOSSLight <fosslight-dev@lge.com>"
 
 COPY --from=build /home/gradle/src/build/libs/*.war /app/FOSSLight.war


### PR DESCRIPTION
Signed-off-by: jongwooo <han980817@gmail.com>
Pull request: #675 
Issue: #722

## Description

I added [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action) in workflow to build multi-arch images. And I reverted jdk base image to apply multi-arch build.

### Supported Platforms

- linux/amd64

### Platforms to be supported

- linux/arm64/v8
- linux/arm/v7
- linux/ppc64le
- linux/s390x
- linux/amd64

## What is a Multi-architecture image?

A multi-arch image is a type of container image that may combine variants for different architectures, and sometimes for different operating systems. When running an image with multi-architecture support, container clients will automatically select an image variant that matches your OS and architecture.

## References

- [Multi-arch build and images, the simple way](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/)
- [Multi-arch docker images the easy way, with Github Actions](https://dev.to/cloudx/multi-arch-docker-images-the-easy-way-with-github-actions-4k54)
- [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
