### PR TITLE
Fix a bug where a space is added at the beginning when there are more than two detected licenses when loading OSS

### DIFF
--- a/src/main/java/oss/fosslight/domain/CoMailManager.java
+++ b/src/main/java/oss/fosslight/domain/CoMailManager.java
@@ -1825,11 +1825,13 @@ public class CoMailManager extends CoTopComponent {
 			after.setCopyright(appendChangeStyleMultiLine(before.getCopyright(), after.getCopyright(), true));
 			isModified = checkEquals(before.getCopyright(), after.getCopyright(), isModified);
 			
+			before.setDownloadLocationLinkFormat(appendChangeStyleLinkFormatArray(before.getDownloadLocation()));
 			String[] beforeUrl = before.getDownloadLocation().split(",");
 			String[] afterUrl = after.getDownloadLocation().split(",");
 			String resultDownloadLocation = appendChangeStyleLinkFormatArray(beforeUrl, afterUrl, 0);
 			after.setDownloadLocationLinkFormat(resultDownloadLocation);
 			isModified = checkEquals(before.getDownloadLocation(), after.getDownloadLocation(), isModified);
+			before.setHomepageLinkFormat(appendChangeStyleLinkFormat(before.getHomepage()));
 			after.setHomepageLinkFormat(appendChangeStyleLinkFormat(before.getHomepage(), after.getHomepage()));
 			isModified = checkEquals(before.getHomepage(), after.getHomepage(), isModified);
 			after.setSummaryDescription(appendChangeStyleMultiLine(before.getSummaryDescription(), after.getSummaryDescription(), true));

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -976,7 +976,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				
 				for(String detectedLicense : detectedLicenses) {			
 					if(!isEmpty(detectedLicense)) {
-						LicenseMaster detectedLicenseInfo = CoCodeManager.LICENSE_INFO_UPPER.get(detectedLicense.toUpperCase());
+						LicenseMaster detectedLicenseInfo = CoCodeManager.LICENSE_INFO_UPPER.get(detectedLicense.toUpperCase().trim());
 						
 						if(detectedLicenseInfo != null) {
 							OssMaster om = new OssMaster(

--- a/src/main/resources/template/email/ossModify.html
+++ b/src/main/resources/template/email/ossModify.html
@@ -118,13 +118,13 @@
 									</tr>
 									<tr>
 										<th align="left" style="padding:5px;background:#f0f0f0;">Homepage</th>
-										<td style="padding:5px;">#if( $before.homepageLinkFormat )$!before.homepageLinkFormat#end</td>
-										<td style="padding:5px;">#if( $after.homepageLinkFormat )$!after.homepageLinkFormat#end</td>
+										<td style="padding:5px;">$!before.homepageLinkFormat</td>
+										<td style="padding:5px;">$!after.homepageLinkFormat</td>
 									</tr>
 									<tr>
 										<th align="left" style="padding:5px;background:#f0f0f0;">Download Location</th>
-										<td style="padding:5px;">#if( $before.downloadLocationLinkFormat )$!before.downloadLocationLinkFormat#end</td>
-										<td style="padding:5px;">#if( $after.downloadLocationLinkFormat )$!after.downloadLocationLinkFormat#end</td>
+										<td style="padding:5px;">$!before.downloadLocationLinkFormat</td>
+										<td style="padding:5px;">$!after.downloadLocationLinkFormat</td>
 									</tr>
 									<tr>
 										<th align="left" style="padding:5px;background:#f0f0f0;">Summary Description</th>

--- a/src/main/webapp/WEB-INF/views/admin/oss/ossAnalysisResultDetailpopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/ossAnalysisResultDetailpopup.jsp
@@ -109,7 +109,7 @@
 					if(licenseName != ''){
 						var cloneData = common_data.detectLicenseClone.split("autoComOssLicense1").join("autoComOssLicense"+seq); // autoComplete 기능으로 인해 cloneData를 별도로 가공함.
 						$(cloneData).appendTo('.detailDetectedLicense'+seq);
-						$(".detailDetectedLicense"+seq+" input[type=text]:last").val(licenseName);
+						$(".detailDetectedLicense"+seq+" input[type=text]:last").val(licenseName.trim());
 						
 						grid_fn.setCustomAutoComplete('single', '', seq);
 						


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
- Fix a bug where a space is added at the beginning when there are more than two detected licenses when loading OSS.
- Fix templdate and data when mailing change.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
