### PR TITLE
Fix Missing imformation in Review_Report

### DIFF
--- a/src/main/java/oss/fosslight/util/PdfUtil.java
+++ b/src/main/java/oss/fosslight/util/PdfUtil.java
@@ -91,6 +91,9 @@ public final class PdfUtil extends CoTopComponent {
                 ossReview.add(oss);
             }
 
+            if(oss.getOssVersion().equals("N/A") || oss.getOssVersion().equals("")){
+                oss.setOssVersion("-");
+            }
             //VulnerabilityReview
             List<Map<String, Object>> _list = vulnerabilityService.selectMaxScoreNvdInfo(oss.getOssName(), oss.getOssVersion());
             for (Map<String, Object> m : _list) {


### PR DESCRIPTION
## Description
A PDF report was generated with missing oss name and vulnerability information.
The oss review and vulnerabilities should show information related to curl.
-> fix to show missing info.


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
