### PR TITLE
Fix:  DB port exposed to host by port binding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
   db:
     image: mariadb:10
     container_name: fosslight_db
-    ports:
-      - "3306:3306"
     volumes:
       - ./db/conf.d:/etc/mysql/conf.d
       - ./db/data:/var/lib/mysql


### PR DESCRIPTION
The database port exposed to outer world by port binding to the host is a security flaw and also not necessary.

## Description
<!-- 
This PR removes the Port binding of DB container to host from outside world -->


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ x] Bug fix (non-breaking change which fixes an issue)
