### PR TITLE
Possible to select other version of oss even if the information is same in oss sync

### DIFF
--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2221,7 +2221,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 										bean.setCheckOssList("I");
 									}
 								} catch (IOException e) {
-									checkName = generateCheckOSSName(urlSearchSeq, downloadlocationUrl, p);
+									checkName = "Invalid download location.";
+									bean.setCheckOssList("I");
 								}
 							} else {
 								checkName = generateCheckOSSName(downloadlocationUrl, p, androidPlatformList);

--- a/src/main/webapp/WEB-INF/views/admin/oss/syncpopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/syncpopup.jsp
@@ -127,7 +127,6 @@
 													for (var i=0; i<sameList.length; i++) {
 														if (id == sameList[i]){
 															row.className = className + ' excludeRow';
-															$(row).attr("onclick", "event.cancelBubble=true;").find("input[type=checkbox]").attr("disabled", true);
 														}
 													}
 												}
@@ -168,17 +167,7 @@
 
 		var fn = {
 			syncSave : function(){
-				var unCheckedList = [];
-				var excludeList = $("#_ossList").find(".excludeRow");
-				for(var i=0; i<excludeList.length; i++){
-					unCheckedList.push(excludeList[i].id);
-				}
-				
-				var checkedOssList = $("#_ossList").jqGrid("getGridParam", "selarrrow").filter(function(element){
-					if (unCheckedList.indexOf(element) === -1){
-						return element;
-					}
-				});
+				var checkedOssList = $("#_ossList").jqGrid("getGridParam", "selarrrow");
 				
 				var checkedSyncList = $(".dCase tbody tr").find("input[type=checkbox]:checked");
 				


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Possible to select other version of oss even if the information is same in oss sync
- Check oss name
    -  If there is timeout to check redirect location, "invaild downlaod location" is displayed.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
