### PR TITLE
Display "Required oss name" warning message when oss name is "-" and license has source obligation.

### DIFF
--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -3695,8 +3695,8 @@ public class CommonFunction extends CoTopComponent {
 						List<OssMaster> ossInfoByNickList = ossService.getOssListByName(param);
 						
 						if(ossInfoByNickList != null) {
-							ossInfoByNickList = ossInfoByNickList.stream().filter(e -> !e.getDeactivateFlag().equals(CoConstDef.FLAG_YES)).collect(Collectors.toList());
-							if(ossInfoByNickList.size() == 0 || ossInfoByNickList.get(0).getOssName().equals(bean.getOssName())) break;
+							int deactivateCnt = ossInfoByNickList.stream().filter(e -> e.getDeactivateFlag().equals(CoConstDef.FLAG_YES)).collect(Collectors.toList()).size();
+							if(deactivateCnt > 0) continue;
 							
 							final Comparator<OssMaster> comp = Comparator.comparing((OssMaster o) -> o.getModifiedDate()).reversed();
 							ossInfoByNickList = ossInfoByNickList.stream().sorted(comp).collect(Collectors.toList());

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -1700,11 +1700,11 @@ public class CommonFunction extends CoTopComponent {
 					LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(obligationLicense.getLicenseName()).toUpperCase());
 					
 					if(master != null) {
-						if(CoConstDef.FLAG_YES.equals(master.getObligationNeedsCheckYn())) {
+						if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNeedsCheckYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK;
-						} else if(CoConstDef.FLAG_YES.equals(master.getObligationDisclosingSrcYn())) {
+						} else if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE;
-						} else if(CoConstDef.FLAG_YES.equals(master.getObligationNotificationYn())) {
+						} else if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNotificationYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_NOTICE;
 						}
 					}
@@ -1947,11 +1947,11 @@ public class CommonFunction extends CoTopComponent {
 					if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(bean.getLicenseName()).toUpperCase())) {
 						LicenseMaster license = CoCodeManager.LICENSE_INFO_UPPER.get(bean.getLicenseName().toUpperCase());
 						
-						if(CoConstDef.FLAG_YES.equals(license.getObligationNeedsCheckYn())) {
+						if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNeedsCheckYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK;
-						} else if(CoConstDef.FLAG_YES.equals(license.getObligationDisclosingSrcYn())) {
+						} else if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationDisclosingSrcYn()))) {
 							rtnVal = CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE;
-						} else if(isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(license.getObligationNotificationYn())) {
+						} else if(isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNotificationYn()))) {
 							rtnVal = CoConstDef.CD_DTL_OBLIGATION_NOTICE;
 						}
 					}
@@ -1972,11 +1972,11 @@ public class CommonFunction extends CoTopComponent {
 					if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(bean.getLicenseName()).toUpperCase())) {
 						LicenseMaster license = CoCodeManager.LICENSE_INFO_UPPER.get(bean.getLicenseName().toUpperCase());
 						
-						if(CoConstDef.FLAG_YES.equals(license.getObligationNeedsCheckYn())) {
+						if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNeedsCheckYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK;
-						} else if(CoConstDef.FLAG_YES.equals(license.getObligationDisclosingSrcYn())) {
+						} else if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationDisclosingSrcYn()))) {
 							rtnVal = CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE;
-						} else if(isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(license.getObligationNotificationYn())) {
+						} else if(isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNotificationYn()))) {
 							rtnVal = CoConstDef.CD_DTL_OBLIGATION_NOTICE;
 						}
 					}
@@ -3025,11 +3025,11 @@ public class CommonFunction extends CoTopComponent {
 				LicenseMaster license = CoCodeManager.LICENSE_INFO_BY_ID.get(bean.getLicenseId());
 				
 				if(license != null) {
-					if(CoConstDef.FLAG_YES.equals(license.getObligationDisclosingSrcYn())) {
+					if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationDisclosingSrcYn()))) {
 						sourceCode = true;
 					}
 					
-					if(CoConstDef.FLAG_YES.equals(license.getObligationNotificationYn())) {
+					if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNotificationYn()))) {
 						notice = true;
 					}
 				}

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -3613,6 +3613,9 @@ public class CommonFunction extends CoTopComponent {
 		
 		int gridSeq = 1; 
 		
+		List<String> deactivateOssList = ossService.getDeactivateOssList();
+		deactivateOssList.replaceAll(String::toUpperCase);
+		
 		for(OssAnalysis bean : analysisResultList) {
 			OssAnalysis userData = analysisList
 										.stream()
@@ -3697,6 +3700,12 @@ public class CommonFunction extends CoTopComponent {
 						if(ossInfoByNickList != null) {
 							int deactivateCnt = ossInfoByNickList.stream().filter(e -> e.getDeactivateFlag().equals(CoConstDef.FLAG_YES)).collect(Collectors.toList()).size();
 							if(deactivateCnt > 0) continue;
+							
+							if(ossAnalysisByNickList.size() > 0) {
+								String checkDuplicateOssName = ossInfoByNickList.get(0).getOssName();
+								int checkDuplicateCnt = ossAnalysisByNickList.stream().filter(e -> e.getOssName().equalsIgnoreCase(checkDuplicateOssName)).collect(Collectors.toList()).size();
+								if(checkDuplicateCnt > 0) continue;
+							}
 							
 							final Comparator<OssMaster> comp = Comparator.comparing((OssMaster o) -> o.getModifiedDate()).reversed();
 							ossInfoByNickList = ossInfoByNickList.stream().sorted(comp).collect(Collectors.toList());
@@ -3785,11 +3794,11 @@ public class CommonFunction extends CoTopComponent {
 						}
 					}
 					
-					if(totalNewestOssInfo != null) {
+					if(totalNewestOssInfo != null && !deactivateOssList.contains(totalNewestOssInfo.getOssName().toUpperCase())) {
 						changeAnalysisResultList.add(totalNewestOssInfo); // seq 3 : 취합정보 최신등록 정보
 					}
 					
-					if(newestOssInfo != null) {
+					if(newestOssInfo != null && !deactivateOssList.contains(newestOssInfo.getOssName().toUpperCase())) {
 						changeAnalysisResultList.add(newestOssInfo); // seq 4 : 최신등록 정보
 						
 						if(newestOssInfo.getOssName().toUpperCase().equals(userData.getOssName().toUpperCase())) {
@@ -3836,7 +3845,7 @@ public class CommonFunction extends CoTopComponent {
 						}
 					}
 					
-					if(totalNewestOssInfo != null) {
+					if(totalNewestOssInfo != null && !deactivateOssList.contains(totalNewestOssInfo.getOssName().toUpperCase())) {
 						changeAnalysisResultList.add(totalNewestOssInfo); // seq 3 : 취합정보 최신등록 정보
 					}
 					
@@ -3865,10 +3874,12 @@ public class CommonFunction extends CoTopComponent {
 					try {
 						OssAnalysis newestOssInfo = ossService.getNewestOssInfo(userData); // 사용자 정보의 ossName기준 최신 등록정보
 						
-						newestOssInfo.setGridId(""+gridSeq++);
-						newestOssInfo.setOssVersion(userData.getOssVersion());
-						
-						changeAnalysisResultList.add(newestOssInfo); // seq 2 : 최신등록 정보
+						if(newestOssInfo != null && !deactivateOssList.contains(newestOssInfo.getOssName().toUpperCase())) {
+							newestOssInfo.setGridId(""+gridSeq++);
+							newestOssInfo.setOssVersion(userData.getOssVersion());
+							
+							changeAnalysisResultList.add(newestOssInfo); // seq 2 : 최신등록 정보
+						}
 					} catch (Exception newestException) {
 						log.error(newestException.getMessage());
 					}

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -3724,7 +3724,7 @@ public class CommonFunction extends CoTopComponent {
 							String analysisTitle = ossInfoByNickList.get(0).getOssName();
 							if(!isEmpty(ossInfoByNickList.get(0).getOssVersion())) analysisTitle += " (" + ossInfoByNickList.get(0).getOssVersion() + ")";
 							
-							ossInfoByNick = new OssAnalysis(userData.getGridId(), ossInfoByNickList.get(0).getOssName(), ossInfoByNickList.get(0).getOssVersion(), ossInfoByNickList.get(0).getOssNickname().replaceAll("<br>", ",")
+							ossInfoByNick = new OssAnalysis(userData.getGridId(), ossInfoByNickList.get(0).getOssName(), bean.getOssVersion(), ossInfoByNickList.get(0).getOssNickname().replaceAll("<br>", ",")
 									, license.substring(0, license.length()-1), ossInfoByNickList.get(0).getCopyright(), ossInfoByNickList.get(0).getDownloadLocation()
 									, ossInfoByNickList.get(0).getHomepage(), null, null, "", analysisTitle + " 최신 등록 정보"); // nick oss 최신정보
 							ossInfoByNick.setGridId(CoConstDef.GRID_NEWROW_DEFAULT_PREFIX + idx);
@@ -3790,7 +3790,19 @@ public class CommonFunction extends CoTopComponent {
 					
 					if(ossAnalysisByNickList != null && !ossAnalysisByNickList.isEmpty()) {
 						for(OssAnalysis oa : ossAnalysisByNickList) {
-							changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
+							if(totalNewestOssInfo != null) {
+								if(!totalNewestOssInfo.getOssName().equalsIgnoreCase(oa.getOssName()) && !totalNewestOssInfo.getOssVersion().equals(oa.getOssVersion())) {
+									changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
+								}
+							} else {
+								if(newestOssInfo != null) {
+									if(!newestOssInfo.getOssName().equalsIgnoreCase(oa.getOssName()) && !newestOssInfo.getOssVersion().equals(oa.getOssVersion())) {
+										changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
+									}
+								} else {
+									changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
+								}
+							}
 						}
 					}
 					
@@ -3841,7 +3853,13 @@ public class CommonFunction extends CoTopComponent {
 					
 					if(ossAnalysisByNickList != null && !ossAnalysisByNickList.isEmpty()) {
 						for(OssAnalysis oa : ossAnalysisByNickList) {
-							changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
+							if(totalNewestOssInfo != null) {
+								if(!totalNewestOssInfo.getOssName().equalsIgnoreCase(oa.getOssName()) && !totalNewestOssInfo.getOssVersion().equals(oa.getOssVersion())) {
+									changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
+								}
+							} else {
+								changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
+							}
 						}
 					}
 					

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -1074,11 +1074,11 @@ public class OssController extends CoTopComponent{
 				else convert.setOssLicenseComb("");
 				convert.setLicenseNameEx(existsLicense.getLicenseNameTemp());
 				convert.setLicenseType(existsLicense.getLicenseType());
-				if (CoConstDef.FLAG_YES.equals(existsLicense.getObligationNeedsCheckYn())) {
+				if (CoConstDef.FLAG_YES.equals(avoidNull(existsLicense.getObligationNeedsCheckYn()))) {
 					convert.setObligation(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK);
-				} else if (CoConstDef.FLAG_YES.equals(existsLicense.getObligationDisclosingSrcYn())) {
+				} else if (CoConstDef.FLAG_YES.equals(avoidNull(existsLicense.getObligationDisclosingSrcYn()))) {
 					convert.setObligation(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
-				} else if (CoConstDef.FLAG_YES.equals(existsLicense.getObligationNotificationYn())) {
+				} else if (CoConstDef.FLAG_YES.equals(avoidNull(existsLicense.getObligationNotificationYn()))) {
 					convert.setObligation(CoConstDef.CD_DTL_OBLIGATION_NOTICE);
 				} else {
 					convert.setObligation("");

--- a/src/main/java/oss/fosslight/controller/VerificationController.java
+++ b/src/main/java/oss/fosslight/controller/VerificationController.java
@@ -115,7 +115,7 @@ public class VerificationController extends CoTopComponent {
 						licenseBean = CoCodeManager.LICENSE_INFO_UPPER.get(license.toUpperCase());
 						if(licenseBean != null && !isEmptyWithLineSeparator(licenseBean.getDescription()) 
 								&& !duplLicenseCheckList.contains(licenseBean.getLicenseId())
-								&& CoConstDef.FLAG_YES.equals(licenseBean.getObligationDisclosingSrcYn())) {
+								&& CoConstDef.FLAG_YES.equals(avoidNull(licenseBean.getObligationDisclosingSrcYn()))) {
 							userGuideLicenseList.add(licenseBean);
 							duplLicenseCheckList.add(licenseBean.getLicenseId());
 						}

--- a/src/main/java/oss/fosslight/service/impl/LicenseServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/LicenseServiceImpl.java
@@ -408,11 +408,11 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		
 		if(list != null) {
 			for(LicenseMaster bean : list) {
-				if(CoConstDef.FLAG_YES.equals(bean.getObligationNeedsCheckYn())) {
+				if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNeedsCheckYn()))) {
 					bean.setObligationCode(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK);
-				} else if(CoConstDef.FLAG_YES.equals(bean.getObligationDisclosingSrcYn())) {
+				} else if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationDisclosingSrcYn()))) {
 					bean.setObligationCode(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
-				} else if(CoConstDef.FLAG_YES.equals(bean.getObligationNotificationYn())) {
+				} else if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNotificationYn()))) {
 					bean.setObligationCode(CoConstDef.CD_DTL_OBLIGATION_NOTICE);
 				}
 			}

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -1648,11 +1648,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			license.setLicenseType(master.getLicenseType());
 			
 			// obligation 설정
-			if(CoConstDef.FLAG_YES.equals(master.getObligationNeedsCheckYn())) {
+			if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNeedsCheckYn()))) {
 				license.setObligation(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK);
-			} else if(CoConstDef.FLAG_YES.equals(master.getObligationDisclosingSrcYn())) {
+			} else if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))) {
 				license.setObligation(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
-			} else if(CoConstDef.FLAG_YES.equals(master.getObligationNotificationYn())) {
+			} else if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNotificationYn()))) {
 				license.setObligation(CoConstDef.CD_DTL_OBLIGATION_NOTICE);
 			}
 			

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -2452,6 +2452,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		if(mergeListMap != null && mergeListMap.get("rows") != null) {
 			for(ProjectIdentification bean : (List<ProjectIdentification>)mergeListMap.get("rows")) {
+				
+				if((isEmpty(bean.getOssName()) || "-".equals(bean.getOssName())) // ossName이 공란이거나 '-' 일때 license가 multi license일때는 bom에 merge하지 않음. 
+					&& bean.getOssComponentsLicenseList().size() > 1) {
+					continue;
+				}
+				
 				bean.setRefDiv(bean.getReferenceDiv());
 				bean.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_BOM);
 				bean.setRefComponentId(bean.getComponentId());

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -2453,11 +2453,6 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		if(mergeListMap != null && mergeListMap.get("rows") != null) {
 			for(ProjectIdentification bean : (List<ProjectIdentification>)mergeListMap.get("rows")) {
 				
-				if((isEmpty(bean.getOssName()) || "-".equals(bean.getOssName())) // ossName이 공란이거나 '-' 일때 license가 multi license일때는 bom에 merge하지 않음. 
-					&& bean.getOssComponentsLicenseList().size() > 1) {
-					continue;
-				}
-				
 				bean.setRefDiv(bean.getReferenceDiv());
 				bean.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_BOM);
 				bean.setRefComponentId(bean.getComponentId());

--- a/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
@@ -733,29 +733,19 @@ public class T2CoProjectValidator extends T2CoValidator {
 					{
 						basicKey = "LICENSE_NAME";
 						gridKey = StringUtil.convertToCamelCase(basicKey);
-						if(bean.getLicenseName().split(",").length > 1){
-							errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
-						} else {
-							// 기본체크
-							String errCd = checkBasicError(basicKey, gridKey, bean.getLicenseName());
-
-							if (!isEmpty(errCd)) {
-								errMap.put(basicKey + "." + bean.getComponentId(), errCd);
-							} else if (isEmpty(bean.getLicenseName())) {
-								errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.REQUIRED");
-							} else if (!CommonFunction.checkLicense(bean.getLicenseName())) {
-								if (CommonFunction.isAdmin()) {
-									errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
-								} else {
-									diffMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
-									diffMapLicense = true;
-								}
-							} else if (CommonFunction.checkLicense(bean.getLicenseName())) {
-								LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER
-										.get(bean.getLicenseName().trim().toUpperCase());
-								if (master.getObligationDisclosingSrcYn() != null && master.getObligationDisclosingSrcYn().equals("Y")) {
-									diffMap.put("OSS_NAME." + bean.getComponentId(), "OSS_NAME.REQUIRED2");
-								}
+						// 기본체크
+						String errCd = checkBasicError(basicKey, gridKey, bean.getLicenseName());
+						
+						if (!isEmpty(errCd)) {
+							errMap.put(basicKey + "." + bean.getComponentId(), errCd);
+						} else if (isEmpty(bean.getLicenseName())) {
+							errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.REQUIRED");
+						} else if (!CommonFunction.checkLicense(bean.getLicenseName())) {
+							if (CommonFunction.isAdmin()) {
+								errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
+							} else {
+								diffMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
+								diffMapLicense = true;
 							}
 						}
 					}
@@ -1700,27 +1690,22 @@ public class T2CoProjectValidator extends T2CoValidator {
 					{
 						basicKey = "LICENSE_NAME";
 						gridKey = StringUtil.convertToCamelCase(basicKey);
-						if(licenseList.size() > 1) {
-							errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
-						} else {
-							// 기본체크
-							String errCd = checkBasicError(basicKey, gridKey, bean.getLicenseName());
-							if (!isEmpty(errCd)) {
-								errMap.put(basicKey + "." + bean.getGridId(), errCd);
-							} else if (isEmpty(bean.getLicenseName())) {
-								errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.REQUIRED");
-							} else if (!CommonFunction.checkLicense(bean.getLicenseName())) {
-								if (CommonFunction.isAdmin()) {
-									errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.UNCONFIRMED");
-								} else {
-									diffMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.UNCONFIRMED");
-								}
-							} else if (CommonFunction.checkLicense(bean.getLicenseName())) {
-								LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER
-										.get(bean.getLicenseName().trim().toUpperCase());
-								if (master.getObligationDisclosingSrcYn() != null && master.getObligationDisclosingSrcYn().equals("Y")) {
-									diffMap.put("OSS_NAME." + bean.getGridId(), "OSS_NAME.REQUIRED2");
-								}
+						// 기본체크
+						String errCd = checkBasicError(basicKey, gridKey, bean.getLicenseName());
+						
+						if (!isEmpty(errCd)) {
+							errMap.put(basicKey + "." + bean.getGridId(), errCd);
+						} else if (isEmpty(bean.getLicenseName())) {
+							errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.REQUIRED");
+						} else if (!CommonFunction.checkLicense(bean.getLicenseName())) {
+							if (CommonFunction.isAdmin()) {
+								errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.UNCONFIRMED");
+							} else {
+								diffMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.UNCONFIRMED");
+							}
+						} else if(bean.getComponentLicenseList() != null) {
+							if(bean.getComponentLicenseList().size() > 1) {
+								errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
 							}
 						}
 					}

--- a/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
@@ -733,19 +733,29 @@ public class T2CoProjectValidator extends T2CoValidator {
 					{
 						basicKey = "LICENSE_NAME";
 						gridKey = StringUtil.convertToCamelCase(basicKey);
-						// 기본체크
-						String errCd = checkBasicError(basicKey, gridKey, bean.getLicenseName());
-						
-						if (!isEmpty(errCd)) {
-							errMap.put(basicKey + "." + bean.getComponentId(), errCd);
-						} else if (isEmpty(bean.getLicenseName())) {
-							errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.REQUIRED");
-						} else if (!CommonFunction.checkLicense(bean.getLicenseName())) {
-							if (CommonFunction.isAdmin()) {
-								errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
-							} else {
-								diffMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
-								diffMapLicense = true;
+						if(bean.getOssComponentsLicenseList().size() > 1) {
+							errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
+						} else {
+							// 기본체크
+							String errCd = checkBasicError(basicKey, gridKey, bean.getLicenseName());
+
+							if (!isEmpty(errCd)) {
+								errMap.put(basicKey + "." + bean.getComponentId(), errCd);
+							} else if (isEmpty(bean.getLicenseName())) {
+								errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.REQUIRED");
+							} else if (!CommonFunction.checkLicense(bean.getLicenseName())) {
+								if (CommonFunction.isAdmin()) {
+									errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
+								} else {
+									diffMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
+									diffMapLicense = true;
+								}
+							} else if (CommonFunction.checkLicense(bean.getLicenseName())) {
+								LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER
+										.get(bean.getLicenseName().trim().toUpperCase());
+								if (master != null && CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))) {
+									diffMap.put("OSS_NAME." + bean.getComponentId(), "OSS_NAME.REQUIRED2");
+								}
 							}
 						}
 					}
@@ -1690,22 +1700,32 @@ public class T2CoProjectValidator extends T2CoValidator {
 					{
 						basicKey = "LICENSE_NAME";
 						gridKey = StringUtil.convertToCamelCase(basicKey);
-						// 기본체크
-						String errCd = checkBasicError(basicKey, gridKey, bean.getLicenseName());
-						
-						if (!isEmpty(errCd)) {
-							errMap.put(basicKey + "." + bean.getGridId(), errCd);
-						} else if (isEmpty(bean.getLicenseName())) {
-							errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.REQUIRED");
-						} else if (!CommonFunction.checkLicense(bean.getLicenseName())) {
-							if (CommonFunction.isAdmin()) {
-								errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.UNCONFIRMED");
-							} else {
-								diffMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.UNCONFIRMED");
-							}
-						} else if(bean.getComponentLicenseList() != null) {
-							if(bean.getComponentLicenseList().size() > 1) {
-								errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
+						if(bean.getComponentLicenseList().size() > 1) {
+							errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
+						} else {
+							// 기본체크
+							String errCd = checkBasicError(basicKey, gridKey, bean.getLicenseName());
+
+							if (!isEmpty(errCd)) {
+								errMap.put(basicKey + "." + bean.getGridId(), errCd);
+							} else if (isEmpty(bean.getLicenseName())) {
+								errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.REQUIRED");
+							} else if (!CommonFunction.checkLicense(bean.getLicenseName())) {
+								if (CommonFunction.isAdmin()) {
+									errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.UNCONFIRMED");
+								} else {
+									diffMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.UNCONFIRMED");
+								}
+							} else if (bean.getComponentLicenseList() != null) {
+								if (bean.getComponentLicenseList().size() > 1) {
+									errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
+								}
+							} else if (CommonFunction.checkLicense(bean.getLicenseName())) {
+								LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER
+										.get(bean.getLicenseName().trim().toUpperCase());
+								if (master != null && CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))) {
+									diffMap.put("OSS_NAME." + bean.getGridId(), "OSS_NAME.REQUIRED2");
+								}
 							}
 						}
 					}

--- a/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
@@ -298,8 +298,8 @@ public class T2CoProjectValidator extends T2CoValidator {
 					LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER.get(license.getLicenseName().toUpperCase());
 					
 					if (master != null 
-							&& !CoConstDef.FLAG_YES.equals(master.getObligationDisclosingSrcYn())
-							&& !CoConstDef.FLAG_YES.equals(master.getObligationNotificationYn())) {
+							&& !CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))
+							&& !CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNotificationYn()))) {
 						return true;
 					}
 				}
@@ -1814,9 +1814,8 @@ public class T2CoProjectValidator extends T2CoValidator {
 						}
 					}
 					
-					OssMaster ossBean = CoCodeManager.OSS_INFO_UPPER.get(checkKey);
-					if(ossBean != null) {
-						if(CoConstDef.FLAG_YES.equals(ossBean.getDeactivateFlag())){
+					if(ossmaster != null) {
+						if(CoConstDef.FLAG_YES.equals(ossmaster.getDeactivateFlag())){
 							if (CommonFunction.isAdmin()) {
 								errMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
 							} else {
@@ -2411,11 +2410,11 @@ public class T2CoProjectValidator extends T2CoValidator {
 				}
 				
 				if (!isEmpty(license.getLicenseName())
-						&& CoCodeManager.LICENSE_INFO_UPPER.containsKey(license.getLicenseName().toUpperCase())) {
+						&& CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(license.getLicenseName()).toUpperCase())) {
 					LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER.get(license.getLicenseName().toUpperCase());
 					
-					if (master != null && (CoConstDef.FLAG_YES.equals(master.getObligationDisclosingSrcYn())
-							|| CoConstDef.FLAG_YES.equals(master.getObligationNotificationYn()))) {
+					if (master != null && (CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))
+							|| CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNotificationYn())))) {
 						return true;
 					}
 				}

--- a/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
@@ -733,7 +733,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 					{
 						basicKey = "LICENSE_NAME";
 						gridKey = StringUtil.convertToCamelCase(basicKey);
-						if(bean.getOssComponentsLicenseList().size() > 1) {
+						if(bean.getLicenseName().split(",").length > 1) {
 							errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
 						} else {
 							// 기본체크
@@ -1700,7 +1700,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 					{
 						basicKey = "LICENSE_NAME";
 						gridKey = StringUtil.convertToCamelCase(basicKey);
-						if(bean.getComponentLicenseList().size() > 1) {
+						if(bean.getLicenseName().split(",").length > 1) {
 							errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
 						} else {
 							// 기본체크

--- a/src/main/resources/messages/validation.properties
+++ b/src/main/resources/messages/validation.properties
@@ -196,6 +196,7 @@ OSS_NAME.DUPLICATEDNICK.MSG	= {0} are already registered as a nickname of <a cla
 OSS_NAME.DUPLICATEDNICK_SHORT.MSG= Duplicated name
 OSS_NAME.DUPLICATEDNICK2.MSG= Already registered as a nickname
 OSS_NAME.DEACTIVATED.MSG	= Deactivated open source
+OSS_NAME.REQUIRED2.MSG		= Required OSS name. 
 
 
 OSS_VERSION.REQUIRED		= FALSE

--- a/src/main/resources/messages/validation.properties
+++ b/src/main/resources/messages/validation.properties
@@ -196,7 +196,7 @@ OSS_NAME.DUPLICATEDNICK.MSG	= {0} are already registered as a nickname of <a cla
 OSS_NAME.DUPLICATEDNICK_SHORT.MSG= Duplicated name
 OSS_NAME.DUPLICATEDNICK2.MSG= Already registered as a nickname
 OSS_NAME.DEACTIVATED.MSG	= Deactivated open source
-OSS_NAME.REQUIRED2.MSG = Required OSS name
+
 
 OSS_VERSION.REQUIRED		= FALSE
 OSS_VERSION.LENGTH			= 100

--- a/src/main/resources/oss/fosslight/repository/SelfCheckMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/SelfCheckMapper.xml
@@ -1402,7 +1402,7 @@
 			   </choose>
 			   ORDER BY COMPONENT_ID, (CASE WHEN S.LICENSE_ID IS NULL THEN 99999 ELSE 1 END), COMPONENT_LICENSE_IDX ASC
 		) RESULT
-		ORDER BY COMPONENT_ID, RNUM ASC 
+		ORDER BY COMPONENT_IDX, RNUM ASC 
 	</select>
 	
 	<select id="getLicensesId" parameterType="String" resultType="String">

--- a/src/main/webapp/WEB-INF/views/admin/project/3rd-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/3rd-js.jsp
@@ -659,6 +659,16 @@ var party_evt = {
 	    	.forEach(function(cur,idx){
 	    		$('#list3').jqGrid('delRowData', cur.gridId);
 	    	});
+
+        var gridData = $('#list3').jqGrid('getGridParam', 'data').filter(function(a){
+            if(a.refPartnerId != refPartnerId){
+                return a;
+            }
+        });
+
+        partMainData = gridData;
+        $("#list3").jqGrid('GridUnload');
+        part_grid.load();
     }
 }
 

--- a/src/main/webapp/WEB-INF/views/admin/project/3rd-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/3rd-js.jsp
@@ -281,12 +281,12 @@ var party_evt = {
 		if (com_fn.checkStatus()){
 			alertify.confirm('<spring:message code="msg.common.confirm.save" />', function (e) {
 				if (e) {
-					var mainDiv = $('#list3').jqGrid('getRowData');
+					var mainData = $('#list3').jqGrid('getGridParam','data');
 					var thirdPartyDiv = $('#_3rdAddList').jqGrid('getRowData');
 					var finalData = {
 						referenceId : '${project.prjId}',
 						identificationSubStatusPartner : $("#applicableParty:checked").val(),
-						mainData : JSON.stringify(mainDiv),
+						mainData : JSON.stringify(mainData),
 						thirdPartyData : JSON.stringify(thirdPartyDiv)
 					}
 					
@@ -650,7 +650,7 @@ var party_evt = {
     },
     removeList : function(removeRow, refPartnerId){
     	$('#_3rdAddList').jqGrid('delRowData', removeRow); // Loaded List - delete row
-    	var mainData = $('#list3').jqGrid('getRowData');
+    	var mainData = $('#list3').jqGrid(('getGridParam','data'));
     	
     	mainData
 	    	.filter(function(a){ 


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Do not display the deactivated oss information in the result of auto analysis.
- Add logic to avoid null exception when checking obligation of license.
- Project > Identification, 3rd-party, self-check
    - Display "Required oss name" warning message under the specific condition as below.
       - oss name : "-"
       - license : source obligation is included
       ![image](https://user-images.githubusercontent.com/102017711/203456302-fabbf757-44c4-4b4c-91eb-f55a4d45a4eb.png)
    
    - Adjust priority of warning message.
        -  "Unconfirmed license" < "Specify OSS Name or put 1 license in a row"
- Project > Identification 
    - When click "merge and save" button, display the information in bom tab under the specific condition as below.
      - oss name : "-" 
      - license : multi/dual license
- Improve the speed of saving self-check project.
- Remove the duplicated list in the result of auto analysis.
## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
