### PR TITLE
Fix a bug where the Homepage/Download Location is saved with a warning message included.

### DIFF
--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -2672,7 +2672,7 @@ public class CommonFunction extends CoTopComponent {
 			String licenseName = !isEmpty(licenseMaster.getShortIdentifier()) ? licenseMaster.getShortIdentifier() : !isEmpty(licenseMaster.getLicenseNameTemp()) ? licenseMaster.getLicenseNameTemp() : licenseMaster.getLicenseName();
 			
 			if(!isEmpty(licenseName)) {
-				String fileName = licenseName.replaceAll(" ", "_").replaceAll("/", "_") + ".html";
+				String fileName = licenseName.replaceAll(" ", "_").replaceAll("/", "_").replaceAll("\"", "&#34;") + ".html";
 				boolean DEFAULT_URL_FLAG = !CoConstDef.FLAG_YES.equals(CoCodeManager.getCodeExpString(CoConstDef.CD_SYSTEM_SETTING, CoConstDef.CD_NOTICE_INTERNAL_URL));
 				if (DEFAULT_URL_FLAG) {
 					return licenseMaster.getWebpage();

--- a/src/main/webapp/WEB-INF/views/admin/partner/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/partner/edit-js.jsp
@@ -2511,8 +2511,16 @@ var saveFlag = false;
 				key.forEach(function(value){
 					if("gridId" != value){
 						var data = obj[value];
-						if(data.indexOf("<div class") > -1){
-							data = data.split("<")[0];
+						if(value == "downloadLocation" || value == "homepage"){
+							if(data.indexOf("Not the same as property") > -1){
+								data = data.split("Not the same as property")[0];
+							} else if(data.indexOf("The address should be") > -1){
+								data = data.split("The address should be")[0];
+							}
+						} else {
+							if(data.indexOf("<div class") > -1){
+								data = data.split("<")[0];
+							}
 						}
 						
 						fn_grid_com.saveCellData(target, gridId, value, data ,null,null);

--- a/src/main/webapp/WEB-INF/views/admin/project/common-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/common-js.jsp
@@ -1119,8 +1119,16 @@ var com_fn = {
 			key.forEach(function(value){
 				if("gridId" != value){
 					var data = obj[value];
-					if(data.indexOf("<div class") > -1){
-						data = data.split("<")[0];
+					if(value == "downloadLocation" || value == "homepage"){
+						if(data.indexOf("Not the same as property") > -1){
+							data = data.split("Not the same as property")[0];
+						} else if(data.indexOf("The address should be") > -1){
+							data = data.split("The address should be")[0];
+						}
+					} else {
+						if(data.indexOf("<div class") > -1){
+							data = data.split("<")[0];
+						}
 					}
 					
 					fn_grid_com.saveCellData(target, gridId, value, data ,null,null);

--- a/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/selfCheck/edit-js.jsp
@@ -2277,8 +2277,16 @@
 				key.forEach(function(value){
 					if("gridId" != value){
 						var data = obj[value];
-						if(data.indexOf("<div class") > -1){
-							data = data.split("<")[0];
+						if(value == "downloadLocation" || value == "homepage"){
+							if(data.indexOf("Not the same as property") > -1){
+								data = data.split("Not the same as property")[0];
+							} else if(data.indexOf("The address should be") > -1){
+								data = data.split("The address should be")[0];
+							}
+						} else {
+							if(data.indexOf("<div class") > -1){
+								data = data.split("<")[0];
+							}
 						}
 						
 						fn_grid_com.saveCellData(target, gridId, value, data ,null,null);


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Fix a bug where the Homepage/Download Location is saved with a warning message included.
- If the Homepage/Download Location address is entered and saved differently from the registration, a warning message is displayed. If you save it again after that, a warning message is added to the existing address and saved.

Fix the error that occurs when the default internal url contains " in the license name.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
