### PR TITLE
Fix if statements without curly braces

### DIFF
--- a/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
@@ -223,10 +223,13 @@ public class ApiProjectController extends CoTopComponent {
 						List<String[]> models = new ArrayList<>();
 						for (String strModel : modelListToUpdate) {
 							String[] model = strModel.split("\\|");
-							if (model.length > 2) models.add(model);
+							if (model.length > 2) {
+								models.add(model);
+							}
 						}
-						if (models.size() > 0)
+						if (models.size() > 0) {
 							modelList = ExcelUtil.readModelFromList(models, prjId, CoConstDef.FLAG_YES, "0", project.getDistributeTarget());
+						}
 					} else {
 						errorCode = CoConstDef.CD_OPEN_API_FILE_NOTEXISTS_MESSAGE;
 					}

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -3495,7 +3495,9 @@ public class CommonFunction extends CoTopComponent {
 		List<List<ProjectIdentification>> ossComponentLicense = new ArrayList<List<ProjectIdentification>>(); 
 		
 		for(ProjectIdentification pi : ossComponent) {
-			if(excludeFlag && CoConstDef.FLAG_YES.equals(pi.getExcludeYn()) && isEmpty(pi.getLicenseName())) continue;
+			if(excludeFlag && CoConstDef.FLAG_YES.equals(pi.getExcludeYn()) && isEmpty(pi.getLicenseName())) {
+				continue;
+			}
 			
 			String convertLicenseName = pi.getLicenseName();
 			
@@ -3699,12 +3701,16 @@ public class CommonFunction extends CoTopComponent {
 						
 						if(ossInfoByNickList != null) {
 							int deactivateCnt = ossInfoByNickList.stream().filter(e -> e.getDeactivateFlag().equals(CoConstDef.FLAG_YES)).collect(Collectors.toList()).size();
-							if(deactivateCnt > 0) continue;
+							if(deactivateCnt > 0) {
+								continue;
+							}
 							
 							if(ossAnalysisByNickList.size() > 0) {
 								String checkDuplicateOssName = ossInfoByNickList.get(0).getOssName();
 								int checkDuplicateCnt = ossAnalysisByNickList.stream().filter(e -> e.getOssName().equalsIgnoreCase(checkDuplicateOssName)).collect(Collectors.toList()).size();
-								if(checkDuplicateCnt > 0) continue;
+								if(checkDuplicateCnt > 0) {
+									continue;
+								}
 							}
 							
 							final Comparator<OssMaster> comp = Comparator.comparing((OssMaster o) -> o.getModifiedDate()).reversed();
@@ -3722,7 +3728,9 @@ public class CommonFunction extends CoTopComponent {
 							}
 							
 							String analysisTitle = ossInfoByNickList.get(0).getOssName();
-							if(!isEmpty(ossInfoByNickList.get(0).getOssVersion())) analysisTitle += " (" + ossInfoByNickList.get(0).getOssVersion() + ")";
+							if(!isEmpty(ossInfoByNickList.get(0).getOssVersion())) {
+								analysisTitle += " (" + ossInfoByNickList.get(0).getOssVersion() + ")";
+							}
 							
 							ossInfoByNick = new OssAnalysis(userData.getGridId(), ossInfoByNickList.get(0).getOssName(), bean.getOssVersion(), ossInfoByNickList.get(0).getOssNickname().replaceAll("<br>", ",")
 									, license.substring(0, license.length()-1), ossInfoByNickList.get(0).getCopyright(), ossInfoByNickList.get(0).getDownloadLocation()
@@ -4310,13 +4318,17 @@ public class CommonFunction extends CoTopComponent {
 		int startIndex = (curPage-1)*pageListSize;
 		
 		int totBlockPage = (totBlockSize / blockSize);
-		if(totBlockSize != blockSize) totBlockPage++;
+		if (totBlockSize != blockSize) {
+			totBlockPage++;
+		}
 		
 		int blockPage = ((curPage-1) / blockSize) + 1;
 		
 		int blockStart = ((blockPage-1) * blockSize) + 1;
 		int blockEnd = blockStart+blockSize-1;
-		if(blockEnd > totBlockSize) blockEnd = totBlockSize;
+		if (blockEnd > totBlockSize) {
+			blockEnd = totBlockSize;
+		}
 		
 		map.put("totBlockSize", totBlockSize);
 		map.put("startIndex", startIndex);

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -1038,8 +1038,9 @@ public class OssController extends CoTopComponent{
 			LicenseMaster licenseMaster;
 			List<String> declaredLicenses = oss.getDeclaredLicenses();
 			String downloadLocation = oss.getDownloadLocation();
-			if (downloadLocation != null)
+			if (downloadLocation != null) {
 				oss.setDownloadLocations(downloadLocation.split(","));
+			}
 			boolean[] check = new boolean[declaredLicenses.size() + 1];
 			List<OssLicense> ossLicenses = new ArrayList<>();
 			int licenseCount = 1;
@@ -1070,8 +1071,11 @@ public class OssController extends CoTopComponent{
 				OssLicense convert = new OssLicense();
 				convert.setLicenseId(existsLicense.getLicenseId());
 				convert.setLicenseName(existsLicense.getLicenseName());
-				if (licenseCount > 1) convert.setOssLicenseComb("AND");
-				else convert.setOssLicenseComb("");
+				if (licenseCount > 1) {
+					convert.setOssLicenseComb("AND");
+				} else {
+					convert.setOssLicenseComb("");
+				}
 				convert.setLicenseNameEx(existsLicense.getLicenseNameTemp());
 				convert.setLicenseType(existsLicense.getLicenseType());
 				if (CoConstDef.FLAG_YES.equals(avoidNull(existsLicense.getObligationNeedsCheckYn()))) {
@@ -1106,14 +1110,22 @@ public class OssController extends CoTopComponent{
 
 			for (int i = 0; i < ossLicenses.size(); i++) {
 				OssLicense ossLicense = ossLicenses.get(i);
-				if (!check[i]) continue;
-				if (licenseCount <= 2) ossLicense.setLicenseType("S");
-				else ossLicense.setLicenseType("M");
+				if (!check[i]) {
+					continue;
+				}
+				if (licenseCount <= 2) {
+					ossLicense.setLicenseType("S");
+				} else {
+					ossLicense.setLicenseType("M");
+				}
 			}
 			oss.setOssLicenses(ossLicenses);
 
-			if (licenseCount > 2) oss.setLicenseDiv("M");
-			else oss.setLicenseDiv("S");
+			if (licenseCount > 2) {
+				oss.setLicenseDiv("M");
+			} else {
+				oss.setLicenseDiv("S");
+			}
 
 			boolean checkDuplicated = true;
 			if (ossService.checkExistsOss(oss) != null) {
@@ -2150,7 +2162,9 @@ public class OssController extends CoTopComponent{
 						}
 				}
 				if(!ossMasterCheclFlag && !declaredLicenseCheckFlag && !detectedLicenseCheckFlag && !downloadLocationCheckFlag){
-					if(!isEmpty(comment)) onlyCommentRegistFlag = true;
+					if(!isEmpty(comment)) {
+						onlyCommentRegistFlag = true;
+					}
 				}
 								
 				if ((ossMasterCheclFlag || declaredLicenseCheckFlag || detectedLicenseCheckFlag || downloadLocationCheckFlag) || onlyCommentRegistFlag) {

--- a/src/main/java/oss/fosslight/controller/PartnerController.java
+++ b/src/main/java/oss/fosslight/controller/PartnerController.java
@@ -748,8 +748,9 @@ public class PartnerController extends CoTopComponent{
 						for(PartnerMaster pm : result) {
 							pm.setPartnerId(project.getPartnerId());
 							
-							if(existPartnerWatcher)
+							if(existPartnerWatcher) {
 								partnerService.addWatcher(pm);
+							}
 						}
 					}
 				}

--- a/src/main/java/oss/fosslight/domain/CoCode.java
+++ b/src/main/java/oss/fosslight/domain/CoCode.java
@@ -160,8 +160,8 @@ public class CoCode {
         for(int j = codeDtls.size(); i < j; i++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
-            if(!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
-            	continue;
+            if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+              continue;
             }
             vector.add(new String[] {
                 codedtl.cdDtlNo, codedtl.cdDtlNm, codedtl.cdSubNo, codedtl.cdDtlExp
@@ -179,7 +179,7 @@ public class CoCode {
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
             if(!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
-            	continue;
+              continue;
             }
             vector.add(codedtl);
         }
@@ -200,8 +200,8 @@ public class CoCode {
         for(int j = codeDtls.size(); i < j; i++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
-            if(!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
-            	continue;
+            if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+              continue;
             }
             vector.add(new String[] {
                 codedtl.cdDtlNo, codedtl.cdSubNo, codedtl.cdDtlNm, codedtl.cdDtlNm2, codedtl.cdDtlExp, codedtl.cdOrder+""
@@ -217,8 +217,8 @@ public class CoCode {
         for(int j = codeDtls.size(); i < j; i++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
-            if(!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
-            	continue;
+            if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+              continue;
             }
             vector.add(codedtl);
         }
@@ -239,8 +239,8 @@ public class CoCode {
         for(int j = codeDtls.size(); i < j; i++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
-            if(!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
-            	continue;
+            if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+              continue;
             }
             vector.add(codedtl.cdDtlNo);
         }
@@ -259,9 +259,9 @@ public class CoCode {
 		int i = 0;
 		for (int j = codeDtls.size(); i < j; i++) {
 			CoCodeDtl codedtl = (CoCodeDtl) codeDtls.get(i);
-			if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
-				continue;
-			}
+      if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+        continue;
+      }
 			vector.add(codedtl.cdDtlNm);
 		}
 
@@ -284,8 +284,7 @@ public class CoCode {
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
             stringbuffer.append("    <option value='").append(codedtl.cdDtlNo).append('\'');
-            if((i == 0 && codedtl.cdDtlNo.equals(s1)) || (i == 1 && codedtl.cdDtlNm.equals(s1)))
-            {
+            if ((i == 0 && codedtl.cdDtlNo.equals(s1)) || (i == 1 && codedtl.cdDtlNm.equals(s1))) {
                 stringbuffer.append(" selected");
             }
             stringbuffer.append(">").append(codedtl.cdDtlNm).append("</option>\n");
@@ -309,15 +308,13 @@ public class CoCode {
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
             
-            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) 
-            {
-            	continue;
+            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+              continue;
             }
             
             stringbuffer.append("    <option VALUE='").append(codedtl.cdDtlNo).append('\'');
             
-            if( (i == 0 && codedtl.cdDtlNo.equals(s) ) || ( i == 1 && codedtl.cdDtlNm.equals(s) ))
-            {
+            if((i == 0 && codedtl.cdDtlNo.equals(s)) || (i == 1 && codedtl.cdDtlNm.equals(s))) {
                 stringbuffer.append(" selected");
             }
             stringbuffer.append(">").append(codedtl.cdDtlNm).append("</option>\n");
@@ -341,11 +338,10 @@ public class CoCode {
 	        for(int k = codeDtls.size(); j < k; j++)
 	        {
 	            CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
-	            
-	            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) 
-	            {
-	            	continue;
-	            }
+
+              if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+                continue;
+              }
 	            
 	            stringbuffer.append("    <input name='statuses' type='checkbox' value='").append(codedtl.cdDtlNo).append("' ").append((status.indexOf(codedtl.cdDtlNo)>-1)?"checked='checked'":""); 
 	            stringbuffer.append(" style='margin:2px 5px 0px 0px;' />&nbsp;").append(codedtl.cdDtlNm).append("&nbsp;&nbsp;&nbsp;&nbsp;");
@@ -363,11 +359,10 @@ public class CoCode {
         	for(int k = codeDtls.size(); j < k; j++)
 	        {
 	            CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
-	            
-	            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) 
-	            {
-	            	continue;
-	            }
+
+              if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+                continue;
+              }
 	            
 	            stringbuffer.append("    <input name='restrictions' type='checkbox' value='").append(codedtl.cdDtlNo).append("' ").append((restrictionList.contains(codedtl.cdDtlNo))?"checked='checked'":""); 
 	            stringbuffer.append(" style='margin:2px 5px 0px 0px;' />&nbsp;").append(codedtl.cdDtlNm).append("&nbsp;&nbsp;&nbsp;&nbsp;"+(j==newLineIdx?"<br>"+("list".equals(callType)?"<label></label>":""):""));
@@ -376,18 +371,16 @@ public class CoCode {
         	for(int k = codeDtls.size(); j < k; j++)
 	        {
 	            CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
-	            
-	            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) 
-	            {
-	            	continue;
-	            }
+
+              if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+                continue;
+              }
 	            
 	            stringbuffer.append("<input name='noticeType' type='checkbox' value='").append(codedtl.cdDtlNo).append("' ").append(CoConstDef.FLAG_YES.equals(codedtl.cdDtlExp)?"checked='checked'":"");
-	            
-	            if(CoConstDef.CD_NOTICE_HTML_STR.equals(codedtl.cdDtlNm.toUpperCase())) 
-	            {
-	            	stringbuffer.append(" disabled ");
-	            }
+
+              if (CoConstDef.CD_NOTICE_HTML_STR.equals(codedtl.cdDtlNm.toUpperCase())) {
+                stringbuffer.append(" disabled ");
+              }
 	            
 	            stringbuffer.append("  />&nbsp;").append(codedtl.cdDtlNm).append("&nbsp;&nbsp;&nbsp;&nbsp;");
 	        }
@@ -411,13 +404,13 @@ public class CoCode {
 	        for(int k = codeDtls.size(); j < k; j++){
 	            CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
 	           
-	            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) 
-	            {
+	            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
 	            	continue;
 	            }
-	            
-	            if(!NAExceptionFlag && codedtl.cdDtlNo.equals("NA")) // default로 NA도 생성 false값 입력시 예외처리
-	            	continue;
+
+              if (!NAExceptionFlag && codedtl.cdDtlNo.equals("NA")) { // default로 NA도 생성 false값 입력시 예외처리
+                continue;
+              }
 	            
 	            stringbuffer.append("    <input name='").append(name).append("' type='checkbox' value='").append(codedtl.cdDtlNo).append("' ").append((values.contains(codedtl.cdDtlNo)) ? "checked='checked'":""); 
 	            stringbuffer.append(" style='margin:2px 5px 0px 0px;' />&nbsp;").append(codedtl.cdDtlNm).append("&nbsp;&nbsp;&nbsp;&nbsp;");
@@ -442,16 +435,16 @@ public class CoCode {
         	distributionType = CoConstDef.CD_GENERAL_MODEL;
         }
         
-        if(StringUtils.isEmpty(networkServerType)) {
-        	networkServerType = CoConstDef.FLAG_NO;
+        if (StringUtils.isEmpty(networkServerType)) {
+          networkServerType = CoConstDef.FLAG_NO;
         }
         
         for(int k = codeDtls.size(); j < k; j++) {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
             
-            if (CoConstDef.FLAG_NO.equals(codedtl.useYn) 
-            		|| codedtl.cdDtlNo.equals(CoConstDef.CD_NETWORK_SERVER)) {
-            	continue;
+            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)
+                || codedtl.cdDtlNo.equals(CoConstDef.CD_NETWORK_SERVER)) {
+              continue;
             }
             
             stringbuffer.append("<span class='radioSet'>")
@@ -485,17 +478,16 @@ public class CoCode {
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
             
-            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) 
-            {
-            	continue;
+            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+              continue;
             }
             
-            if(s1.equals("oss")) {
-            	stringbuffer.append("<li><input type='checkbox' name='mostUsedOssChartDivision' value='").append(codedtl.cdDtlNo).append("' ")
+            if (s1.equals("oss")) {
+              stringbuffer.append("<li><input type='checkbox' name='mostUsedOssChartDivision' value='").append(codedtl.cdDtlNo).append("' ")
                 .append(" id='checkboxOss_").append(codedtl.cdDtlNo).append("' />")
                 .append("<label for='checkboxOss_").append(codedtl.cdDtlNo).append("'>").append(codedtl.cdDtlNm).append("</label></li>");
             } else {
-            	stringbuffer.append("<li><input type='checkbox' name='mostUsedLicenseChartDivision' value='").append(codedtl.cdDtlNo).append("' ")
+              stringbuffer.append("<li><input type='checkbox' name='mostUsedLicenseChartDivision' value='").append(codedtl.cdDtlNo).append("' ")
                 .append(" id='checkboxLicense_").append(codedtl.cdDtlNo).append("' />")
                 .append("<label for='checkboxLicense_").append(codedtl.cdDtlNo).append("'>").append(codedtl.cdDtlNm).append("</label></li>");
             }

--- a/src/main/java/oss/fosslight/domain/ComBean.java
+++ b/src/main/java/oss/fosslight/domain/ComBean.java
@@ -390,7 +390,9 @@ public class ComBean extends CoTopComponent implements Serializable {
 		this.startIndex = (curPage-1)*pageListSize;
 		
 		int totBlockPage = (totBlockSize / blockSize);
-		if(totBlockSize != blockSize) totBlockPage++;
+		if(totBlockSize != blockSize) {
+			totBlockPage++;
+		}
 		this.totBlockPage = totBlockPage;
 		
 		int blockPage = ((curPage-1) / blockSize) + 1;
@@ -398,7 +400,9 @@ public class ComBean extends CoTopComponent implements Serializable {
 		
 		int blockStart = ((blockPage-1) * blockSize) + 1;
 		int blockEnd = blockStart+blockSize-1;
-		if(blockEnd > totBlockSize) blockEnd = totBlockSize;
+		if(blockEnd > totBlockSize) {
+			blockEnd = totBlockSize;
+		}
 		
 		this.blockStart = blockStart;
 		this.blockEnd = blockEnd;

--- a/src/main/java/oss/fosslight/service/NvdDataService.java
+++ b/src/main/java/oss/fosslight/service/NvdDataService.java
@@ -78,7 +78,9 @@ public class NvdDataService {
 		// 작업등록
 		try {
 			boolean fileCheck = nvdMetaCheckJob(NVD_DATA_FILE_NAME_CPEMATCH, "MATCH");
-			if(!fileCheck) fileCheck = nvdMetaRetryCheckJob(NVD_DATA_FILE_NAME_CPEMATCH, "MATCH", fileCheck, 0);
+			if(!fileCheck) {
+				fileCheck = nvdMetaRetryCheckJob(NVD_DATA_FILE_NAME_CPEMATCH, "MATCH", fileCheck, 0);
+			}
 			
 			if(fileCheck) {
 				nvdFeedDataDownloadJob(NVD_DATA_FILE_NAME_CPEMATCH);
@@ -108,7 +110,9 @@ public class NvdDataService {
 
 		try {
 			boolean fileCheck = nvdMetaCheckJob(NVD_DATA_FILE_NAME_NVDCVE, "CVE");
-			if(!fileCheck) fileCheck = nvdMetaRetryCheckJob(NVD_DATA_FILE_NAME_NVDCVE, "CVE", fileCheck, 0);
+			if(!fileCheck) {
+				fileCheck = nvdMetaRetryCheckJob(NVD_DATA_FILE_NAME_NVDCVE, "CVE", fileCheck, 0);
+			}
 			
 			if(fileCheck) {
 				nvdFeedDataDownloadJob(NVD_DATA_FILE_NAME_NVDCVE);
@@ -201,7 +205,9 @@ public class NvdDataService {
 				insertStmt = conn2.prepareStatement(insertQuery);
 				
 				for(int idx = 0; idx < cnt; ) {
-					if(endIdx >= cnt) endIdx = cnt;
+					if (endIdx >= cnt) {
+						endIdx = cnt;
+					}
 					preparedStatementGetProductList(conn2, itemList, params, getProductStmt, getMaxScoreProductVerStmt, insertStmt, idx, endIdx);
 					
 					idx = idx+BATCH_SIZE;
@@ -215,56 +221,68 @@ public class NvdDataService {
 			} catch(Exception e) {
 				log.error(e.getMessage(), e);
 				
-				try{
-					if(insertStmt!=null)
+				try {
+					if (insertStmt != null) {
 						insertStmt.close();
-				}catch(SQLException e1){}
-				try{
-					if(getMaxScoreProductVerStmt!=null)
+					}
+				} catch(SQLException e1) {}
+				try {
+					if (getMaxScoreProductVerStmt != null) {
 						getMaxScoreProductVerStmt.close();
-				}catch(SQLException e1){}
+					}
+				} catch(SQLException e1) {}
 				try{
-					if(getMaxScoreProductVerStmt!=null)
+					if (getMaxScoreProductVerStmt != null) {
 						getMaxScoreProductVerStmt.close();
-				}catch(SQLException e1){}
+					}
+				} catch(SQLException e1) {}
 				try{
-					if(conn2!=null)
+					if (conn2 != null) {
 						conn2.rollback();
 						conn2.close();
-				}catch(SQLException e1){}
-				try{
-					if(conn1!=null)
+					}
+				} catch(SQLException e1) {}
+				try {
+					if (conn1 != null) {
 						conn1.close();
-				}catch(SQLException e1){}
+					}
+				} catch(SQLException e1) {}
 				try{
-					if(conn!=null)
+					if (conn != null) {
 						conn.close();
+					}
 				}catch(SQLException e1){}
 			} finally {
 				try{
-					if(insertStmt!=null)
+					if (insertStmt != null) {
 						insertStmt.close();
-				}catch(SQLException e1){}
+					}
+				} catch(SQLException e1) {}
 				try{
-					if(getMaxScoreProductVerStmt!=null)
+					if (getMaxScoreProductVerStmt != null) {
 						getMaxScoreProductVerStmt.close();
-				}catch(SQLException e1){}
+					}
+				} catch(SQLException e1) {}
 				try{
-					if(getMaxScoreProductVerStmt!=null)
+					if (getMaxScoreProductVerStmt != null) {
 						getMaxScoreProductVerStmt.close();
-				}catch(SQLException e1){}
-				try{
-					if(conn2!=null)
+					}
+				} catch(SQLException e1) {}
+				try {
+					if (conn2 != null) {
 						conn2.close();
-				}catch(SQLException e1){}
-				try{
-					if(conn1!=null)
+					}
+				} catch(SQLException e1) {}
+				try {
+					if (conn1 != null) {
 						conn1.close();
-				}catch(SQLException e1){}
+					}
+				} catch(SQLException e1) {}
 				try{
-					if(conn!=null)
+					if (conn != null) {
 						conn.close();
-				}catch(SQLException e1){}
+					}
+				} catch(SQLException e1) {}
 			}
 			
 			nvdDataMapper.deleteNvdDataScoreV3();
@@ -339,15 +357,17 @@ public class NvdDataService {
 			itemList.clear();
 			log.error(e.getMessage(), e);
 			try{
-				if(rs!=null)
+				if (rs != null) {
 					rs.close();
-			}catch(SQLException e1){}
+				}
+			} catch(SQLException e1) {}
 		} finally {
 			itemList.clear();
 			try{
-				if(rs!=null)
+				if (rs != null) {
 					rs.close();
-			}catch(SQLException e1){}
+				}
+			} catch(SQLException e1) {}
 		}
 	}
 	
@@ -426,20 +446,23 @@ public class NvdDataService {
 		} catch(Exception e) {
 			params.clear();
 			log.error(e.getMessage(), e);
-			try{
-				if(getMaxScoreProductVerRs!=null)
+			try {
+				if (getMaxScoreProductVerRs != null) {
 					getMaxScoreProductVerRs.close();
-			}catch(SQLException e1){}
-			try{
-				if(getMaxScoreProductVerStmt!=null)
+				}
+			} catch(SQLException e1) {}
+			try {
+				if (getMaxScoreProductVerStmt != null) {
 					getMaxScoreProductVerStmt.close();
-			}catch(SQLException e1){}
+				}
+			} catch(SQLException e1) {}
 		} finally {
 			params.clear();
 			try{
-				if(getMaxScoreProductVerRs!=null)
+				if (getMaxScoreProductVerRs != null) {
 					getMaxScoreProductVerRs.close();
-			}catch(SQLException e){}
+				}
+			} catch(SQLException e) {}
 		}
 	}
 	
@@ -638,14 +661,16 @@ public class NvdDataService {
 			}
 		} finally {
 			try{
-				if(stmt!=null)
+				if (stmt != null) {
 					stmt.close();
-			}catch(SQLException e){}
+				}
+			} catch(SQLException e){}
 			
 			try{
-				if(conn!=null)
+				if (conn != null) {
 					conn.close();
-			}catch(SQLException e){}
+				}
+			} catch(SQLException e){}
 		}
 	}
 
@@ -967,18 +992,21 @@ public class NvdDataService {
 							}
 						}
 					} finally {
-						try{
-							if(stmt!=null)
+						try {
+							if (stmt != null) {
 								stmt.close();
-						}catch(SQLException e){}
-						try{
-							if(stmt2!=null)
+							}
+						} catch(SQLException e) {}
+						try {
+							if (stmt2 != null) {
 								stmt2.close();
-						}catch(SQLException e){}
+							}
+						} catch(SQLException e) {}
 						try{
-							if(conn!=null)
+							if (conn != null) {
 								conn.close();
-						}catch(SQLException e){}
+							}
+						} catch(SQLException e) {}
 					}
 				}
 

--- a/src/main/java/oss/fosslight/service/impl/ApiBatServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiBatServiceImpl.java
@@ -137,13 +137,13 @@ public class ApiBatServiceImpl implements ApiBatService {
 				} catch (Exception e) {}
 			}
 			
-			if(stmt!=null) {
+			if (stmt != null) {
 				try {
 					stmt.close();
 				} catch (SQLException e) {}
 			}
 			
-			if(conn!=null) {
+			if (conn != null) {
 				try {
 					conn.close();
 				} catch (SQLException e) {}

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2257,7 +2257,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						if(!isEmpty(checkName)){
 							bean.setCheckName(checkName);
 							bean.setDownloadLocation(downloadLocation);
-							if(!bean.getOssName().equals(bean.getCheckName())) result.add(bean);
+							if(!bean.getOssName().equals(bean.getCheckName())) {
+								result.add(bean);
+							}
 						}
 					}
 				} else {
@@ -2652,9 +2654,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			resMap.put("isChangedName", isChangedName);
 			resMap.put("isDeactivateFlag", isDeactivateFlag);
 			resMap.put("isActivateFlag", isActivateFlag);
-			if(beforeBean != null) resMap.put("beforeBean", beforeBean);
-			if(afterBean != null) resMap.put("afterBean", afterBean);
-			if(updateOssNameVersionDiffMergeObject != null) resMap.put("updateOssNameVersionDiffMergeObject", updateOssNameVersionDiffMergeObject);
+			if(beforeBean != null) {
+				resMap.put("beforeBean", beforeBean);
+			}
+			if(afterBean != null) {
+				resMap.put("afterBean", afterBean);
+			}
+			if(updateOssNameVersionDiffMergeObject != null) {
+				resMap.put("updateOssNameVersionDiffMergeObject", updateOssNameVersionDiffMergeObject);
+			}
 		}
 		resMap.put("resCd", resCd);
 		return resMap;
@@ -3141,26 +3149,40 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<String> checkList = new ArrayList<String>();
 				
 		if (!Arrays.equals(standardOss.getOssLicenses().toArray(), selectOss.getOssLicenses().toArray())) {
-			if (!standardOss.getLicenseName().equals(selectOss.getLicenseName())) checkList.add("Declared License");
+			if (!standardOss.getLicenseName().equals(selectOss.getLicenseName())) {
+				checkList.add("Declared License");
+			}
 		}
 		if (!Arrays.equals(standardOss.getDetectedLicenses().toArray(), selectOss.getDetectedLicenses().toArray())) {
-			if (!standardOss.getDetectedLicense().equals(selectOss.getDetectedLicense())) checkList.add("Detected License");
+			if (!standardOss.getDetectedLicense().equals(selectOss.getDetectedLicense())) {
+				checkList.add("Detected License");
+			}
 		}
-		if (!avoidNull(standardOss.getCopyright(), "").equals(avoidNull(selectOss.getCopyright(), ""))) checkList.add("Copyright");
+		if (!avoidNull(standardOss.getCopyright(), "").equals(avoidNull(selectOss.getCopyright(), ""))) {
+			checkList.add("Copyright");
+		}
 		if (standardOss.getDownloadLocations() != null) {
 			if (selectOss.getDownloadLocations() != null) {
-				if (!Arrays.equals(Arrays.asList(standardOss.getDownloadLocations()).toArray(), Arrays.asList(selectOss.getDownloadLocations()).toArray())) checkList.add("Download Location");
-			}else {
+				if (!Arrays.equals(Arrays.asList(standardOss.getDownloadLocations()).toArray(), Arrays.asList(selectOss.getDownloadLocations()).toArray())) {
+					checkList.add("Download Location");
+				}
+			} else {
 				checkList.add("Download Location");
 			}
-		}else {
+		} else {
 			if (selectOss.getDownloadLocations() != null) {
 				checkList.add("Download Location");
 			}
 		}
-		if (!avoidNull(standardOss.getHomepage(), "").equals(avoidNull(selectOss.getHomepage(), ""))) checkList.add("Home Page");
-		if (!avoidNull(standardOss.getSummaryDescription(), "").equals(avoidNull(selectOss.getSummaryDescription(), ""))) checkList.add("Summary Description");
-		if (!avoidNull(standardOss.getAttribution(), "").equals(avoidNull(selectOss.getAttribution(), ""))) checkList.add("Attribution");
+		if (!avoidNull(standardOss.getHomepage(), "").equals(avoidNull(selectOss.getHomepage(), ""))) {
+			checkList.add("Home Page");
+		}
+		if (!avoidNull(standardOss.getSummaryDescription(), "").equals(avoidNull(selectOss.getSummaryDescription(), ""))) {
+			checkList.add("Summary Description");
+		}
+		if (!avoidNull(standardOss.getAttribution(), "").equals(avoidNull(selectOss.getAttribution(), ""))) {
+			checkList.add("Attribution");
+		}
 		
 		return checkList;
 	}
@@ -3607,7 +3629,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		boolean isActivateFlag = (boolean) resMap.get("isActivateFlag");
 		
 		Map<String, List<OssMaster>> updateOssNameVersionDiffMergeObject = null;
-		if(resMap.containsKey("updateOssNameVersionDiffMergeObject")) updateOssNameVersionDiffMergeObject = (Map<String, List<OssMaster>>) resMap.get("updateOssNameVersionDiffMergeObject");
+		if (resMap.containsKey("updateOssNameVersionDiffMergeObject")) {
+			updateOssNameVersionDiffMergeObject = (Map<String, List<OssMaster>>) resMap.get(
+					"updateOssNameVersionDiffMergeObject");
+		}
 		
 		String mailType = "";
 		

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -1822,7 +1822,9 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			}
 		}
 		
-		if(fileDeleteCheckFlag) projectMapper.updateFileId2(project);
+		if(fileDeleteCheckFlag) {
+			projectMapper.updateFileId2(project);
+		}
 	}
 	
 	@Override

--- a/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
@@ -732,7 +732,9 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			if(!isEmpty(max_vuln_ossName)) {
 				vnlnUpdBean.setOssName(max_vuln_ossName);
 				vnlnUpdBean.setOssVersion(avoidNull(max_vuln_ossVersion));
-				if(max_vuln_ossName.contains(" ")) vnlnUpdBean.setOssNameTemp(max_vuln_ossName.replaceAll(" ", "_"));
+				if(max_vuln_ossName.contains(" ")) {
+					vnlnUpdBean.setOssNameTemp(max_vuln_ossName.replaceAll(" ", "_"));
+				}
 				vnlnUpdBean = selfCheckMapper.getMaxVulnByOssName(vnlnUpdBean);				
 			}
 			
@@ -870,19 +872,22 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 			try{
-				if(stmt!=null)
+				if (stmt != null) {
 					stmt.close();
-			}catch(SQLException se){}
+				}
+			} catch(SQLException se) {}
 			
 			try{
-				if(stmt2!=null)
+				if (stmt2 != null) {
 					stmt2.close();
-			}catch(SQLException se){}
+				}
+			} catch(SQLException se) {}
 			
 			try{
-				if(stmt3!=null)
+				if (stmt3 != null) {
 					stmt3.close();
-			}catch(SQLException se){}
+				}
+			} catch(SQLException se) {}
 			
 			if(conn != null) {
 				try {
@@ -894,24 +899,28 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			}
 		} finally {
 			try{
-				if(stmt!=null)
+				if (stmt != null) {
 					stmt.close();
-			}catch(SQLException e){}
+				}
+			} catch(SQLException e) {}
 			
-			try{
-				if(stmt2!=null)
+			try {
+				if (stmt2 != null) {
 					stmt2.close();
-			}catch(SQLException e){}
+				}
+			} catch(SQLException e) {}
 			
 			try{
-				if(stmt3!=null)
+				if (stmt3 != null) {
 					stmt3.close();
-			}catch(SQLException e){}
+				}
+			} catch(SQLException e) {}
 			
 			try{
-				if(conn!=null)
+				if (conn != null) {
 					conn.close();
-			}catch(SQLException e){}
+				}
+			} catch(SQLException e) {}
 		}
 	}
 
@@ -936,7 +945,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				if((idx % 1000) == 0) {
 					stmt.executeBatch();
 					stmt.clearBatch();
-		            conn.commit();
+					conn.commit();
 				}
 				
 				idx++;
@@ -947,9 +956,10 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 			try{
-				if(stmt!=null)
+				if (stmt != null) {
 					stmt.close();
-			}catch(SQLException e1){}
+				}
+			} catch(SQLException e1) {}
 			
 			if(conn != null) {
 				try {
@@ -960,15 +970,17 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				}
 			}
 		} finally {
-			try{
-				if(stmt!=null)
+			try {
+				if (stmt != null) {
 					stmt.close();
-			}catch(SQLException e){}
+				}
+			} catch(SQLException e) {}
 			
 			try{
-				if(conn!=null)
+				if (conn != null) {
 					conn.close();
-			}catch(SQLException e){}
+				}
+			} catch(SQLException e) {}
 		}
 	}
 	
@@ -995,7 +1007,9 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				ossCheckParam.add(_ossName);
 			}
 			
-			if(!isEmpty(ossInfoKey)) ossInfoKey = "";
+			if(!isEmpty(ossInfoKey)) {
+				ossInfoKey = "";
+			}
 		}
 		if(!ossCheckParam.isEmpty()) {
 			OssMaster param = new OssMaster();
@@ -1710,7 +1724,9 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				switch(CommonFunction.checkObligationSelectedLicense(ossComponent.getOssComponentsLicense())){
 					case CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE: 
 						if(hideOssVersionFlag) {
-							if(!srcInfo.containsKey(componentKey)) srcInfo.put(componentKey, ossComponent);
+							if(!srcInfo.containsKey(componentKey)) {
+								srcInfo.put(componentKey, ossComponent);
+							}
 						} else {
 							srcInfo.put(componentKey, ossComponent);
 						}
@@ -1718,7 +1734,9 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 						break;
 					case CoConstDef.CD_DTL_OBLIGATION_NOTICE: 
 						if(hideOssVersionFlag) {
-							if(!noticeInfo.containsKey(componentKey)) noticeInfo.put(componentKey, ossComponent);
+							if(!noticeInfo.containsKey(componentKey)) {
+								noticeInfo.put(componentKey, ossComponent);
+							}
 						} else {
 							noticeInfo.put(componentKey, ossComponent);
 						}

--- a/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
@@ -654,7 +654,9 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				boolean isFirst = true;
 				
 				for(String s : result) {
-					if(s.contains("?")) s = s.replaceAll("[?]", "0x3F");
+					if(s.contains("?")) {
+						s = s.replaceAll("[?]", "0x3F");
+					}
 					if(!isEmpty(s) && !(s.contains("(") && s.contains(")"))) {
 						// packaging file name의 경우 Path로 인식하지 못하도록 처리함.
 
@@ -757,7 +759,9 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			List<String> pathCheckList46 = new ArrayList<>();
 			
 			for (String path : deCompResultMap.keySet()) {
-				if(path.contains("?")) path = path.replaceAll("[?]", "0x3F");
+				if (path.contains("?")) {
+					path = path.replaceAll("[?]", "0x3F");
+				}
 				
 				pathCheckList1.add(path);
 				pathCheckList2.add("/" + path);
@@ -910,7 +914,9 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			log.info("VERIFY Path Check START -----------------");
 			
 			for(String gridPath : gridFilePaths){
-				if(gridPath.contains("?")) gridPath = gridPath.replaceAll("[?]", "0x3F");
+				if (gridPath.contains("?")) {
+					gridPath = gridPath.replaceAll("[?]", "0x3F");
+				}
 				
 				if(!separatorErrFlag) {
 					separatorErrFlag = gridPath.contains("\\") ? true : false;

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -1794,9 +1794,13 @@ public class ExcelUtil extends CoTopComponent {
 					for (colindex = 0; colindex < maxcols; colindex++) {
 						Cell cell = row.getCell(colindex);
 						String value = getCellData(cell);
-						if (colindex < model.length && value != null) model[colindex] = value;
+						if (colindex < model.length && value != null) {
+							model[colindex] = value;
+						}
 					}
-					if (!model[0].isEmpty() && !model[1].isEmpty() && !model[2].isEmpty()) models.add(model);
+					if (!model[0].isEmpty() && !model[1].isEmpty() && !model[2].isEmpty()) {
+						models.add(model);
+					}
 				}
 			} catch (Exception e) {
 				log.error(e.getMessage(), e);
@@ -2824,8 +2828,9 @@ public class ExcelUtil extends CoTopComponent {
 							}
 						} else {
 							OssMaster ossMaster = getOssDataByColumn(row.cellIterator());
-							if (ossMaster != null)
+							if (ossMaster != null) {
 								ossMasterList.add(ossMaster);
+							}
 						}
 					}
 				} catch (IOException e) {
@@ -2851,8 +2856,9 @@ public class ExcelUtil extends CoTopComponent {
 							}
 						} else {
 							OssMaster ossMaster = getOssDataByColumn(row.cellIterator());
-							if (ossMaster != null)
+							if (ossMaster != null) {
 								ossMasterList.add(ossMaster);
+							}
 						}
 					}
 				} catch (IOException e) {
@@ -2937,8 +2943,9 @@ public class ExcelUtil extends CoTopComponent {
 							}
 						} else {
 							LicenseMaster licenseMaster = getLicenseDataByColumn(row.cellIterator());
-							if (licenseMaster != null)
+							if (licenseMaster != null) {
 								licenseMasterList.add(licenseMaster);
+							}
 						}
 					}
 				} catch (IOException e) {
@@ -2966,8 +2973,9 @@ public class ExcelUtil extends CoTopComponent {
 						} else {
 							//licenseMaster Object
 							LicenseMaster licenseMaster = getLicenseDataByColumn(row.cellIterator());
-							if (licenseMaster != null)
+							if (licenseMaster != null) {
 								licenseMasterList.add(licenseMaster);
+							}
 						}
 					}
 				} catch (IOException e) {
@@ -2998,39 +3006,59 @@ public class ExcelUtil extends CoTopComponent {
 					licenseMaster.setLicenseName(value);
 				}
 			} else if (colIndex == 1) {
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				licenseMaster.setLicenseType(value);
 			} else if (colIndex == 2) {
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				licenseMaster.setObligationNotificationYn(value);
 			} else if (colIndex == 3) {
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				licenseMaster.setObligationDisclosingSrcYn(value);
 			} else if (colIndex == 4) {
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				licenseMaster.setShortIdentifier(value);
 			} else if (colIndex == 5) {
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				String[] nicknames = StringUtil.delimitedStringToStringArray(value, ",");
 				licenseMaster.setLicenseNicknames(nicknames);
 			} else if (colIndex == 6) {
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				String[] webpages = StringUtil.delimitedStringToStringArray(value, ",");
 				Arrays.stream(webpages).forEach((webpage)->{
 					webpage.replaceAll("(\r\n|\r|\n|\n\r)", "");
 				});
 				licenseMaster.setWebpages(webpages);
 			} else if (colIndex == 7) { //userGuide string
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				licenseMaster.setDescription(value);
 			} else if (colIndex == 8) { //licenseText string
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				licenseMaster.setLicenseText(value);
 			} else if (colIndex == 9) { //attribute string
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				licenseMaster.setAttribution(value);
 			} else if (colIndex == 10) { //comment string
-				if (value == null || value.trim().isEmpty()) continue;
+				if (value == null || value.trim().isEmpty()) {
+					continue;
+				}
 				licenseMaster.setComment(value);
 			}
 		}

--- a/src/main/java/oss/fosslight/util/StringUtil.java
+++ b/src/main/java/oss/fosslight/util/StringUtil.java
@@ -4417,8 +4417,9 @@ public final class StringUtil {
     }
 
 	public static String convert2CamelCase(String underScore) {
-		if (underScore.indexOf('_') < 0	&& Character.isLowerCase(underScore.charAt(0)))
+		if (underScore.indexOf('_') < 0	&& Character.isLowerCase(underScore.charAt(0))) {
 			return underScore;
+		}
 
 		StringBuilder result = new StringBuilder();
 		boolean nextUpper = false;

--- a/src/main/java/oss/fosslight/validation/T2BasicValidator.java
+++ b/src/main/java/oss/fosslight/validation/T2BasicValidator.java
@@ -19,7 +19,10 @@ public abstract class T2BasicValidator extends T2CoValidator{
     }
     
     protected String treatment(String paramvalue){
-        if(paramvalue == null) return null;
+        if(paramvalue == null) {
+          return null;
+        }
+
         return paramvalue;
     }
     

--- a/src/main/java/oss/fosslight/validation/T2CoValidationResult.java
+++ b/src/main/java/oss/fosslight/validation/T2CoValidationResult.java
@@ -83,12 +83,14 @@ public class T2CoValidationResult {
     }
     
     void validate(String key){
-        if(dataMap == null) throw new IllegalStateException("no dataMap");
+        if (dataMap == null) {
+          throw new IllegalStateException("no dataMap");
+        }
         
-        if(dataMap.containsKey(key)){
-            validDataMap.put(key, dataMap.get(key));
-        }else{
-            throw new IllegalArgumentException("invalid key. Entry not found in dataMap.");
+        if (dataMap.containsKey(key)) {
+          validDataMap.put(key, dataMap.get(key));
+        } else {
+          throw new IllegalArgumentException("invalid key. Entry not found in dataMap.");
         }
     }
     
@@ -101,7 +103,9 @@ public class T2CoValidationResult {
     }
     
     public boolean isValid(){
-        if(errMap == null) throw new IllegalStateException("Not validated yet.");
+        if (errMap == null) {
+          throw new IllegalStateException("Not validated yet.");
+        }
         
         return errMap.isEmpty();
     }

--- a/src/main/java/oss/fosslight/validation/custom/T2CoOssValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoOssValidator.java
@@ -492,12 +492,14 @@ public class T2CoOssValidator extends T2CoValidator {
 		String gridKey = StringUtil.convertToCamelCase(basicKey);
 		String errCd = checkBasicError(basicKey, gridKey, ossBean.getOssName(), false);
 
-		if(!isEmpty(errCd))
-			errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), errCd);
-		else if(ossService.checkExistsOssNickname2(ossBean) != null)
-			errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), "OSS_NAME.DUPLICATEDNICK_SHORT");
-		else if(ossService.checkExistsOssByname(ossBean) == 0)
-			errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), "OSS_NAME.UNCONFIRMED");
+		if (!isEmpty(errCd)) {
+			errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""), errCd);
+		} else if(ossService.checkExistsOssNickname2(ossBean) != null) {
+			errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""),
+					"OSS_NAME.DUPLICATEDNICK_SHORT");
+		} else if(ossService.checkExistsOssByname(ossBean) == 0) {
+			errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""), "OSS_NAME.UNCONFIRMED");
+		}
 
 		/** OSS_NICKNAME */
 		basicKey = "OSS_NICKNAMES";
@@ -518,9 +520,9 @@ public class T2CoOssValidator extends T2CoValidator {
 		basicKey = "DECLARED_LICENSES";
 		gridKey = StringUtil.convertToCamelCase(basicKey);
 
-		if(Objects.isNull(ossBean.getDeclaredLicenses()) || ossBean.getDeclaredLicenses().isEmpty())
-			errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), "LICENSE_NAME.REQUIRED");
-		else {
+		if (Objects.isNull(ossBean.getDeclaredLicenses()) || ossBean.getDeclaredLicenses().isEmpty()) {
+			errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""), "LICENSE_NAME.REQUIRED");
+		} else {
 			for(String license : ossBean.getDeclaredLicenses()) {
 				errCd = checkBasicError(basicKey, gridKey, license, false);
 


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>
#777 

## Description

It is generally considered a best practice to use curly braces with if statements, even when the body of the if statement consists of only a single statement. This helps to avoid mistakes and makes the code easier to read and understand.

I found if statements without curly braces in the project through the following command:

```bash
$ find . -name '*.java' | xargs egrep '^\s*if[^\{]*\s*$' --no-filename
```

There are 311 if statements without curly braces, as calculated by the `wc -l` command, and 106 of them were actually corrected.

## References

- [새로 입사한 개발자가 프로젝트에 기여하는 방법 한 가지 - 컬리 기술 블로그](https://helloworld.kurly.com/blog/fix-style-with-command/)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
