### PR TITLE
Add space after if and for, while statements

### DIFF
--- a/src/main/java/oss/fosslight/CoTopComponent.java
+++ b/src/main/java/oss/fosslight/CoTopComponent.java
@@ -92,7 +92,7 @@ public class CoTopComponent {
 	}
     
     public static Boolean isEmptyWithLineSeparator(String s) {
-    	if(s != null) {
+    	if (s != null) {
     		s = s.replaceAll(System.lineSeparator(), "");
     	}
     	
@@ -130,7 +130,7 @@ public class CoTopComponent {
     	try {
 	    	Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) SecurityContextHolder.getContext().getAuthentication().getAuthorities();
 	    	
-	    	if(!authorities.isEmpty()) {
+	    	if (!authorities.isEmpty()) {
 	    		for (GrantedAuthority authority : authorities) {
 	    			result = (authority.getAuthority()).replaceFirst(AppConstBean.SECURITY_ROLE_PREFIX, "");
 	    			
@@ -144,11 +144,11 @@ public class CoTopComponent {
     
     protected static String userRole(T2Users userInfo) {
     	String result = "anonymousUser";
-    	if(!isEmpty(userInfo.getAuthority())) {
+    	if (!isEmpty(userInfo.getAuthority())) {
     		return userInfo.getAuthority();
     	}
     	List<T2Authorities> authList = userInfo.getAuthoritiesList();
-    	if(authList != null && !authList.isEmpty()) {
+    	if (authList != null && !authList.isEmpty()) {
     		result = authList.get(0).getAuthority();
     	}
     	return result;
@@ -221,23 +221,23 @@ public class CoTopComponent {
 		Map<String, Object> resultMap = new HashMap<>();
 		resultMap.put("isValid", isValid ? "true" : "false");
 		
-		if(!isEmpty(alertMsg)) {
+		if (!isEmpty(alertMsg)) {
 			resultMap.put("validMsg", alertMsg);
 		}
 		
-		if(obj != null) {
+		if (obj != null) {
 			resultMap.put("resultData", obj);
 		}
 		
-		if(extObj != null) {
+		if (extObj != null) {
 			resultMap.put("externalData", extObj);
 		}
 		
-		if(extObj2 != null){
+		if (extObj2 != null){
 			resultMap.put("externalData2", extObj2);
 		}
 		
-		if(extObj3 != null) {
+		if (extObj3 != null) {
 			resultMap.put("externalData3", extObj3);
 		}
 		
@@ -271,15 +271,15 @@ public class CoTopComponent {
 	protected T2CoValidationResult validate(HttpServletRequest req, String ignore, String hint, String appendixKey, Object appendixObj) {
 		T2CoAdminValidator validator = new T2CoAdminValidator();
 		
-		if(!isEmpty(ignore)) {
+		if (!isEmpty(ignore)) {
 			validator.setIgnore(ignore);
 		}
 		
-		if(!isEmpty(hint)) {
+		if (!isEmpty(hint)) {
 			validator.setHint(hint);
 		}
 		
-		if(!isEmpty(appendixKey) && appendixObj != null) {
+		if (!isEmpty(appendixKey) && appendixObj != null) {
 			validator.setAppendix(appendixKey, appendixObj);
 		}
 		
@@ -324,7 +324,7 @@ public class CoTopComponent {
 	    
 	    HttpHeaders responseHeaders = new HttpHeaders();
 	    
-	    if(!isEmpty(contentType)) {
+	    if (!isEmpty(contentType)) {
 	    	responseHeaders.add(HttpHeaders.CONTENT_TYPE, contentType);
 	    }
 	    
@@ -371,10 +371,10 @@ public class CoTopComponent {
 	public static boolean putSessionObject(String key, Object obj) {
 		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
 		
-		if(request != null) {
+		if (request != null) {
 			HttpSession session = request.getSession();
 			
-			if(session != null) {
+			if (session != null) {
 				session.setAttribute(key, obj);
 				
 				return true;
@@ -395,13 +395,13 @@ public class CoTopComponent {
 	public static Object getSessionObject(String key, boolean oneTimeFlag) {
 		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
 		
-		if(request != null) {
+		if (request != null) {
 			HttpSession session = request.getSession();
 			
-			if(session != null) {
+			if (session != null) {
 				Object sessionObj = session.getAttribute(key);
 				
-				if(oneTimeFlag) {
+				if (oneTimeFlag) {
 					try {
 						session.removeAttribute(key);
 					} catch (Exception e) {
@@ -420,10 +420,10 @@ public class CoTopComponent {
 		try {
 			HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
 			
-			if(request != null) {
+			if (request != null) {
 				HttpSession session = request.getSession();
 				
-				if(session != null) {
+				if (session != null) {
 					session.removeAttribute(key);
 				}
 			}			

--- a/src/main/java/oss/fosslight/FOSSLightApplication.java
+++ b/src/main/java/oss/fosslight/FOSSLightApplication.java
@@ -40,13 +40,13 @@ public class FOSSLightApplication implements CommandLineRunner  {
 	public void run(String... args) throws Exception {
 		boolean checkFlag = false;
 		
-		if(env.containsProperty("secret.key")) {
+		if (env.containsProperty("secret.key")) {
 			List<String> argsList = Arrays.asList(args)
 											.stream()
 											.filter(c -> c.indexOf("secretKey") > -1)
 											.collect(Collectors.toList());
 			
-			if(argsList != null && argsList.size() > 0) {
+			if (argsList != null && argsList.size() > 0) {
 				String checkSecretKey = String.join("", argsList).split("=")[1];
 				String secretKey = env.getProperty("secret.key");
 				

--- a/src/main/java/oss/fosslight/api/aop/ApiControllerAspect.java
+++ b/src/main/java/oss/fosslight/api/aop/ApiControllerAspect.java
@@ -87,7 +87,7 @@ public class ApiControllerAspect {
 	
 	private String paramMapToString(Map<String, String[]> paramMap) {
 
-		if(CoConstDef.FLAG_YES.equals(convertParamJson)) {
+		if (CoConstDef.FLAG_YES.equals(convertParamJson)) {
 			JSONObject jsonObject = new JSONObject();
 			List<String> ignoreParamList = new ArrayList<>();
 			

--- a/src/main/java/oss/fosslight/api/controller/v1/ApiBatController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiBatController.java
@@ -65,7 +65,7 @@ public class ApiBatController extends CoTopComponent {
 		Map<String, Object> paramMap = new HashMap<String, Object>();
 		
 		// 전부 null이면 parameter error return
-		if(!isEmpty(fileName) 
+		if (!isEmpty(fileName) 
 				|| !isEmpty(tlsh) 
 				|| !isEmpty(checksum)) {
 			paramMap.put("fileName", 		fileName);
@@ -77,7 +77,7 @@ public class ApiBatController extends CoTopComponent {
 			
 			List<Map<String, Object>> contents = apibatService.getBatList(paramMap);
 			
-			if(contents != null) {
+			if (contents != null) {
 				resultMap.put("content", contents);
 			}
 			

--- a/src/main/java/oss/fosslight/api/controller/v1/ApiCodeController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiCodeController.java
@@ -60,7 +60,7 @@ public class ApiCodeController extends CoTopComponent {
 		try {
 			List<Map<String, Object>> contents = apiCodeService.getCodeList(codeType, detailValue);
 			
-			if(contents.size() > 0) {
+			if (contents.size() > 0) {
 				result.put("content", contents);
 			}
 			

--- a/src/main/java/oss/fosslight/api/controller/v1/ApiOssController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiOssController.java
@@ -64,7 +64,7 @@ public class ApiOssController extends CoTopComponent {
 			paramMap.put("ossVersion", ossVersion);
 			List<Map<String, Object>> content = apiOssService.getOssInfo(paramMap);
 			
-			if(content.size() > 0) {
+			if (content.size() > 0) {
 				resultMap.put("content", content);
 			}
 			
@@ -91,7 +91,7 @@ public class ApiOssController extends CoTopComponent {
 		try {
 			List<Map<String, Object>> content = apiOssService.getOssInfoByDownloadLocation(downloadLocation);
 			
-			if(content.size() > 0) {
+			if (content.size() > 0) {
 				resultMap.put("content", content);
 			}
 			
@@ -119,7 +119,7 @@ public class ApiOssController extends CoTopComponent {
 			List<Map<String, Object>> content = apiOssService.getLicenseInfo(licenseName);
 		
 			
-			if(content.size() > 0) {
+			if (content.size() > 0) {
 				resultMap.put("content", content);
 			}
 			

--- a/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
@@ -277,20 +277,20 @@ public class ApiProjectController extends CoTopComponent {
 		Map<String, Object> result = new HashMap<String, Object>();
 		
 		try {
-			if(CoConstDef.CD_OPEN_API_CREATE_PROJECT_LIMIT > createCnt) {
+			if (CoConstDef.CD_OPEN_API_CREATE_PROJECT_LIMIT > createCnt) {
 				Map<String, Object> paramMap = new HashMap<String, Object>();
 				
 				String osTypeStr = CoCodeManager.getCodeString(CoConstDef.CD_OS_TYPE, osType);
 				
-				if(isEmpty(osTypeStr)) {
+				if (isEmpty(osTypeStr)) {
 					return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
 							, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
 				}
 				
-				if(!isEmpty(distributionType)) {
+				if (!isEmpty(distributionType)) {
 					String distributionTypeStr = CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, distributionType);
 					
-					if(isEmpty(distributionTypeStr)) {
+					if (isEmpty(distributionTypeStr)) {
 						return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
 								, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
 					}
@@ -298,10 +298,10 @@ public class ApiProjectController extends CoTopComponent {
 					distributionType = CoConstDef.CD_DTL_NOTICE_TYPE_GENERAL;
 				}
 				
-				if(!isEmpty(distributionSite)) {
+				if (!isEmpty(distributionSite)) {
 					String distributionSiteStr = CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTE_CODE, distributionSite);
 					
-					if(isEmpty(distributionSiteStr)) {
+					if (isEmpty(distributionSiteStr)) {
 						return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
 								, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
 					}
@@ -310,8 +310,8 @@ public class ApiProjectController extends CoTopComponent {
 				}
 				
 				
-				if(!isEmpty(networkServerType)) {
-					if(!CoConstDef.FLAG_YES.equals(networkServerType) 
+				if (!isEmpty(networkServerType)) {
+					if (!CoConstDef.FLAG_YES.equals(networkServerType) 
 							&& !CoConstDef.FLAG_NO.equals(networkServerType)) { // NETWORK Service Only는 Y / N만 선택 가능함.
 						return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
 								, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
@@ -320,47 +320,47 @@ public class ApiProjectController extends CoTopComponent {
 					networkServerType = CoConstDef.FLAG_NO;
 				} 
 				
-				if(isEmpty(noticeType)) {
-					if(!isEmpty(noticeTypeEtc)) {
+				if (isEmpty(noticeType)) {
+					if (!isEmpty(noticeTypeEtc)) {
 						String noticeTypeEtcStr = CoCodeManager.getCodeString(CoConstDef.CD_PLATFORM_GENERATED, noticeTypeEtc);
 						
-						if(!isEmpty(noticeTypeEtcStr)) {
+						if (!isEmpty(noticeTypeEtcStr)) {
 							noticeType = CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED;
-						} else if(isEmpty(noticeTypeEtcStr)) {
+						} else if (isEmpty(noticeTypeEtcStr)) {
 							return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
 									, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
 						}
 					} else {
 						noticeType = CoConstDef.CD_DTL_NOTICE_TYPE_GENERAL;
 					}
-				} else if(!isEmpty(noticeType)) {
+				} else if (!isEmpty(noticeType)) {
 					String noticeTypeStr = CoCodeManager.getCodeString(CoConstDef.CD_NOTICE_TYPE, noticeType);
 					
-					if(isEmpty(noticeTypeStr)) {
+					if (isEmpty(noticeTypeStr)) {
 						return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
 								, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
 					}
 				}
 				
-				if(!CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(noticeType)) {
+				if (!CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(noticeType)) {
 					noticeTypeEtc = "";
-				} else if(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(noticeType) && isEmpty(noticeTypeEtc)) {
+				} else if (CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(noticeType) && isEmpty(noticeTypeEtc)) {
 					noticeTypeEtc = CoConstDef.CD_DTL_DEFAULT_PLATFORM;
-				} else if(!isEmpty(noticeTypeEtc)) {
+				} else if (!isEmpty(noticeTypeEtc)) {
 					String noticeTypeEtcStr = CoCodeManager.getCodeString(CoConstDef.CD_PLATFORM_GENERATED, noticeTypeEtc);
 					
-					if(!isEmpty(noticeTypeEtcStr)) {
+					if (!isEmpty(noticeTypeEtcStr)) {
 						noticeTypeEtc = noticeTypeEtcStr;
-					} else if(isEmpty(noticeTypeEtcStr)) {
+					} else if (isEmpty(noticeTypeEtcStr)) {
 						return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
 								, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
 					}
 				}
 				
-				if(!isEmpty(priority)) {
+				if (!isEmpty(priority)) {
 					String priorityStr = CoCodeManager.getCodeString(CoConstDef.CD_PROJECT_PRIORITY, priority);
 					
-					if(isEmpty(priorityStr)) {
+					if (isEmpty(priorityStr)) {
 						return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE
 								, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
 					}
@@ -389,7 +389,7 @@ public class ApiProjectController extends CoTopComponent {
 				
 				int resultCnt = apiProjectService.makeOssNotice(noticeParamMap);
 				
-				if(!isEmpty(resultPrjId) && resultCnt > 0) {
+				if (!isEmpty(resultPrjId) && resultCnt > 0) {
 					try {
 						History h = new History();
 						Project project = new Project();
@@ -403,7 +403,7 @@ public class ApiProjectController extends CoTopComponent {
 						log.error(e.getMessage(), e);
 					}
 					
-					if(comment != null) {
+					if (comment != null) {
 						CommentsHistory commentHisBean = new CommentsHistory();
 						commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PROJECT_USER);
 						commentHisBean.setReferenceId(resultPrjId);
@@ -467,8 +467,8 @@ public class ApiProjectController extends CoTopComponent {
 			
 			boolean searchFlag = apiProjectService.existProjectCnt(paramMap);
 			
-			if(searchFlag) {
-				if("Y".equals(mergeSaveFlag)) {
+			if (searchFlag) {
+				if ("Y".equals(mergeSaveFlag)) {
 					apiProjectService.registBom(prjId, mergeSaveFlag);
 				}
 				downloadId = ExcelDownLoadUtil.getExcelDownloadId("bom", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
@@ -506,7 +506,7 @@ public class ApiProjectController extends CoTopComponent {
 
 			boolean searchFlag = apiProjectService.existProjectCnt(paramMap);
 
-			if(searchFlag) {
+			if (searchFlag) {
 				resultMap = apiProjectService.getBomExportJson(prjId);
 			}
 			return responseService.getSingleResult(resultMap);
@@ -533,7 +533,7 @@ public class ApiProjectController extends CoTopComponent {
 			
 			Map<String, Object> paramMap = new HashMap<>();
 		
-			if(!isEmpty(beforePrjId) && beforePrjId.equals(afterPrjId)) {
+			if (!isEmpty(beforePrjId) && beforePrjId.equals(afterPrjId)) {
 				paramMap.put("status", "same");
 				resultMap.put("contents", paramMap);
 				return responseService.getSingleResult(resultMap);
@@ -549,11 +549,11 @@ public class ApiProjectController extends CoTopComponent {
 			
 			int records = apiProjectService.existProjectCntBomCompare(paramMap);
 			
-			if(records > 0) {
+			if (records > 0) {
 				List<Map<String, Object>> beforeBomList = apiProjectService.getBomList(beforePrjId);
 				List<Map<String, Object>> afterBomList = apiProjectService.getBomList(afterPrjId);
 				
-				if(beforeBomList == null 
+				if (beforeBomList == null 
 						|| afterBomList == null) { // before, after값 중 하나라도 null이 있으면 비교 불가함.
 					throw new Exception();
 				}
@@ -600,13 +600,13 @@ public class ApiProjectController extends CoTopComponent {
 			paramMap.put("distributionType", "normal");
 			
 			boolean searchFlag = apiProjectService.existProjectCnt(paramMap); // 조회가 안된다면 권한이 없는 project id를 입력함.
-			if(searchFlag) {
-				if(ossReport != null) {
-					if(ossReport.getOriginalFilename().contains("xls") // 확장자 xls, xlsx, xlsm 허용
+			if (searchFlag) {
+				if (ossReport != null) {
+					if (ossReport.getOriginalFilename().contains("xls") // 확장자 xls, xlsx, xlsm 허용
 							&& CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT > ossReport.getSize()) { // file size 5MB 이하만 허용.
 						
 						boolean checkDistributionTypeFlag = apiProjectService.checkDistributionType(paramMap); // 잘못된  project에 oss report를 upload하려고 할 경우 ex) src -> bin Android
-						if(!checkDistributionTypeFlag) {
+						if (!checkDistributionTypeFlag) {
 							return responseService.getFailResult(CoConstDef.CD_OPEN_API_UPLOAD_TARGET_ERROR_MESSAGE
 									, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UPLOAD_TARGET_ERROR_MESSAGE));
 						}
@@ -628,7 +628,7 @@ public class ApiProjectController extends CoTopComponent {
 						List<ProjectIdentification> ossComponents = (List<ProjectIdentification>) result.get("ossComponents");
 						List<List<ProjectIdentification>> ossComponentsLicense = (List<List<ProjectIdentification>>) result.get("ossComponentLicense");
 						
-						if(!isEmpty(errorMsg)) {
+						if (!isEmpty(errorMsg)) {
 							resultMap.put("errorMessage", errorMsg);
 						}
 						
@@ -667,7 +667,7 @@ public class ApiProjectController extends CoTopComponent {
 								log.error(e.getMessage(), e);
 							}
 							
-							if(comment != null) {
+							if (comment != null) {
 								CommentsHistory commentHisBean = new CommentsHistory();
 								commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
 								commentHisBean.setReferenceId(prjId);
@@ -743,7 +743,7 @@ public class ApiProjectController extends CoTopComponent {
 			
 			boolean searchFlag = apiProjectService.existProjectCnt(paramMap); // 조회가 안된다면 권한이 없는 project id를 입력함.
 			
-			if(searchFlag) {
+			if (searchFlag) {
 				List<ProjectIdentification> ossComponents = new ArrayList<>();
 				List<List<ProjectIdentification>> ossComponentsLicense = null;
 				String changeExclude = "";
@@ -752,17 +752,17 @@ public class ApiProjectController extends CoTopComponent {
 				UploadFile ossReportBean = null;
 				UploadFile binartTxtBean = null;
 				
-				if(ossReport != null) {
-					if(!ossReport.getOriginalFilename().contains("xls")) { // 확장자 xls, xlsx, xlsm 허용
+				if (ossReport != null) {
+					if (!ossReport.getOriginalFilename().contains("xls")) { // 확장자 xls, xlsx, xlsm 허용
 						return responseService.getFailResult(CoConstDef.CD_OPEN_API_EXT_UNSUPPORT_MESSAGE
 								, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_EXT_UNSUPPORT_MESSAGE));
-					} else if(CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT <= ossReport.getSize()) { // file size 5MB 이하만 허용.
+					} else if (CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT <= ossReport.getSize()) { // file size 5MB 이하만 허용.
 						return responseService.getFailResult(CoConstDef.CD_OPEN_API_FILE_SIZEOVER_MESSAGE
 								, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_FILE_SIZEOVER_MESSAGE));
 					} else {
 						
 						boolean checkDistributionTypeFlag = apiProjectService.checkDistributionType(paramMap); // 잘못된  project에 oss report를 upload하려고 할 경우 ex) bin -> bin Android 
-						if(!checkDistributionTypeFlag) {
+						if (!checkDistributionTypeFlag) {
 							return responseService.getFailResult(CoConstDef.CD_OPEN_API_UPLOAD_TARGET_ERROR_MESSAGE
 									, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UPLOAD_TARGET_ERROR_MESSAGE));
 						}
@@ -775,7 +775,7 @@ public class ApiProjectController extends CoTopComponent {
 						ossComponents = (ossComponents != null ? ossComponents : new ArrayList<>()); 
 						ossComponentsLicense = (List<List<ProjectIdentification>>) result.get("ossComponentLicense");
 						
-						if(!isEmpty(errorMsg)) {
+						if (!isEmpty(errorMsg)) {
 							resultMap.put("errorMessage", errorMsg);
 						}
 						
@@ -783,24 +783,24 @@ public class ApiProjectController extends CoTopComponent {
 					}
 				}
 				
-				if(binartTxt != null) {
-						if(binartTxt.getOriginalFilename().contains("txt")) {
+				if (binartTxt != null) {
+						if (binartTxt.getOriginalFilename().contains("txt")) {
 						binartTxtBean = apiFileService.uploadFile(binartTxt); // file 등록 처리 이후 upload된 file정보를 return함.
 						String binaryFileId = binartTxtBean.getRegistFileId();
 						List<String> binaryTxtList = CommonFunction.getBinaryListBinBinaryTxt(fileService.selectFileInfoById(binaryFileId));
 						
-						if(binaryTxtList != null && !binaryTxtList.isEmpty()) {
+						if (binaryTxtList != null && !binaryTxtList.isEmpty()) {
 							// 현재 osslist의 binary 목록을 격납
 							Map<String, ProjectIdentification> componentBinaryList = new HashMap<>();
-							for(ProjectIdentification bean : ossComponents) {
-								if(bean != null && !isEmpty(bean.getBinaryName())) {
+							for (ProjectIdentification bean : ossComponents) {
+								if (bean != null && !isEmpty(bean.getBinaryName())) {
 									componentBinaryList.put(bean.getBinaryName(), bean);
 								}
 							}
 							List<ProjectIdentification> addComponentList = Lists.newArrayList();
 							// 존재여부 확인
-							for(String binaryNameTxt : binaryTxtList) {
-								if(!componentBinaryList.containsKey(binaryNameTxt)) {
+							for (String binaryNameTxt : binaryTxtList) {
+								if (!componentBinaryList.containsKey(binaryNameTxt)) {
 									// add 해야할 list
 									ProjectIdentification bean = new ProjectIdentification();
 									// 화면에서 추가한 것 처럼 jqg로 시작하는 component id를 임시로 설정한다.
@@ -813,12 +813,12 @@ public class ApiProjectController extends CoTopComponent {
 								// exclude처리된 경우
 								else {
 									ProjectIdentification bean = componentBinaryList.get(binaryNameTxt);
-									if(bean != null && CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+									if (bean != null && CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 										changeExclude += "<br>" + binaryNameTxt;
 									}
 								}
 							}
-							if(addComponentList != null && !addComponentList.isEmpty()) {
+							if (addComponentList != null && !addComponentList.isEmpty()) {
 								ossComponents.addAll(addComponentList);
 							}
 						}
@@ -830,7 +830,7 @@ public class ApiProjectController extends CoTopComponent {
 					}
 				}
 				
-				if(ossReportBean == null 
+				if (ossReportBean == null 
 						&& binartTxtBean == null) {
 					return responseService.getFailResult(CoConstDef.CD_OPEN_API_FILE_NOTEXISTS_MESSAGE
 							, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_FILE_NOTEXISTS_MESSAGE));
@@ -854,12 +854,12 @@ public class ApiProjectController extends CoTopComponent {
 						if (!isEmpty(changeExclude) || !isEmpty(changeAdded)) {
 							String changedByResultTxt = "";
 							
-							if(!isEmpty(changeAdded)) {
+							if (!isEmpty(changeAdded)) {
 								changedByResultTxt += "<b>The following binaries were added to OSS List automatically because they exist in the binary.txt.</b><br>";
 								changedByResultTxt += changeAdded;
 							}
-							if(!isEmpty(changeExclude)) {
-								if(!isEmpty(changedByResultTxt)) {
+							if (!isEmpty(changeExclude)) {
+								if (!isEmpty(changedByResultTxt)) {
 									changedByResultTxt += "<br><br>";
 								}
 								changedByResultTxt += "<b>The following binaries are written to the OSS report as excluded, but they are in the binary.txt. Make sure it is not included in the final firmware.</b><br>";
@@ -916,9 +916,9 @@ public class ApiProjectController extends CoTopComponent {
 						}
 						
 						try {
-							if(getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, csvFileId)) != null) {
+							if (getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, csvFileId)) != null) {
 								String chagedOssVersion = (String) getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, csvFileId), true);
-								if(!isEmpty(chagedOssVersion)) {
+								if (!isEmpty(chagedOssVersion)) {
 									CommentsHistory commentHisBean = new CommentsHistory();
 									commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
 									commentHisBean.setReferenceId(prjId);
@@ -931,7 +931,7 @@ public class ApiProjectController extends CoTopComponent {
 							log.error(e.getMessage(), e);
 						}
 						
-						if(comment != null) {
+						if (comment != null) {
 							CommentsHistory commentHisBean = new CommentsHistory();
 							commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
 							commentHisBean.setReferenceId(prjId);
@@ -1000,16 +1000,16 @@ public class ApiProjectController extends CoTopComponent {
 			boolean searchFlag = apiProjectService.existProjectCnt(paramMap); // 조회가 안된다면 권한이 없는 project id를 입력함.
 			UploadFile ossReportBean = null;
 			
-			if(searchFlag) {
-				if(!ossReport.getOriginalFilename().contains("xls")){ // 확장자 xls, xlsx, xlsm 허용
+			if (searchFlag) {
+				if (!ossReport.getOriginalFilename().contains("xls")){ // 확장자 xls, xlsx, xlsm 허용
 					return responseService.getFailResult(CoConstDef.CD_OPEN_API_EXT_UNSUPPORT_MESSAGE
 							, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_EXT_UNSUPPORT_MESSAGE));
-				} else if(CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT <= ossReport.getSize()) { // file size 5MB 이하만 허용.
+				} else if (CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT <= ossReport.getSize()) { // file size 5MB 이하만 허용.
 					return responseService.getFailResult(CoConstDef.CD_OPEN_API_FILE_SIZEOVER_MESSAGE
 							, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_FILE_SIZEOVER_MESSAGE));
 				} else {
 					boolean checkDistributionTypeFlag = apiProjectService.checkDistributionType(paramMap); // 잘못된  project에 oss report를 upload하려고 할 경우 ex) bin Android -> bin 
-					if(!checkDistributionTypeFlag) {
+					if (!checkDistributionTypeFlag) {
 						return responseService.getFailResult(CoConstDef.CD_OPEN_API_UPLOAD_TARGET_ERROR_MESSAGE
 								, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UPLOAD_TARGET_ERROR_MESSAGE));
 					}
@@ -1030,12 +1030,12 @@ public class ApiProjectController extends CoTopComponent {
 				
 				UploadFile noticeHtmlBean = null;
 				UploadFile noticeXMLBean = null;
-				if(count == 1) {
+				if (count == 1) {
 					Map<String, UploadFile> Files = apiFileService.uploadNoticeXMLFile(noticeHtml, prjId);
 					
 					noticeHtmlBean = Files.get("noticeHTML");
 					noticeXMLBean = Files.get("noticeXML");
-				}else if(count == 0) {
+				}else if (count == 0) {
 					noticeHtmlBean = apiFileService.uploadFile(noticeHtml); // noticeHtml 등록
 				} else {
 					noticeHtmlBean = null;
@@ -1043,7 +1043,7 @@ public class ApiProjectController extends CoTopComponent {
 				
 				UploadFile resultTxtBean = null;
 				
-				if(resultTxt != null) {
+				if (resultTxt != null) {
 					resultTxtBean = apiFileService.uploadFile(resultTxt); // resultTxt 등록
 				}
 				
@@ -1052,7 +1052,7 @@ public class ApiProjectController extends CoTopComponent {
 				List<ProjectIdentification> ossComponents = (List<ProjectIdentification>) result.get("ossComponents");
 				List<List<ProjectIdentification>> ossComponentsLicense = (List<List<ProjectIdentification>>) result.get("ossComponentLicense");
 				
-				if(ossReportBean == null 
+				if (ossReportBean == null 
 						&& noticeHtmlBean == null
 						&& resultTxtBean == null) {
 					return responseService.getFailResult(CoConstDef.CD_OPEN_API_FILE_NOTEXISTS_MESSAGE
@@ -1140,9 +1140,9 @@ public class ApiProjectController extends CoTopComponent {
 						}
 						
 						try {
-							if(getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, csvFileId)) != null) {
+							if (getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, csvFileId)) != null) {
 								String chagedOssVersion = (String) getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, csvFileId), true);
-								if(!isEmpty(chagedOssVersion)) {
+								if (!isEmpty(chagedOssVersion)) {
 									CommentsHistory commentHisBean = new CommentsHistory();
 									commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
 									commentHisBean.setReferenceId(prjId);
@@ -1155,7 +1155,7 @@ public class ApiProjectController extends CoTopComponent {
 							log.error(e.getMessage(), e);
 						}
 						
-						if(comment != null) {
+						if (comment != null) {
 							CommentsHistory commentHisBean = new CommentsHistory();
 							commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
 							commentHisBean.setReferenceId(prjId);
@@ -1222,12 +1222,12 @@ public class ApiProjectController extends CoTopComponent {
 		String afterFileSeq = "";
 		boolean uploadFlag = false;
 		
-		if(searchFlag) {
+		if (searchFlag) {
 			Map<String, Object> result = apiProjectService.selectVerificationCheck(prjId);
 			String useYn = (String) result.get("useYn");
 			String packageFileSeq = (String) result.get("packageFileSeq").toString();
 						
-			if(CoConstDef.CD_OPEN_API_PACKAGE_FILE_LIMIT < Integer.parseInt(packageFileSeq)) {
+			if (CoConstDef.CD_OPEN_API_PACKAGE_FILE_LIMIT < Integer.parseInt(packageFileSeq)) {
 				return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE, "Up to 3 packaging files can be uploaded.");
 			}
 			
@@ -1235,7 +1235,7 @@ public class ApiProjectController extends CoTopComponent {
 			UploadFile packageFileBean = apiFileService.uploadFile(packageFile, filePath); // packagingFile 등록
 			afterFileSeq = packageFileBean.getRegistSeq();
 			
-			if(CoConstDef.FLAG_YES.equals(useYn) && CoConstDef.CD_OPEN_API_PACKAGE_FILE_LIMIT >= Integer.parseInt(packageFileSeq)) {
+			if (CoConstDef.FLAG_YES.equals(useYn) && CoConstDef.CD_OPEN_API_PACKAGE_FILE_LIMIT >= Integer.parseInt(packageFileSeq)) {
 				// packaging File comment
 				String uploadComment = "Packaging file, "+packageFileBean.getOriginalFilename()+", was uploaded by "+userInfo.getUserId()+". <br>";
 				
@@ -1254,7 +1254,7 @@ public class ApiProjectController extends CoTopComponent {
 				errorMsg = null; // 정상적으로 처리됨.
 				uploadFlag = true;
 			} else {
-				if(!CoConstDef.FLAG_YES.equals(useYn)) {
+				if (!CoConstDef.FLAG_YES.equals(useYn)) {
 					errorMsg = "delete project"; // 삭제된 project
 				}
 			}
@@ -1327,7 +1327,7 @@ public class ApiProjectController extends CoTopComponent {
 				
 				resMap = result.get(0);
 				
-				if(fileSeqs.size() > 1){
+				if (fileSeqs.size() > 1){
 					resMap.put("verifyValid", result.get(result.size()-1).get("verifyValid"));
 					resMap.put("fileCounts", result.get(result.size()-1).get("fileCounts"));
 				}

--- a/src/main/java/oss/fosslight/api/controller/v1/ApiSelfCheckController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiSelfCheckController.java
@@ -83,7 +83,7 @@ public class ApiSelfCheckController extends CoTopComponent {
 			
 			int createCnt = apiSelfCheckService.getCreateProjectCnt(userInfo.getUserId());
 			
-			if(CoConstDef.CD_OPEN_API_CREATE_PROJECT_LIMIT > createCnt) {
+			if (CoConstDef.CD_OPEN_API_CREATE_PROJECT_LIMIT > createCnt) {
 				Map<String, Object> paramMap = new HashMap<String, Object>();
 				
 				paramMap.put("prjName", prjName);
@@ -93,7 +93,7 @@ public class ApiSelfCheckController extends CoTopComponent {
 				result = apiSelfCheckService.createSelfCheck(paramMap);
 				String prjId = (String) result.get("prjId");
 				
-				if(isEmpty(prjId)) {
+				if (isEmpty(prjId)) {
 					throw new Exception(); // parameter Error -> create Failure
 				}
 			} else {
@@ -129,9 +129,9 @@ public class ApiSelfCheckController extends CoTopComponent {
 			paramMap.put("prjId", prjId);
 			boolean searchFlag = apiSelfCheckService.existProjectCnt(paramMap); // 조회가 안된다면 권한이 없는 project id를 입력함.
 			
-			if(searchFlag) {
-				if(ossReport != null) {
-					if(ossReport.getOriginalFilename().contains("xls") // 확장자 xls, xlsx, xlsm 허용
+			if (searchFlag) {
+				if (ossReport != null) {
+					if (ossReport.getOriginalFilename().contains("xls") // 확장자 xls, xlsx, xlsm 허용
 							&& CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT > ossReport.getSize()) { // file size 5MB 이하만 허용.
 						
 						UploadFile bean = apiFileService.uploadFile(ossReport); // file 등록 처리 이후 upload된 file정보를 return함.
@@ -141,7 +141,7 @@ public class ApiSelfCheckController extends CoTopComponent {
 						List<ProjectIdentification> ossComponents = (List<ProjectIdentification>) result.get("ossComponents");
 						List<List<ProjectIdentification>> ossComponentsLicense = (List<List<ProjectIdentification>>) result.get("ossComponentLicense");
 						
-						if(!isEmpty(errorMsg)) {
+						if (!isEmpty(errorMsg)) {
 							throw new Exception(); // readData시 문제가 발생할 경우 parameter error로 return 함.
 						}
 						
@@ -152,7 +152,7 @@ public class ApiSelfCheckController extends CoTopComponent {
 						pv.setAppendix("subList", ossComponentsLicense);
 						T2CoValidationResult vr = pv.validate(new HashMap<>());
 						
-						if(!vr.isValid()) {
+						if (!vr.isValid()) {
 							return responseService.getFailResult(getMessage("api.dataValidationError.code"), getMessage("api.dataValidationError.msg")); // data validation error
 						} else {
 							Project project = new Project();

--- a/src/main/java/oss/fosslight/api/controller/v1/ApiVulnerabilityController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiVulnerabilityController.java
@@ -61,13 +61,13 @@ public class ApiVulnerabilityController extends CoTopComponent {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
 		
 		try {
-			if(isEmpty(ossVersion)) { // ossVersion을 입력하지 않을 경우 전체 검색으로 처리함.
+			if (isEmpty(ossVersion)) { // ossVersion을 입력하지 않을 경우 전체 검색으로 처리함.
 				ossVersion = "-";
 			}
 			
 			List<Map<String, Object>> content = apiVulnerabilityService.selectNvdList(ossName, ossVersion, cveId);
 			
-			if(content.size() > 0) {
+			if (content.size() > 0) {
 				resultMap.put("content", content);
 			}
 			
@@ -93,13 +93,13 @@ public class ApiVulnerabilityController extends CoTopComponent {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
 		
 		try {
-			if(isEmpty(ossVersion)) { // ossVersion을 입력하지 않을 경우 전체 검색으로 처리함.
+			if (isEmpty(ossVersion)) { // ossVersion을 입력하지 않을 경우 전체 검색으로 처리함.
 				ossVersion = "-";
 			}
 			
 			List<Map<String, Object>> content = apiVulnerabilityService.selectMaxScoreNvdInfo(ossName, ossVersion);
 			
-			if(content.size() > 0) {
+			if (content.size() > 0) {
 				resultMap.put("content", content);
 			}	
 			

--- a/src/main/java/oss/fosslight/common/CoCodeManager.java
+++ b/src/main/java/oss/fosslight/common/CoCodeManager.java
@@ -79,11 +79,11 @@ public class CoCodeManager extends CoTopComponent {
         try {
             list = codeManagerMapper.getCodeListAll();
            
-            if(list == null) {
+            if (list == null) {
                 throw new RuntimeException("SYSTEM ERR GET CODE INFO FAIL");
             }
             
-            for(CodeDtlBean vo : list) {
+            for (CodeDtlBean vo : list) {
                 String s = vo.getCdNo();
                 code = (CoCode) codes.get(s);
                 
@@ -124,26 +124,26 @@ public class CoCodeManager extends CoTopComponent {
 			Map<String, OssMaster> _ossMap = new HashMap<>();
 			Map<String, String> _ossNamesMap = new HashMap<>();
 			
-			if(nickNameList != null) {
-				for(OssMaster bean : nickNameList) {
-					if(bean.getOssNickname() != null) {
+			if (nickNameList != null) {
+				for (OssMaster bean : nickNameList) {
+					if (bean.getOssNickname() != null) {
 						nickNameMap.put(bean.getOssName(), bean.getOssNickname().split(","));
 					}
 				}
 			}
 			
-			if(list != null) {
-				for(OssMaster bean : list) {
+			if (list != null) {
+				for (OssMaster bean : list) {
 					OssMaster targetBean = null;
 					String key = bean.getOssName() +"_"+ avoidNull(bean.getOssVersion()); // oss name을 nick name으로 가져온다.
 					key = key.toUpperCase();
 					
-					if(_ossMap.containsKey(key)) {
+					if (_ossMap.containsKey(key)) {
 						targetBean = _ossMap.get(key);
 					} else {
 						targetBean = bean;
 						
-						if(nickNameMap.containsKey(targetBean.getOssNameTemp())) {
+						if (nickNameMap.containsKey(targetBean.getOssNameTemp())) {
 							targetBean.setOssNicknames(nickNameMap.get(targetBean.getOssNameTemp()));
 						}
 					}
@@ -163,35 +163,35 @@ public class CoCodeManager extends CoTopComponent {
 					
 					targetBean.addOssLicense(subBean);
 					
-					if(_ossMap.containsKey(key)) {
+					if (_ossMap.containsKey(key)) {
 						_ossMap.replace(key, targetBean);
 					} else {
 						_ossMap.put(key, targetBean);
 					}
 					
-					if(!_ossNamesMap.containsKey(bean.getOssName().toUpperCase())) {
+					if (!_ossNamesMap.containsKey(bean.getOssName().toUpperCase())) {
 						_ossNamesMap.put(bean.getOssName().toUpperCase(), bean.getOssName());
 					}
 				}
 			}
 			
 			Map<String, OssMaster> _idMasterMap = new HashMap<>();
-			for(OssMaster bean : _ossMap.values()) {
-				if(!_idMasterMap.containsKey(bean.getOssId())) {
+			for (OssMaster bean : _ossMap.values()) {
+				if (!_idMasterMap.containsKey(bean.getOssId())) {
 					_idMasterMap.put(bean.getOssId(), bean);
 				}
 			}
 			
 			OSS_INFO_BY_ID = _idMasterMap;
 			
-			if(listNick != null) {
+			if (listNick != null) {
 
-				for(OssMaster bean : listNick) {
+				for (OssMaster bean : listNick) {
 					//OssMaster targetBean = null;
 					String key = bean.getOssName() +"_"+ avoidNull(bean.getOssVersion()); // oss name을 nick name으로 가져온다.
 					String ossNickNameKey = bean.getOssName().toUpperCase();
 
-					if(!_ossNamesMap.containsKey(ossNickNameKey)) {
+					if (!_ossNamesMap.containsKey(ossNickNameKey)) {
 						_ossNamesMap.put(ossNickNameKey, bean.getOssNameTemp());
 					}
 					
@@ -222,11 +222,11 @@ public class CoCodeManager extends CoTopComponent {
 			
 			}
 			
-			if(!_ossMap.isEmpty()) {
+			if (!_ossMap.isEmpty()) {
 				OSS_INFO_UPPER = _ossMap;
 			}
 			
-			if(!_ossNamesMap.isEmpty()) {
+			if (!_ossNamesMap.isEmpty()) {
 				OSS_INFO_UPPER_NAMES = _ossNamesMap;
 			}
 		} catch(Exception e) {
@@ -243,21 +243,21 @@ public class CoCodeManager extends CoTopComponent {
             List<LicenseMaster> list = licenseMapper.getLicenseInfoInit();
             List<LicenseMaster> nickList = licenseMapper.getLicenseInfoInitNick();
             
-            if(list == null) {
+            if (list == null) {
                 throw new RuntimeException("SYSTEM ERR GET CODE LICENSE MASTER INFO");
             }
             
             Map<String, LicenseMaster> license_info_map = new HashMap<>();
             Map<String, LicenseMaster> license_info_upper_map = new HashMap<>();
             Map<String, LicenseMaster> license_info_by_id_map = new HashMap<>();
-            for(LicenseMaster vo : list) {
-            	if(!isEmpty(vo.getLicenseNicknameStr())) {
-            		for(String nick : vo.getLicenseNicknameStr().split("\\|")) {
+            for (LicenseMaster vo : list) {
+            	if (!isEmpty(vo.getLicenseNicknameStr())) {
+            		for (String nick : vo.getLicenseNicknameStr().split("\\|")) {
             			vo.addLicenseNicknameList(nick);
             		}
             	}
             	
-            	if(!isEmpty(vo.getRestriction())) {
+            	if (!isEmpty(vo.getRestriction())) {
             		vo.setRestrictionStr(CommonFunction.setLicenseRestrictionList(vo.getRestriction()));
             	}
             	
@@ -265,12 +265,12 @@ public class CoCodeManager extends CoTopComponent {
             	license_info_upper_map.put(vo.getLicenseName().toUpperCase(),vo);
             	
             	//SHORT_IDENTIFIER
-            	if(!isEmpty(vo.getShortIdentifier())) {
-            		if(!license_info_map.containsKey(vo.getShortIdentifier())) {
+            	if (!isEmpty(vo.getShortIdentifier())) {
+            		if (!license_info_map.containsKey(vo.getShortIdentifier())) {
                     	license_info_map.put(vo.getShortIdentifier(),vo);
             		}
             		
-            		if(!license_info_upper_map.containsKey(vo.getShortIdentifier().toUpperCase())) {
+            		if (!license_info_upper_map.containsKey(vo.getShortIdentifier().toUpperCase())) {
             			license_info_upper_map.put(vo.getShortIdentifier().toUpperCase(), vo);
             		}
             	}
@@ -278,7 +278,7 @@ public class CoCodeManager extends CoTopComponent {
             	license_info_by_id_map.put(vo.getLicenseId(), vo);
             }
             
-            for(LicenseMaster vo : nickList) {
+            for (LicenseMaster vo : nickList) {
             	
             	LicenseMaster sourceBean = license_info_by_id_map.get(vo.getLicenseId());
             	vo.setLicenseNicknameList(sourceBean.getLicenseNicknameList());
@@ -288,15 +288,15 @@ public class CoCodeManager extends CoTopComponent {
             	license_info_upper_map.put(vo.getLicenseName().toUpperCase(),vo);
             }
             
-            if(!license_info_map.isEmpty()) {
+            if (!license_info_map.isEmpty()) {
             	LICENSE_INFO = license_info_map;
             }
             
-            if(!license_info_upper_map.isEmpty()) {
+            if (!license_info_upper_map.isEmpty()) {
             	LICENSE_INFO_UPPER = license_info_upper_map;
             }
             
-            if(!license_info_by_id_map.isEmpty()) {
+            if (!license_info_by_id_map.isEmpty()) {
             	LICENSE_INFO_BY_ID = license_info_by_id_map;
             }
 
@@ -305,21 +305,21 @@ public class CoCodeManager extends CoTopComponent {
             List<LicenseMaster> roleOutLicenseList = licenseMapper.getRoleOutLicense();
             List<String> roleOutLicenseNames = new ArrayList<>();
             List<String> roleOutLicenseIds = new ArrayList<>();
-            if(roleOutLicenseList != null) {
-            	for(LicenseMaster bean : roleOutLicenseList) {
-            		if(!roleOutLicenseNames.contains(bean.getLicenseName())) {
+            if (roleOutLicenseList != null) {
+            	for (LicenseMaster bean : roleOutLicenseList) {
+            		if (!roleOutLicenseNames.contains(bean.getLicenseName())) {
             			roleOutLicenseNames.add(bean.getLicenseName());
             		}
             		
-            		if(!roleOutLicenseIds.contains(bean.getLicenseId())) {
+            		if (!roleOutLicenseIds.contains(bean.getLicenseId())) {
             			roleOutLicenseIds.add(bean.getLicenseId());
             		}
             	}
             }
             
             String noOpensourceStr = "";
-            for(String s : roleOutLicenseNames) { 
-            	if(!isEmpty(noOpensourceStr)) {
+            for (String s : roleOutLicenseNames) { 
+            	if (!isEmpty(noOpensourceStr)) {
             		noOpensourceStr += "|";
             	}
             	
@@ -332,17 +332,17 @@ public class CoCodeManager extends CoTopComponent {
         	log.error(e.getMessage(), e);
         }
         
-        if(LICENSE_INFO_UPPER != null) {
+        if (LICENSE_INFO_UPPER != null) {
         	List<String> _licenseUserGuideList = new ArrayList<>();
         	
-        	for(String s : LICENSE_INFO_UPPER.keySet()) {
+        	for (String s : LICENSE_INFO_UPPER.keySet()) {
         		LicenseMaster _license = LICENSE_INFO_UPPER.get(s);
-        		if(_license != null && !isEmptyWithLineSeparator(_license.getDescription())) {
+        		if (_license != null && !isEmptyWithLineSeparator(_license.getDescription())) {
         			_licenseUserGuideList.add(s);
         		}
         	}
         	
-        	if(!_licenseUserGuideList.isEmpty()) {
+        	if (!_licenseUserGuideList.isEmpty()) {
         		LICENSE_USER_GUIDE_LIST = _licenseUserGuideList;
         	}
         }
@@ -355,7 +355,7 @@ public class CoCodeManager extends CoTopComponent {
 	private CoCodeManager() {}
     
     public static CoCodeManager getInstance() {
-    	if(instance == null) {
+    	if (instance == null) {
     		instance = new CoCodeManager();
     	}
     	
@@ -672,7 +672,7 @@ public class CoCodeManager extends CoTopComponent {
     public static String genCommonCheckbox(String s, String name, String val, Boolean NAExceptionFlag) {
     	CoCode code = getCodeInstance(s);
 		
-    	if(!StringUtils.isEmpty(code)) {
+    	if (!StringUtils.isEmpty(code)) {
     		return code.createCommonCheckboxString(val, name, NAExceptionFlag);
     	} else {
     		return null;
@@ -699,11 +699,11 @@ public class CoCodeManager extends CoTopComponent {
         try {
 			list = codeManagerMapper.getCodeListAll();
 			
-	        if(list == null) {
+	        if (list == null) {
 	            throw new RuntimeException("SYSTEM ERR GET CODE INFO FAIL");
 	        }
 	        
-	        for(CodeDtlBean vo : list) {
+	        for (CodeDtlBean vo : list) {
 	            String s = vo.getCdNo();
 	            code = (CoCode) hashmap.get(s);
 	            
@@ -751,16 +751,16 @@ public class CoCodeManager extends CoTopComponent {
              CoCode code = getCodeInstance(s);
              codes = code != null ? code.getCdDtlNoVector(false) : new Vector<String>();
              
-             while(i < codes.size()){
-        		 if(!("").equals(codes.get(i))){
+             while (i < codes.size()){
+        		 if (!("").equals(codes.get(i))){
         			 String temp = code != null ? code.getCdDtlExp(codes.get(i)) : "";
         			 
-        			 if(!temp.equals("")){
+        			 if (!temp.equals("")){
         				 exps.add(temp);
         				 CoCode code_ = getCodeInstance(temp);
         				 Vector<String> temps = code_ != null ? code_.getCdDtlNoVector(false) : null;
         				 
-        				 if(temps != null && temps.size() > size){
+        				 if (temps != null && temps.size() > size){
         					 size = temps.size();
         					
         					 j++;
@@ -771,7 +771,7 @@ public class CoCodeManager extends CoTopComponent {
         		 i++;
         	 }
              
-             if(size > 0){
+             if (size > 0){
             	 code = getCodeInstance(exps.get(j-1));
 				 ret = code != null ? code.getCdDtlNoVector(false) : null;
              }
@@ -783,7 +783,7 @@ public class CoCodeManager extends CoTopComponent {
     public static String getLicenseUserGuideJsonString() {
     	String jsonStr = null;
     	
-    	if(LICENSE_USER_GUIDE_LIST != null) {
+    	if (LICENSE_USER_GUIDE_LIST != null) {
             Gson gson = new Gson();
             jsonStr = gson.toJson(LICENSE_USER_GUIDE_LIST);
     	}

--- a/src/main/java/oss/fosslight/common/CommonFunction.java
+++ b/src/main/java/oss/fosslight/common/CommonFunction.java
@@ -138,11 +138,11 @@ public class CommonFunction extends CoTopComponent {
         StringBuffer ret = new StringBuffer();
         dt = dt.replaceAll("[^\\d]*", "");
         
-        if(dt.length() >= 8) {
-            if(CoConstDef.DISP_FORMAT_DATE_TAG_SIMPLE.equals(separator)) {
+        if (dt.length() >= 8) {
+            if (CoConstDef.DISP_FORMAT_DATE_TAG_SIMPLE.equals(separator)) {
                 // yyyyMMdd
                 dt = dt.substring(0, 8);
-            } else if(dt.length() >= 14) {
+            } else if (dt.length() >= 14) {
                 dt = dt.substring(0, 14);
             }
         }
@@ -176,7 +176,7 @@ public class CommonFunction extends CoTopComponent {
     }
     
     public static boolean contains(Object[] array, Object item) {
-        if(array != null) {
+        if (array != null) {
             return Arrays.asList(array).contains(item);
         }
         
@@ -185,11 +185,11 @@ public class CommonFunction extends CoTopComponent {
     
     public static String arrayToString(String[] arr, String sep) {
         String tmpStr = CoConstDef.EMPTY_STRING;
-        if(isEmpty(sep)) {
+        if (isEmpty(sep)) {
             sep = ","; // default value
         }
-        if(arr != null) {
-            for(String s : arr) {
+        if (arr != null) {
+            for (String s : arr) {
                 tmpStr += (isEmpty(tmpStr) ? "" : sep) + s.trim();
             }
         }
@@ -198,8 +198,8 @@ public class CommonFunction extends CoTopComponent {
     
     public static String arrayToStringForSql(String[] arr) {
         String tmpStr = CoConstDef.EMPTY_STRING;
-        if(arr != null) {
-            for(String s : arr) {
+        if (arr != null) {
+            for (String s : arr) {
                 tmpStr += (isEmpty(tmpStr) ? "" : ",") + "\'" + avoidNull(s) + "\'";
             }
         }
@@ -207,7 +207,7 @@ public class CommonFunction extends CoTopComponent {
     }
     
     public static String arrayToString(List<String> list) {
-    	if(list == null || list.isEmpty()) {
+    	if (list == null || list.isEmpty()) {
     		return "";
     	}
     	String[] arr = new String[list.size()];
@@ -260,7 +260,7 @@ public class CommonFunction extends CoTopComponent {
         HashMap<String, Object> resultMap = new HashMap<String, Object>();
 		
 		// 파일 null 체크
-		if(uploadFile != null && uploadFile.getSize() > 0){
+		if (uploadFile != null && uploadFile.getSize() > 0){
 			// STEP 1 : 디렉토리 구조를 정하고 디렉토리를 만든다.
 			String thisDate = DateUtil.getCurrentDateTime("yyyy-MM-dd-hh-mm-ss");
 			
@@ -315,7 +315,7 @@ public class CommonFunction extends CoTopComponent {
 		String ret = "";
 		String Hyphen = "-";
 		
-		if(s.length() == 12) {
+		if (s.length() == 12) {
 			ret += s.substring(0, 2) + Hyphen + s.substring(2, 4) + Hyphen + s.substring(4, 6) + Hyphen + s.substring(6, 8);
 			ret += Hyphen + s.substring(8, 10) + Hyphen + s.substring(10, 12);
 		}else{
@@ -336,7 +336,7 @@ public class CommonFunction extends CoTopComponent {
 		
         StringBuffer stringbuffer = new StringBuffer();
         
-        for(int k = users.size(), j = 0; j < k; j++) {
+        for (int k = users.size(), j = 0; j < k; j++) {
             T2Users user = users.get(j);
             stringbuffer.append("    <option value='").append(user.getUserId()).append('\'');
             stringbuffer.append(">").append(user.getUserName()).append("</option>\n");
@@ -352,7 +352,7 @@ public class CommonFunction extends CoTopComponent {
         String result = "";
     	try{
 	    	Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) SecurityContextHolder.getContext().getAuthentication().getAuthorities();
-	    	if(!authorities.isEmpty()){
+	    	if (!authorities.isEmpty()){
 	    		for (GrantedAuthority authority : authorities) {
 	    			result = (authority.getAuthority()).replaceFirst(AppConstBean.SECURITY_ROLE_PREFIX, "");
 	    			break;
@@ -374,7 +374,7 @@ public class CommonFunction extends CoTopComponent {
         
     	try{
 	    	Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) SecurityContextHolder.getContext().getAuthentication().getAuthorities();
-	    	if(!authorities.isEmpty()){
+	    	if (!authorities.isEmpty()){
 	    		for (GrantedAuthority authority : authorities) {
 	    			result = (authority.getAuthority()).replaceFirst(AppConstBean.SECURITY_ROLE_PREFIX, "");
 	    			break;
@@ -395,25 +395,25 @@ public class CommonFunction extends CoTopComponent {
 	
 	public static String makeLicenseExpressionIdentify(List<ProjectIdentification> list, String delimiter) {
 		
-		if(list == null || list.isEmpty()) {
+		if (list == null || list.isEmpty()) {
 			return "";
 		}
 		
 		List<OssLicense> licenseList = new ArrayList<>();
 		
 		// 필요한 정보만 재설정한다.
-		for(ProjectIdentification bean : list) {
+		for (ProjectIdentification bean : list) {
 			OssLicense license = new OssLicense();
 			license.setOssLicenseComb(bean.getOssLicenseComb());
 			license.setLicenseName(bean.getLicenseName());
 			
-			if(!CoConstDef.FLAG_YES.equals(bean.getExcludeYn())){
+			if (!CoConstDef.FLAG_YES.equals(bean.getExcludeYn())){
 				license.setLicenseName(license.getLicenseName());
 				licenseList.add(license);
 			}
 		}
 		
-		if(isEmpty(delimiter)) {
+		if (isEmpty(delimiter)) {
 			return makeLicenseExpression(licenseList);
 		}else {
 			return makeLicenseString(licenseList, delimiter);
@@ -421,13 +421,13 @@ public class CommonFunction extends CoTopComponent {
 	}
 	public static String makeLicenseString(List<OssLicense> list, String delimiter) {
 		String result = "";
-		for(OssLicense bean : list) {
-			if(!isEmpty(result)) {
+		for (OssLicense bean : list) {
+			if (!isEmpty(result)) {
 				result += delimiter;
 			}
 			
 			String licenseName = bean.getLicenseName();
-			if(CoCodeManager.LICENSE_INFO.containsKey(licenseName)) {
+			if (CoCodeManager.LICENSE_INFO.containsKey(licenseName)) {
 				licenseName = avoidNull(CoCodeManager.LICENSE_INFO.get(licenseName).getShortIdentifier(), licenseName);
 			}
 			
@@ -459,9 +459,9 @@ public class CommonFunction extends CoTopComponent {
 		List<List<String>> licenseNameList = new ArrayList<>();
 		List<String> andLicenseList = new ArrayList<>();
 		boolean isFirstLicense = true;
-		for(OssLicense bean : list) { 
-			if(!isFirstLicense && "OR".equals(bean.getOssLicenseComb())) {
-				if(!andLicenseList.isEmpty()) {
+		for (OssLicense bean : list) { 
+			if (!isFirstLicense && "OR".equals(bean.getOssLicenseComb())) {
+				if (!andLicenseList.isEmpty()) {
 					licenseNameList.add(andLicenseList);
 					andLicenseList = new ArrayList<>();
 					andLicenseList.add(bean.getLicenseName());
@@ -472,20 +472,20 @@ public class CommonFunction extends CoTopComponent {
 			isFirstLicense = false;
 		}
 		
-		if(!andLicenseList.isEmpty()) {
+		if (!andLicenseList.isEmpty()) {
 			licenseNameList.add(andLicenseList);
 		}
 		
 		// 연삭식 적용 및 Short Identifier 로 변경
-		if(!licenseNameList.isEmpty()) {
-			for(List<String> combList : licenseNameList) {
-				if(!isEmpty(rtnVal)) {
+		if (!licenseNameList.isEmpty()) {
+			for (List<String> combList : licenseNameList) {
+				if (!isEmpty(rtnVal)) {
 					rtnVal += " OR ";
 				}
 				String andStr = "";
-				for(String s : combList) {
-					if(!isEmpty(andStr)) {
-						if(msgType) { 
+				for (String s : combList) {
+					if (!isEmpty(andStr)) {
+						if (msgType) { 
 							andStr += ", ";
 						} else {
 							andStr += " AND ";
@@ -494,15 +494,15 @@ public class CommonFunction extends CoTopComponent {
 					
 					LicenseMaster licenseMaster = null;
 					
-					if(CoCodeManager.LICENSE_INFO.containsKey(s)) {
+					if (CoCodeManager.LICENSE_INFO.containsKey(s)) {
 						s = avoidNull(CoCodeManager.LICENSE_INFO.get(s).getShortIdentifier(), s);
 						licenseMaster = CoCodeManager.LICENSE_INFO.get(s);
 					}
 					
-					if(htmlLinkType && licenseMaster != null) {
+					if (htmlLinkType && licenseMaster != null) {
 						andStr += "<a href='javascript:void(0);' class='urlLink'  onclick='showLicenseText(" + licenseMaster.getLicenseId() + ");' >" + s + "</a>" ;
 					} else {
-						if(spdxConvert) {
+						if (spdxConvert) {
 							// identifier가 없는 경우 라이선스 이름을 spdx 연동 용으로 변경한다.
 							s = licenseStrToSPDXLicenseFormat(s);
 						}
@@ -518,7 +518,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	public static String licenseStrToSPDXLicenseFormat(String licenseStr) {
-		if(CoCodeManager.LICENSE_INFO.containsKey(licenseStr) && isEmpty(CoCodeManager.LICENSE_INFO.get(licenseStr).getShortIdentifier())) {
+		if (CoCodeManager.LICENSE_INFO.containsKey(licenseStr) && isEmpty(CoCodeManager.LICENSE_INFO.get(licenseStr).getShortIdentifier())) {
 			licenseStr = "LicenseRef-" + licenseStr;
 		}
 
@@ -538,19 +538,19 @@ public class CommonFunction extends CoTopComponent {
 					licenseName = licenseName.replaceAll("\\(", "-").replaceAll("\\)", "").replaceAll(" ", "-").replaceAll("--", "-");
 				}
 				
-				if(!resultList.contains(licenseName)) {
+				if (!resultList.contains(licenseName)) {
 					resultList.add(licenseName);
 				}
 			}
 
-			if(detectedLicenseList != null) {
-				for(String licenseName : detectedLicenseList) {
+			if (detectedLicenseList != null) {
+				for (String licenseName : detectedLicenseList) {
 					if (booleanflag) {
 						licenseName = avoidNull(CoCodeManager.LICENSE_INFO.get(licenseName).getShortIdentifier(), "LicenseRef-" + licenseName);
 						licenseName = licenseName.replaceAll("\\(", "-").replaceAll("\\)", "").replaceAll(" ", "-").replaceAll("--", "-");
 					}
 					
-					if(!resultList.contains(licenseName)) {
+					if (!resultList.contains(licenseName)) {
 						resultList.add(licenseName);
 					}
 				}
@@ -564,8 +564,8 @@ public class CommonFunction extends CoTopComponent {
 		// OR 조건으로 각 list로 구분한다.
 		List<List<ProjectIdentification>> andCombLicenseList = new ArrayList<>();
 		
-		for(ProjectIdentification bean : list) {
-			if(andCombLicenseList.isEmpty() || "OR".equals(bean.getOssLicenseComb())) {
+		for (ProjectIdentification bean : list) {
+			if (andCombLicenseList.isEmpty() || "OR".equals(bean.getOssLicenseComb())) {
 				andCombLicenseList.add(new ArrayList<>());
 			}
 			
@@ -582,7 +582,7 @@ public class CommonFunction extends CoTopComponent {
 		List<Integer> permissiveListCP = new ArrayList<>(); // 미사용
 		String finalPermissive = null; // or 기준 가장 permissive 한 라이선스가 무었인지
 		
-		for(List<ProjectIdentification> andList : andCombLicenseList) {
+		for (List<ProjectIdentification> andList : andCombLicenseList) {
 			// 그룹별 퍼미션 취득
 			switch (getLicensePermissive(andList)) {
 				case CoConstDef.CD_LICENSE_TYPE_PMS:
@@ -592,7 +592,7 @@ public class CommonFunction extends CoTopComponent {
 				
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_WCP:
-					if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(finalPermissive)) {
+					if (!CoConstDef.CD_LICENSE_TYPE_PMS.equals(finalPermissive)) {
 						finalPermissive = CoConstDef.CD_LICENSE_TYPE_WCP;
 						selectedIdx = idx;
 						permissiveListWCP.add(selectedIdx);
@@ -600,7 +600,7 @@ public class CommonFunction extends CoTopComponent {
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_CP:
-					if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(finalPermissive)
+					if (!CoConstDef.CD_LICENSE_TYPE_PMS.equals(finalPermissive)
 							&& !CoConstDef.CD_LICENSE_TYPE_WCP.equals(finalPermissive)) {
 						finalPermissive = CoConstDef.CD_LICENSE_TYPE_CP;
 						selectedIdx = idx;
@@ -609,7 +609,7 @@ public class CommonFunction extends CoTopComponent {
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_PF:
-					if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(finalPermissive)
+					if (!CoConstDef.CD_LICENSE_TYPE_PMS.equals(finalPermissive)
 							&& !CoConstDef.CD_LICENSE_TYPE_WCP.equals(finalPermissive)
 							&& !CoConstDef.CD_LICENSE_TYPE_CP.equals(finalPermissive)) {
 						finalPermissive = CoConstDef.CD_LICENSE_TYPE_PF;
@@ -619,7 +619,7 @@ public class CommonFunction extends CoTopComponent {
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_NA:
-					if(isEmpty(finalPermissive)) {
+					if (isEmpty(finalPermissive)) {
 						finalPermissive = CoConstDef.CD_LICENSE_TYPE_NA;
 						selectedIdx = idx;
 						permissiveListNA.add(selectedIdx);
@@ -636,10 +636,10 @@ public class CommonFunction extends CoTopComponent {
 		List<ProjectIdentification> resultList = new ArrayList<>();
 		boolean hasSelected = false;
 		
-		for(List<ProjectIdentification> andList : andCombLicenseList) {
+		for (List<ProjectIdentification> andList : andCombLicenseList) {
 			boolean _break = false;
-			for(ProjectIdentification bean : andList) {
-				if(hasSelected) {
+			for (ProjectIdentification bean : andList) {
+				if (hasSelected) {
 					bean.setExcludeYn(CoConstDef.FLAG_YES);
 				} else {
 					List<Integer> containsList = CoConstDef.CD_LICENSE_TYPE_PMS.equals(finalPermissive) ? 
@@ -649,7 +649,7 @@ public class CommonFunction extends CoTopComponent {
 													permissiveListPF : CoConstDef.CD_LICENSE_TYPE_NA.equals(finalPermissive) ? 
 															permissiveListNA : new ArrayList<>();
 
-					if(containsList.contains(idx)) {
+					if (containsList.contains(idx)) {
 						bean.setExcludeYn(CoConstDef.FLAG_NO);
 						_break = true;
 					} else {
@@ -660,7 +660,7 @@ public class CommonFunction extends CoTopComponent {
 				resultList.add(bean);
 			}
 			
-			if(_break) {
+			if (_break) {
 				hasSelected = true;
 			}
 			
@@ -673,7 +673,7 @@ public class CommonFunction extends CoTopComponent {
 	private static String getLicensePermissive(List<ProjectIdentification> andList) {
 		String rtnVal = "";
 		
-		for(ProjectIdentification bean : andList) {
+		for (ProjectIdentification bean : andList) {
 			// 가장 Strong한 라이선스부터 case
 			switch (bean.getLicenseType()) {
 				case CoConstDef.CD_LICENSE_TYPE_NA:
@@ -681,20 +681,20 @@ public class CommonFunction extends CoTopComponent {
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_PF:
-					if(!CoConstDef.CD_LICENSE_TYPE_NA.equals(rtnVal)) {
+					if (!CoConstDef.CD_LICENSE_TYPE_NA.equals(rtnVal)) {
 						rtnVal = CoConstDef.CD_LICENSE_TYPE_PF;
 					}
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_CP:
-					if(!CoConstDef.CD_LICENSE_TYPE_NA.equals(rtnVal)
+					if (!CoConstDef.CD_LICENSE_TYPE_NA.equals(rtnVal)
 							&& !CoConstDef.CD_LICENSE_TYPE_PF.equals(rtnVal)) {
 						rtnVal = CoConstDef.CD_LICENSE_TYPE_CP;
 					}
 				
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_WCP:
-					if(!CoConstDef.CD_LICENSE_TYPE_NA.equals(rtnVal)
+					if (!CoConstDef.CD_LICENSE_TYPE_NA.equals(rtnVal)
 							&& !CoConstDef.CD_LICENSE_TYPE_PF.equals(rtnVal)
 							&& !CoConstDef.CD_LICENSE_TYPE_CP.equals(rtnVal)) {
 						rtnVal = CoConstDef.CD_LICENSE_TYPE_WCP;
@@ -702,7 +702,7 @@ public class CommonFunction extends CoTopComponent {
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_PMS:
-					if(isEmpty(rtnVal)) {
+					if (isEmpty(rtnVal)) {
 						rtnVal = CoConstDef.CD_LICENSE_TYPE_PMS;
 					}
 					
@@ -718,7 +718,7 @@ public class CommonFunction extends CoTopComponent {
 	public static String getLicensePermissiveType(List<OssLicense> andList) {
 		String rtnVal = "";
 		
-		for(OssLicense bean : andList) {
+		for (OssLicense bean : andList) {
 			// 가장 Strong한 라이선스부터 case
 			switch (bean.getLicenseType()) {
 				case CoConstDef.CD_LICENSE_TYPE_CP:
@@ -726,13 +726,13 @@ public class CommonFunction extends CoTopComponent {
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_WCP:
-					if(!CoConstDef.CD_LICENSE_TYPE_CP.equals(rtnVal)) {
+					if (!CoConstDef.CD_LICENSE_TYPE_CP.equals(rtnVal)) {
 						rtnVal = CoConstDef.CD_LICENSE_TYPE_WCP;
 					}
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_PMS:
-					if(isEmpty(rtnVal)) {
+					if (isEmpty(rtnVal)) {
 						rtnVal = CoConstDef.CD_LICENSE_TYPE_PMS;
 					}
 					
@@ -756,8 +756,8 @@ public class CommonFunction extends CoTopComponent {
 		String currentType = "";
 		boolean breakFlag = false;
 		
-		if(andList != null) {
-			for(OssLicense bean : andList) {
+		if (andList != null) {
+			for (OssLicense bean : andList) {
 				// 가장 Strong한 라이선스부터 case
 				switch (bean.getLicenseType()) {
 					case CoConstDef.CD_LICENSE_TYPE_NA:
@@ -767,28 +767,28 @@ public class CommonFunction extends CoTopComponent {
 						
 						break;
 					case CoConstDef.CD_LICENSE_TYPE_PF:
-						if(!CoConstDef.CD_LICENSE_TYPE_NA.equals(currentType)) {
+						if (!CoConstDef.CD_LICENSE_TYPE_NA.equals(currentType)) {
 							currentType = CoConstDef.CD_LICENSE_TYPE_PF;
 							rtnVal = bean;
 						}
 						
 						break;
 					case CoConstDef.CD_LICENSE_TYPE_CP:
-						if(!CoConstDef.CD_LICENSE_TYPE_PF.equals(currentType)) {
+						if (!CoConstDef.CD_LICENSE_TYPE_PF.equals(currentType)) {
 							currentType = CoConstDef.CD_LICENSE_TYPE_CP;
 							rtnVal = bean;
 						}
 						
 						break;
 					case CoConstDef.CD_LICENSE_TYPE_WCP:
-						if(!CoConstDef.CD_LICENSE_TYPE_CP.equals(currentType)) {
+						if (!CoConstDef.CD_LICENSE_TYPE_CP.equals(currentType)) {
 							currentType = CoConstDef.CD_LICENSE_TYPE_WCP;
 							rtnVal = bean;
 						}
 						
 						break;
 					case CoConstDef.CD_LICENSE_TYPE_PMS:
-						if(isEmpty(currentType)) {
+						if (isEmpty(currentType)) {
 							currentType = CoConstDef.CD_LICENSE_TYPE_PMS;
 							rtnVal = bean;
 						}
@@ -798,7 +798,7 @@ public class CommonFunction extends CoTopComponent {
 						break;
 				}
 				
-				if(breakFlag) {
+				if (breakFlag) {
 					break;
 				}
 			}
@@ -812,7 +812,7 @@ public class CommonFunction extends CoTopComponent {
 		StringBuffer sb = new StringBuffer();
 		File file = new File(path);
 		
-		if(file.exists() && file.isFile()) {
+		if (file.exists() && file.isFile()) {
 			BufferedReader br = null;  
 			InputStreamReader isr = null; 
 			FileInputStream fis = null;  
@@ -825,7 +825,7 @@ public class CommonFunction extends CoTopComponent {
 	            // Input 스트림 객체를 이용하여 버퍼를 생성
 	            br = new BufferedReader(isr);
 	            // 버퍼를 한줄한줄 읽어들여 내용 추출
-	            while( (temp = br.readLine()) != null) {
+	            while ( (temp = br.readLine()) != null) {
 	            	sb.append(temp).append(System.lineSeparator());
 	            }
 	        } catch (FileNotFoundException e) {
@@ -834,13 +834,13 @@ public class CommonFunction extends CoTopComponent {
 	        } catch (Exception e) {
 	             log.error(e.getMessage(), e);
 	        } finally {
-	        	if(fis != null) {
+	        	if (fis != null) {
 	        		try {fis.close();} catch (IOException e) {}
 	        	}
-	        	if(isr != null) {
+	        	if (isr != null) {
 	        		try {isr.close();} catch (IOException e) {}
 	        	}
-	        	if(br != null) {
+	        	if (br != null) {
 	        		try {br.close();} catch (IOException e) {}
 	        	}
 	        }
@@ -856,7 +856,7 @@ public class CommonFunction extends CoTopComponent {
 	public static String getStringFromFile(String path, String ignorePathStr, List<String> checkList, List<String> ignoreList) {
 		StringBuffer sb = new StringBuffer();
 		File file = new File(path);
-		if(file.exists() && file.isFile()) {
+		if (file.exists() && file.isFile()) {
 			BufferedReader br = null;  
 			InputStreamReader isr = null; 
 			FileInputStream fis = null;  
@@ -871,11 +871,11 @@ public class CommonFunction extends CoTopComponent {
 	            // Input 스트림 객체를 이용하여 버퍼를 생성
 	            br = new BufferedReader(isr);
 	            // 버퍼를 한줄한줄 읽어들여 내용 추출
-	            while( (temp = br.readLine()) != null) {
-	            	if(duplicationCheckList.contains(temp.trim())) {
+	            while ( (temp = br.readLine()) != null) {
+	            	if (duplicationCheckList.contains(temp.trim())) {
 	            		continue;
 	            	}
-	            	if(checkExceptionWords(temp, ignorePathStr, checkList, ignoreList)) {
+	            	if (checkExceptionWords(temp, ignorePathStr, checkList, ignoreList)) {
 	            		sb.append(temp).append(System.lineSeparator());
 	            	}
 	            	duplicationCheckList.add(temp.trim());
@@ -886,13 +886,13 @@ public class CommonFunction extends CoTopComponent {
 	        } catch (Exception e) {
 	             log.error(e.getMessage(), e);
 	        } finally {
-	        	if(fis != null) {
+	        	if (fis != null) {
 	        		try {fis.close();} catch (IOException e) {}
 	        	}
-	        	if(isr != null) {
+	        	if (isr != null) {
 	        		try {isr.close();} catch (IOException e) {}
 	        	}
-	        	if(br != null) {
+	        	if (br != null) {
 	        		try {br.close();} catch (IOException e) {}
 	        	}
 	        }
@@ -910,14 +910,14 @@ public class CommonFunction extends CoTopComponent {
 		line = line.replaceAll(ignorePathStr, "");
 		line = line.toUpperCase();
 		
-		for(String s : ignoreList) {
-			if(line.replaceAll(" ", "").replaceAll("\t", "").contains(s.toUpperCase().replaceAll(" ", "").replaceAll("\t", ""))) {
+		for (String s : ignoreList) {
+			if (line.replaceAll(" ", "").replaceAll("\t", "").contains(s.toUpperCase().replaceAll(" ", "").replaceAll("\t", ""))) {
 				return false;
 			}
 		}
 		
-		for(String s : checkList) {
-			if(line.contains(s.toUpperCase())) {
+		for (String s : checkList) {
+			if (line.contains(s.toUpperCase())) {
 				return true;
 			}
 		}
@@ -948,7 +948,7 @@ public class CommonFunction extends CoTopComponent {
 		    detector.reset();			
 		} catch (Exception e) {
 		} finally {
-			if(fis != null) {
+			if (fis != null) {
 				try {
 					fis.close();
 				} catch (Exception e2) {
@@ -962,8 +962,8 @@ public class CommonFunction extends CoTopComponent {
 	public static String sortLicenseName(List<OssLicense> ossLicenses) {
 		List<String> l = new ArrayList<>();
 		
-		if(ossLicenses != null && !ossLicenses.isEmpty()){
-			for(OssLicense bean : ossLicenses) {
+		if (ossLicenses != null && !ossLicenses.isEmpty()){
+			for (OssLicense bean : ossLicenses) {
 				l.add(avoidNull(bean.getLicenseId()));
 			}			
 		}
@@ -971,7 +971,7 @@ public class CommonFunction extends CoTopComponent {
 		Collections.sort(l);
 		
 		String rtn = "";
-		for(String s : l) {
+		for (String s : l) {
 			rtn += (!isEmpty(s) ? "|" : "") + s;
 		}
 		
@@ -979,7 +979,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String getShortIdentify(String licenseName) {
-		if(CoCodeManager.LICENSE_INFO.containsKey(licenseName)) {
+		if (CoCodeManager.LICENSE_INFO.containsKey(licenseName)) {
 			LicenseMaster bean = CoCodeManager.LICENSE_INFO.get(licenseName);
 			
 			return !isEmpty(bean.getShortIdentifier()) ? bean.getShortIdentifier() : licenseName;
@@ -989,10 +989,10 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String getLicenseIdByName(String licenseName) {
-		if(!isEmpty(licenseName)) {
+		if (!isEmpty(licenseName)) {
 			licenseName = licenseName.trim().toUpperCase();
 			
-			if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName)) {
+			if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName)) {
 				return CoCodeManager.LICENSE_INFO_UPPER.get(licenseName).getLicenseId();
 			}
 		}
@@ -1001,16 +1001,16 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String getLicenseNameById(String licenseId, String licenseName) {
-		if(!isEmpty(licenseId)) {
-			if(CoCodeManager.LICENSE_INFO_BY_ID.containsKey(licenseId)) {
+		if (!isEmpty(licenseId)) {
+			if (CoCodeManager.LICENSE_INFO_BY_ID.containsKey(licenseId)) {
 				LicenseMaster licenseInfo = CoCodeManager.LICENSE_INFO_BY_ID.get(licenseId);
-				if(licenseInfo != null) {
+				if (licenseInfo != null) {
 					// short identify를 최우선
-					if(!isEmpty(licenseInfo.getShortIdentifier())) {
+					if (!isEmpty(licenseInfo.getShortIdentifier())) {
 						return licenseInfo.getShortIdentifier();
 					}
 					
-					if(!isEmpty(licenseInfo.getLicenseNameTemp())) {
+					if (!isEmpty(licenseInfo.getLicenseNameTemp())) {
 						// 정식 명칭으로 변환
 						return licenseInfo.getLicenseNameTemp();
 					}
@@ -1022,9 +1022,9 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static List<OssLicense> changeLicenseNameToShort(List<OssLicense> list) {
-		if(list != null) {
-			for(OssLicense bean : list) {
-				if(CoCodeManager.LICENSE_INFO.containsKey(bean.getLicenseName()) && !isEmpty(CoCodeManager.LICENSE_INFO.get(bean.getLicenseName()).getShortIdentifier())) {
+		if (list != null) {
+			for (OssLicense bean : list) {
+				if (CoCodeManager.LICENSE_INFO.containsKey(bean.getLicenseName()) && !isEmpty(CoCodeManager.LICENSE_INFO.get(bean.getLicenseName()).getShortIdentifier())) {
 					bean.setLicenseName(CoCodeManager.LICENSE_INFO.get(bean.getLicenseName()).getShortIdentifier());
 				}
 			}
@@ -1049,7 +1049,7 @@ public class CommonFunction extends CoTopComponent {
 		ProjectIdentification gridLicenseBean;
 		int keyCnt = 1;
 		
-		for(OssComponents bean : reportData) {
+		for (OssComponents bean : reportData) {
 			gridBean = new ProjectIdentification();
 			gridBean.setGridId(CoConstDef.GRID_NEWROW_DEFAULT_PREFIX+fileSeq +"f"+keyCnt++);
 			gridBean.setComponentId(bean.getComponentId());
@@ -1059,12 +1059,12 @@ public class CommonFunction extends CoTopComponent {
 			gridBean.setOssName(bean.getOssName());
 			// oss version이 정수형인 경우 분석결과서 서식에 따라, ".0" 이 사라지는 경우를 위해 
 			// 기 등록된 oss에 존재하는 경우 자동으로 .0을 채워줌
-			if(!isEmpty(bean.getOssName()) && !isEmpty(bean.getOssVersion()) && StringUtil.isNumeric(bean.getOssVersion())) {
+			if (!isEmpty(bean.getOssName()) && !isEmpty(bean.getOssVersion()) && StringUtil.isNumeric(bean.getOssVersion())) {
 				String _test = bean.getOssName().trim() + "_" + bean.getOssVersion().trim();
 				String _test2 = bean.getOssName().trim() + "_" + bean.getOssVersion().trim() + ".0";
-				if(!CoCodeManager.OSS_INFO_UPPER.containsKey(_test.toUpperCase()) 
+				if (!CoCodeManager.OSS_INFO_UPPER.containsKey(_test.toUpperCase()) 
 						&& CoCodeManager.OSS_INFO_UPPER.containsKey(_test2.toUpperCase())) {
-					if(!versionChangeCheckList.contains(bean.getOssName() + "_" + bean.getOssVersion())) {
+					if (!versionChangeCheckList.contains(bean.getOssName() + "_" + bean.getOssVersion())) {
 						versionChangeCheckList.add(bean.getOssName() + "_" + bean.getOssVersion());
 						versionChangeList.add(bean.getOssName() + " : " + bean.getOssVersion() + " => " + bean.getOssVersion().trim() + ".0");
 					}
@@ -1094,16 +1094,16 @@ public class CommonFunction extends CoTopComponent {
 			gridBean.setCopyrightText(bean.getCopyrightText());
 			gridBean.setComments(bean.getComments());
 			
-			if(!isEmpty(bean.getOssNickName())) {
+			if (!isEmpty(bean.getOssNickName())) {
 				gridBean.setOssNickName(bean.getOssNickName());
 			}
 			
 			// license 
 			int licenseIdx = 1;
-			if(bean.getOssComponentsLicense() != null) {
+			if (bean.getOssComponentsLicense() != null) {
 				String licenseText = "";
 				
-				for(OssComponentsLicense license : bean.getOssComponentsLicense()) {
+				for (OssComponentsLicense license : bean.getOssComponentsLicense()) {
 					gridLicenseBean = new ProjectIdentification();
 					gridLicenseBean.setGridId(gridBean.getGridId() + "-" + licenseIdx++);
 					gridLicenseBean.setComponentLicenseId(license.getComponentLicenseId());
@@ -1118,14 +1118,14 @@ public class CommonFunction extends CoTopComponent {
 					gridBean.addComponentLicenseList(gridLicenseBean);
 					
 
-					if(!isEmpty(license.getLicenseText())) {
+					if (!isEmpty(license.getLicenseText())) {
 						licenseText += (!isEmpty(licenseText) ? "\r\n" : "") + license.getLicenseText();
 					}				
 				}
 				
 				gridBean.setLicenseText(licenseText);
 				
-				if(CoConstDef.LICENSE_DIV_MULTI.equals(gridBean.getLicenseDiv())) {
+				if (CoConstDef.LICENSE_DIV_MULTI.equals(gridBean.getLicenseDiv())) {
 					gridBean.setLicenseName(CommonFunction.makeLicenseExpressionIdentify(gridBean.getComponentLicenseList(), ","));
 				} else {
 					gridBean.setLicenseName(CommonFunction.makeLicenseExpressionIdentify(gridBean.getComponentLicenseList()));
@@ -1136,7 +1136,7 @@ public class CommonFunction extends CoTopComponent {
 			resultList.add(gridBean);
 		}
 	
-		if(!versionChangeList.isEmpty()) {
+		if (!versionChangeList.isEmpty()) {
 			resultMap.put("versionChangeList", versionChangeList);
 		}
 		
@@ -1165,8 +1165,8 @@ public class CommonFunction extends CoTopComponent {
 		ProjectIdentification gridLicenseBean;
 		List<ProjectIdentification> mainGridList = ossComponents != null ? ossComponents : new ArrayList<>();
 		// single license 의 경우 메인grid로 처리하기 때문에 다시 license정보를 생성해줘야함
-		for(ProjectIdentification bean : mainGridList) {
-			if(CoConstDef.LICENSE_DIV_SINGLE.equals(bean.getLicenseDiv())) {
+		for (ProjectIdentification bean : mainGridList) {
+			if (CoConstDef.LICENSE_DIV_SINGLE.equals(bean.getLicenseDiv())) {
 				gridLicenseBean = new ProjectIdentification();
 				gridLicenseBean.setComponentLicenseId(bean.getComponentLicenseId());
 				gridLicenseBean.setComponentId(bean.getComponentId());
@@ -1182,19 +1182,19 @@ public class CommonFunction extends CoTopComponent {
 			}
 		}
 		
-		if(ossComponentsLicense != null) {
-			for(List<ProjectIdentification> licenseList : ossComponentsLicense) {
+		if (ossComponentsLicense != null) {
+			for (List<ProjectIdentification> licenseList : ossComponentsLicense) {
 				String gridId = licenseList.get(0).getGridId();
 				String key = licenseList.get(0).getGridId().split(gridId.indexOf("-") > -1 ? "-" : "_")[0];
 				subMap.put(key, licenseList);
 			}
 		}
 		
-		if(addOssComponents != null) {
+		if (addOssComponents != null) {
 			String key = "";
-			for(ProjectIdentification bean : addOssComponents) {
+			for (ProjectIdentification bean : addOssComponents) {
 				String key2 = bean.getBinaryName()+ "-" + bean.getOssName() + "-" + bean.getOssVersion();
-				if(key.equals(key2)) {
+				if (key.equals(key2)) {
 					ProjectIdentification result = mainGridList.get(mainGridList.size()-1);
 					result.setLicenseName(result.getLicenseName() + "," + bean.getLicenseName());
 					
@@ -1206,31 +1206,31 @@ public class CommonFunction extends CoTopComponent {
 					key = key2;
 				}
 				
-				if(bean.getComponentLicenseList() != null) {
+				if (bean.getComponentLicenseList() != null) {
 					subMap.put(bean.getGridId(), bean.getComponentLicenseList());
 				}
 			}
 
 		}
 		
-		if(reportData != null) {
+		if (reportData != null) {
 			Map<String, Object> convertObj = convertToProjectIdentificationList(reportData, fileSeq);
 			List<ProjectIdentification> _list = (List<ProjectIdentification>) convertObj.get("resultList");
 			
-			if(_list != null) {
+			if (_list != null) {
 				Map<String, ProjectIdentification> sortMap = new TreeMap<String, ProjectIdentification>();
 				
-				for(ProjectIdentification gridBean : _list) { // 중복제거 및 정렬
+				for (ProjectIdentification gridBean : _list) { // 중복제거 및 정렬
 					String key = "";
-					if("BIN".equals(readType.toUpperCase()) || "BINANDROID".equals(readType.toUpperCase()) || "PARTNER".equals(readType.toUpperCase())) {
-						if(!isEmpty(gridBean.getFilePath()) && isEmpty(gridBean.getBinaryName())) {
+					if ("BIN".equals(readType.toUpperCase()) || "BINANDROID".equals(readType.toUpperCase()) || "PARTNER".equals(readType.toUpperCase())) {
+						if (!isEmpty(gridBean.getFilePath()) && isEmpty(gridBean.getBinaryName())) {
 							gridBean.setBinaryName(gridBean.getFilePath());
 						}
 						
 						key = gridBean.getBinaryName() + "-" + gridBean.getOssName() + "-" + gridBean.getOssVersion() + "-" + gridBean.getLicenseName() + "-" 
 								+ gridBean.getDownloadLocation() + "-" + gridBean.getHomepage() + "-" + gridBean.getCopyrightText() + "-" + gridBean.getExcludeYn();
 					}else {
-						if(isEmpty(gridBean.getFilePath()) && !isEmpty(gridBean.getBinaryName())) {
+						if (isEmpty(gridBean.getFilePath()) && !isEmpty(gridBean.getBinaryName())) {
 							gridBean.setFilePath(gridBean.getBinaryName());
 						}
 						
@@ -1238,17 +1238,17 @@ public class CommonFunction extends CoTopComponent {
 								+ gridBean.getDownloadLocation() + "-" + gridBean.getHomepage() + "-" + gridBean.getCopyrightText() + "-" + gridBean.getExcludeYn();
 					}
 					
-					if(!sortMap.keySet().contains(key)) {
+					if (!sortMap.keySet().contains(key)) {
 						List<ProjectIdentification> resultLicenseList = new ArrayList<ProjectIdentification>();
 						List<String> duplicateLicense = new ArrayList<String>();
 						
-						if(gridBean.getComponentLicenseList() != null) {
-							for(ProjectIdentification licenseList : gridBean.getComponentLicenseList()) {
-								if(licenseList.getLicenseName().contains(",")){
+						if (gridBean.getComponentLicenseList() != null) {
+							for (ProjectIdentification licenseList : gridBean.getComponentLicenseList()) {
+								if (licenseList.getLicenseName().contains(",")){
 									ProjectIdentification copyLicenseList = null;
 									String[] licenses = licenseList.getLicenseName().split(",");
-									for(String li : licenses) {
-										if(!duplicateLicense.contains(StringUtil.trim(li).toUpperCase())) {
+									for (String li : licenses) {
+										if (!duplicateLicense.contains(StringUtil.trim(li).toUpperCase())) {
 											try {
 												copyLicenseList = licenseList.copy();
 												
@@ -1261,7 +1261,7 @@ public class CommonFunction extends CoTopComponent {
 										}
 									}
 								}else {
-									if(!duplicateLicense.contains(licenseList.getLicenseName()) && CoConstDef.FLAG_NO.equals(avoidNull(licenseList.getExcludeYn(), CoConstDef.FLAG_NO))) {
+									if (!duplicateLicense.contains(licenseList.getLicenseName()) && CoConstDef.FLAG_NO.equals(avoidNull(licenseList.getExcludeYn(), CoConstDef.FLAG_NO))) {
 										resultLicenseList.add(licenseList);
 										duplicateLicense.add(StringUtil.trim(licenseList.getLicenseName()).toUpperCase());
 									}
@@ -1276,31 +1276,31 @@ public class CommonFunction extends CoTopComponent {
 				
 				String key = "";
 				String key3 = "";
-				for(ProjectIdentification gridBean : sortMap.values()) {
+				for (ProjectIdentification gridBean : sortMap.values()) {
 					LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO.get(gridBean.getLicenseName());
 					String ossName = isEmpty(gridBean.getOssName()) ? "-" : gridBean.getOssName();
 					String key2 = "";
 					String key4 = ossName + "-" + (licenseMaster != null ? licenseMaster.getLicenseType() : "");
 					String gridId = "";
 					
-					if("BIN".equals(readType.toUpperCase()) || "BINANDROID".equals(readType.toUpperCase()) || "PARTNER".equals(readType.toUpperCase())) {
+					if ("BIN".equals(readType.toUpperCase()) || "BINANDROID".equals(readType.toUpperCase()) || "PARTNER".equals(readType.toUpperCase())) {
 						key2 = gridBean.getBinaryName() + "-" + ossName + "-" + gridBean.getOssVersion() + "-" + gridBean.getExcludeYn();
 					}else {
 						key2 = gridBean.getFilePath() + "-" + ossName + "-" + gridBean.getOssVersion() + "-" + gridBean.getExcludeYn();
 					}
 					
-					if(!"-".equals(ossName) 
+					if (!"-".equals(ossName) 
 							&& key.equals(key2)
 							&& !"--NA".equals(key3)
 							&& !"--NA".equals(key4)) { // 단, OSS Name: - 이면서, License Type: Proprietary이 아닌 경우 Row를 합치지 않음.
 						ProjectIdentification result = mainGridList.get(mainGridList.size()-1);
 						
-						if(!result.getLicenseName().contains(StringUtil.trim(gridBean.getLicenseName()))) {
+						if (!result.getLicenseName().contains(StringUtil.trim(gridBean.getLicenseName()))) {
 							String resultLicenseName = StringUtil.trim(result.getLicenseName());
 							String licenseNameList = StringUtil.trim(gridBean.getLicenseName());
-							if(licenseNameList.contains(",")) {
-								for(String licensename : licenseNameList.split(",")) {
-									if(!resultLicenseName.contains(licensename) && !isEmpty(licensename)) {
+							if (licenseNameList.contains(",")) {
+								for (String licensename : licenseNameList.split(",")) {
+									if (!resultLicenseName.contains(licensename) && !isEmpty(licensename)) {
 										resultLicenseName += "," + licensename;
 									}
 								}
@@ -1319,20 +1319,20 @@ public class CommonFunction extends CoTopComponent {
 						key3 = key4;
 					}
 					
-					if(gridBean.getComponentLicenseList() != null) {
-						if(isEmpty(gridId)) {
+					if (gridBean.getComponentLicenseList() != null) {
+						if (isEmpty(gridId)) {
 							subMap.put(gridBean.getGridId(), gridBean.getComponentLicenseList());
 						}else {
 							List<ProjectIdentification> result = (List<ProjectIdentification>) subMap.get(gridId);
-							for(ProjectIdentification subData : gridBean.getComponentLicenseList()) {
-								for(ProjectIdentification resultData : result) {
-									if(!resultData.getLicenseName().equals(resultData.getLicenseName())) {
+							for (ProjectIdentification subData : gridBean.getComponentLicenseList()) {
+								for (ProjectIdentification resultData : result) {
+									if (!resultData.getLicenseName().equals(resultData.getLicenseName())) {
 										result.add(subData);
 										break;
 									}
 								}
 							}
-							if(result.size() > 0) {
+							if (result.size() > 0) {
 								subMap.replace(gridId, result);
 							}else {
 								subMap.replace(gridId, gridBean.getComponentLicenseList());
@@ -1344,7 +1344,7 @@ public class CommonFunction extends CoTopComponent {
 			
 			// OSC-486
 			// version 정보가 자동으로 변경된 Data 체크
-			if(convertObj.containsKey("versionChangeList")) {
+			if (convertObj.containsKey("versionChangeList")) {
 				resultMap.put("versionChangedList",convertObj.get("versionChangeList"));
 			}
 						
@@ -1358,13 +1358,13 @@ public class CommonFunction extends CoTopComponent {
 	public static String makeLicenseObligationStr(String obligationChecks) {
 		String rtnStr = "";
 		
-		if(avoidNull(obligationChecks).length() == 3) {
+		if (avoidNull(obligationChecks).length() == 3) {
 			// 우선순위가 높은 순으로
-			if(CoConstDef.FLAG_YES.equals(obligationChecks.substring(2))) {
+			if (CoConstDef.FLAG_YES.equals(obligationChecks.substring(2))) {
 				rtnStr = CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK);
-			} else if(CoConstDef.FLAG_YES.equals(obligationChecks.substring(1, 2))) {
+			} else if (CoConstDef.FLAG_YES.equals(obligationChecks.substring(1, 2))) {
 				rtnStr = CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
-			} else if(CoConstDef.FLAG_YES.equals(obligationChecks.substring(0, 1))) {
+			} else if (CoConstDef.FLAG_YES.equals(obligationChecks.substring(0, 1))) {
 				rtnStr = CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, CoConstDef.CD_DTL_OBLIGATION_NOTICE);
 			}
 		}
@@ -1383,7 +1383,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String makeCategoryFormat(String distributeTarget, String categoryCd) {
-		if(!isEmpty(categoryCd) && categoryCd.length() == 6) {
+		if (!isEmpty(categoryCd) && categoryCd.length() == 6) {
 			return makeCategoryFormat(distributeTarget, categoryCd.substring(0,3), categoryCd.substring(3));
 		}
 		
@@ -1392,37 +1392,37 @@ public class CommonFunction extends CoTopComponent {
 
 	public static boolean isSameLicense(List<OssComponentsLicense> list1,
 			List<OssComponentsLicense> list2) {
-		if(list1 == null && list2 == null) {
+		if (list1 == null && list2 == null) {
 			return false;
 		}
 		
-		if((list1 == null && list2 != null) || (list1 != null && list2 == null)) {
+		if ((list1 == null && list2 != null) || (list1 != null && list2 == null)) {
 			return false;
 		}
 		
-		if(list1.size() != list2.size()) {
+		if (list1.size() != list2.size()) {
 			return false;
 		}
 		
 		List<String> licenseNames = new ArrayList<>();
 		
-		for(OssComponentsLicense bean : list1) {
+		for (OssComponentsLicense bean : list1) {
 			LicenseMaster liMaster = CoCodeManager.LICENSE_INFO.get(bean.getLicenseName());
-			if(liMaster == null) {
+			if (liMaster == null) {
 				licenseNames.add(avoidNull( bean.getLicenseName()));
 			} else {
 				licenseNames.add(liMaster.getLicenseName());
-				if(!isEmpty(liMaster.getShortIdentifier())) {
+				if (!isEmpty(liMaster.getShortIdentifier())) {
 					licenseNames.add(liMaster.getShortIdentifier());
 				}
-				if(liMaster.getLicenseNicknameList() != null && !liMaster.getLicenseNicknameList().isEmpty()) {
+				if (liMaster.getLicenseNicknameList() != null && !liMaster.getLicenseNicknameList().isEmpty()) {
 					licenseNames.addAll(liMaster.getLicenseNicknameList());
 				}
 			}
 		}
 		
-		for(OssComponentsLicense bean : list2) {
-			if(!licenseNames.contains(bean.getLicenseName())) {
+		for (OssComponentsLicense bean : list2) {
+			if (!licenseNames.contains(bean.getLicenseName())) {
 				return false;
 			}
 		}
@@ -1459,19 +1459,19 @@ public class CommonFunction extends CoTopComponent {
 		Map<String, List<String>> infoOnlyMap = new HashMap<>(); // info level
 		Map<String, String> hideObligationIdList = new HashMap<>();
 		
-		if(RestrictionFlag) {
-			for(ProjectIdentification p : list) {
-				if(!StringUtil.isEmpty(p.getRestriction()) && CoConstDef.FLAG_NO.equals(p.getExcludeYn())) {
+		if (RestrictionFlag) {
+			for (ProjectIdentification p : list) {
+				if (!StringUtil.isEmpty(p.getRestriction()) && CoConstDef.FLAG_NO.equals(p.getExcludeYn())) {
 					restrictionMap.put(avoidNull(p.getGridId(), p.getComponentId()), new ArrayList<String>());
 				}
 			}
 		}
 		
-		if(validMap != null && !validMap.isEmpty()) {
-			for(String errKey : validMap.keySet()) {
-				if(errKey.indexOf(".") > -1) {
+		if (validMap != null && !validMap.isEmpty()) {
+			for (String errKey : validMap.keySet()) {
+				if (errKey.indexOf(".") > -1) {
 					String _key = errKey.substring(errKey.indexOf(".") + 1, errKey.length());
-					if(errorMap.containsKey(_key)) {
+					if (errorMap.containsKey(_key)) {
 						List<String> _list = errorMap.get(_key);
 						_list.add(errKey.substring(0, errKey.indexOf(".")).toUpperCase());
 						errorMap.replace(_key, _list);
@@ -1481,8 +1481,8 @@ public class CommonFunction extends CoTopComponent {
 						errorMap.put(_key, _list);
 					}
 					/*
-					if(hideObligation) {
-						if(hideObligationColumns.contains(errKey.substring(0, errKey.indexOf(".")).toUpperCase())) {
+					if (hideObligation) {
+						if (hideObligationColumns.contains(errKey.substring(0, errKey.indexOf(".")).toUpperCase())) {
 //							hideObligationIdList.put(_key, validMap.get(errKey));
 							hideObligationIdList.put(_key, getMessage("msg.project.obligation.unclear"));
 						}
@@ -1494,20 +1494,20 @@ public class CommonFunction extends CoTopComponent {
 
 		
 		// warning message 가 포함되어 있는 경우 정렬 (우선순위 3)
-		if(validDiffMap != null && !validDiffMap.isEmpty()) {
-			for(String errKey : validDiffMap.keySet()) {
-				if(errKey.indexOf(".") > -1) {
+		if (validDiffMap != null && !validDiffMap.isEmpty()) {
+			for (String errKey : validDiffMap.keySet()) {
+				if (errKey.indexOf(".") > -1) {
 					String _key = errKey.substring(errKey.indexOf(".") + 1, errKey.length());
 					/*
-					if(hideObligation) {
-						if(hideObligationColumns.contains(errKey.substring(0, errKey.indexOf(".")).toUpperCase())) {
+					if (hideObligation) {
+						if (hideObligationColumns.contains(errKey.substring(0, errKey.indexOf(".")).toUpperCase())) {
 //							hideObligationIdList.put(_key, validDiffMap.get(errKey));
 							hideObligationIdList.put(_key, getMessage("msg.project.obligation.unclear"));
 						}
 					}
 					*/
 					
-					if(warningMap.containsKey(_key)) {
+					if (warningMap.containsKey(_key)) {
 						List<String> _list = warningMap.get(_key);
 						_list.add(errKey.substring(0, errKey.indexOf(".")).toUpperCase());
 						warningMap.replace(_key, _list);
@@ -1521,21 +1521,21 @@ public class CommonFunction extends CoTopComponent {
 		}
 		
 		// info message가 포함되어 있는 경우 정렬 (우선순위 6)
-		if(validInfoMap != null && !validInfoMap.isEmpty()) {
-			for(String errKey : validInfoMap.keySet()) {
-				if(errKey.indexOf(".") > -1) {
+		if (validInfoMap != null && !validInfoMap.isEmpty()) {
+			for (String errKey : validInfoMap.keySet()) {
+				if (errKey.indexOf(".") > -1) {
 					String _key = errKey.substring(errKey.indexOf(".") + 1, errKey.length());
 					
-					if(hideObligation) {
-						if(hideObligationColumns.contains(errKey.substring(0, errKey.indexOf(".")).toUpperCase())) {
+					if (hideObligation) {
+						if (hideObligationColumns.contains(errKey.substring(0, errKey.indexOf(".")).toUpperCase())) {
 //							hideObligationIdList.put(_key, validInfoMap.get(errKey));
 							hideObligationIdList.put(_key, getMessage("msg.project.obligation.unclear"));
 						}
 					}
 					
 					// info level message 중에서 new binary message는 info level 상단으로 정렬하기 위해 우선순위 5로 구분하여 격납함
-					if(errKey.startsWith("binaryName.") && "NEW".equalsIgnoreCase(validInfoMap.get(errKey))) {
-						if(infoBiMap.containsKey(_key)) {
+					if (errKey.startsWith("binaryName.") && "NEW".equalsIgnoreCase(validInfoMap.get(errKey))) {
+						if (infoBiMap.containsKey(_key)) {
 							List<String> _list = infoBiMap.get(_key);
 							_list.add(errKey.substring(0, errKey.indexOf(".")).toUpperCase());
 							infoBiMap.replace(_key, _list);
@@ -1545,8 +1545,8 @@ public class CommonFunction extends CoTopComponent {
 							infoBiMap.put(_key, _list);
 						}
 						
-					} else if(errKey.startsWith("binaryName.") && validInfoMap.get(errKey).toUpperCase().startsWith("MODIFIED")) {
-						if(infoModifyMap.containsKey(_key)) {
+					} else if (errKey.startsWith("binaryName.") && validInfoMap.get(errKey).toUpperCase().startsWith("MODIFIED")) {
+						if (infoModifyMap.containsKey(_key)) {
 							List<String> _list = infoModifyMap.get(_key);
 							_list.add(errKey.substring(0, errKey.indexOf(".")).toUpperCase());
 							infoModifyMap.replace(_key, _list);
@@ -1557,7 +1557,7 @@ public class CommonFunction extends CoTopComponent {
 						}
 					} else {
 						
-						if(infoOnlyMap.containsKey(_key)) {
+						if (infoOnlyMap.containsKey(_key)) {
 							List<String> _list = infoOnlyMap.get(_key);
 							_list.add(errKey.substring(0, errKey.indexOf(".")).toUpperCase());
 							infoOnlyMap.replace(_key, _list);
@@ -1573,70 +1573,70 @@ public class CommonFunction extends CoTopComponent {
 		
 		// bom의 경우 우선순위가 높은 1개 row만 sort대상으로 취급
 		String currentGroup = "";
-		for(ProjectIdentification bean : list) {
+		for (ProjectIdentification bean : list) {
 			
 			// self check case only
-			if(hideObligation) {
-				if(hideObligationIdList.containsKey(bean.getGridId())) {
+			if (hideObligation) {
+				if (hideObligationIdList.containsKey(bean.getGridId())) {
 					bean.setObligationGrayFlag(CoConstDef.FLAG_YES);
 					bean.setObligationMsg(hideObligationIdList.get(bean.getGridId()));
 				} 
 
 				// Need Check license인 경우
-				else if(hasNeedCheckLicense(bean, true)) {
+				else if (hasNeedCheckLicense(bean, true)) {
 					bean.setObligationGrayFlag(CoConstDef.FLAG_YES);
 					bean.setObligationMsg(getMessage("msg.info.selfcheck.include.needcheck.licnese"));
 				}
 				// 선택된 license로 다시 계산해야함 obligation type
-				else if(CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())) {
+				else if (CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())) {
 					bean.setObligationType(CommonFunction.getObligationTypeWithSelectedLicense(bean));
 				}
 			}
 			
-			if(	!(!isEmpty(bean.getGroupingColumn()) && currentGroup.equals(bean.getGroupingColumn()))) {
+			if (	!(!isEmpty(bean.getGroupingColumn()) && currentGroup.equals(bean.getGroupingColumn()))) {
 				// 0(1) : error level
-				if(errorMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
+				if (errorMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
 					//sortList.add(bean);
 					sortMap.put(makeValidSortKey(errorMap.get(avoidNull(bean.getGridId(), bean.getComponentId())), avoidNull(bean.getGridId(), bean.getComponentId()) , "0"), bean);
-				} else if(checkMultiLicenseError(errorMap, bean.getComponentLicenseList()) != null) {
+				} else if (checkMultiLicenseError(errorMap, bean.getComponentLicenseList()) != null) {
 					String _id = checkMultiLicenseError(errorMap, bean.getComponentLicenseList());
 					sortMap.put(makeValidSortKey(errorMap.get(_id), _id, "0"), bean);
-				} else if(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(bean.getObligationLicense())) {
+				} else if (CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(bean.getObligationLicense())) {
 					sortMap.put(makeValidSortKey(new ArrayList<String>(), avoidNull(bean.getGridId(), bean.getComponentId()) , "0", bean.getObligationLicense()), bean);
 				}
 				// 2 : Restriction
-				else if(restrictionMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
+				else if (restrictionMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
 					//sortList.add(bean);
 					sortMap.put(makeValidSortKey(restrictionMap.get(avoidNull(bean.getGridId(), bean.getComponentId())), avoidNull(bean.getGridId(), bean.getComponentId()) , "2"), bean);
 				}
 				// 3 : warning level
-				else if(warningMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
+				else if (warningMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
 					//sortList.add(bean);
 					sortMap.put(makeValidSortKey(warningMap.get(avoidNull(bean.getGridId(), bean.getComponentId())), avoidNull(bean.getGridId(), bean.getComponentId()) , "3"), bean);
-				} else if(checkMultiLicenseError(warningMap, bean.getComponentLicenseList()) != null) {
+				} else if (checkMultiLicenseError(warningMap, bean.getComponentLicenseList()) != null) {
 					String _id = checkMultiLicenseError(warningMap, bean.getComponentLicenseList());
 					sortMap.put(makeValidSortKey(warningMap.get(_id), _id, "3"), bean);
 				}
 				// 5 : info level (new binary)
-				else if(infoBiMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
+				else if (infoBiMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
 					//sortList.add(bean);
 					sortMap.put(makeValidSortKey(infoBiMap.get(avoidNull(bean.getGridId(), bean.getComponentId())), avoidNull(bean.getGridId(), bean.getComponentId()) , "5"), bean);
-				} else if(checkMultiLicenseError(infoBiMap, bean.getComponentLicenseList()) != null) {
+				} else if (checkMultiLicenseError(infoBiMap, bean.getComponentLicenseList()) != null) {
 					String _id = checkMultiLicenseError(infoBiMap, bean.getComponentLicenseList());
 					sortMap.put(makeValidSortKey(infoBiMap.get(_id), _id, "5"), bean);
 				}
 				// 6 : info level (Modified = new + tlsh > 120)
-				else if(infoModifyMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
+				else if (infoModifyMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
 					sortMap.put(makeValidSortKey(infoModifyMap.get(avoidNull(bean.getGridId(), bean.getComponentId())), avoidNull(bean.getGridId(), bean.getComponentId()) , "6"), bean);
-				} else if(checkMultiLicenseError(infoModifyMap, bean.getComponentLicenseList()) != null) {
+				} else if (checkMultiLicenseError(infoModifyMap, bean.getComponentLicenseList()) != null) {
 					String _id = checkMultiLicenseError(infoBiMap, bean.getComponentLicenseList());
 					sortMap.put(makeValidSortKey(infoModifyMap.get(_id), _id, "6"), bean);
 				}
 				// 7 : info level
-				else if(infoOnlyMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
+				else if (infoOnlyMap.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
 					//sortList.add(bean);
 					sortMap.put(makeValidSortKey(infoOnlyMap.get(avoidNull(bean.getGridId(), bean.getComponentId())), avoidNull(bean.getGridId(), bean.getComponentId()) , "7"), bean);
-				} else if(checkMultiLicenseError(infoOnlyMap, bean.getComponentLicenseList()) != null) {
+				} else if (checkMultiLicenseError(infoOnlyMap, bean.getComponentLicenseList()) != null) {
 					String _id = checkMultiLicenseError(infoOnlyMap, bean.getComponentLicenseList());
 					sortMap.put(makeValidSortKey(infoOnlyMap.get(_id), _id, "7"), bean);
 				}
@@ -1652,17 +1652,17 @@ public class CommonFunction extends CoTopComponent {
 		// validation 위치별 재정렬
 		// treemap을 이용하여 오름차순으로 정렬한다.
 		TreeMap<String,ProjectIdentification> tm = new TreeMap<String,ProjectIdentification>(sortMap);
-		for(String key : tm.keySet()) {
+		for (String key : tm.keySet()) {
 			sortList.add(tm.get(key));
 		}
 
 		// subGrid에서 오류가 있는 row
-		if(!sortList2.isEmpty()) {
+		if (!sortList2.isEmpty()) {
 			sortList.addAll(sortList2);
 		}
 		
 		// 오류가 없는 row
-		if(!sortListOk.isEmpty()) {
+		if (!sortListOk.isEmpty()) {
 			sortList.addAll(sortListOk);
 		}
 		
@@ -1670,19 +1670,19 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	private static String getObligationTypeWithSelectedLicense(ProjectIdentification identificationBean) {
-		if(identificationBean != null && identificationBean.getComponentLicenseList() != null && !identificationBean.getComponentLicenseList().isEmpty()) {
+		if (identificationBean != null && identificationBean.getComponentLicenseList() != null && !identificationBean.getComponentLicenseList().isEmpty()) {
 
 			// oss master의 obligation과는 달리, exclude 이외의 license는 모두 선택중인 license로 판단한다. (AND)
 			List<OssLicense> checkForObligationLicenseList = new ArrayList<>();
 			
-			for(ProjectIdentification bean : identificationBean.getComponentLicenseList()) {
-				if(CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+			for (ProjectIdentification bean : identificationBean.getComponentLicenseList()) {
+				if (CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 					continue;
 				}
 				
 				LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(bean.getLicenseName()).toUpperCase());
 				
-				if(master != null) {
+				if (master != null) {
 					OssLicense license = new OssLicense();
 					license.setLicenseName(master.getLicenseNameTemp());
 					license.setLicenseId(master.getLicenseId());
@@ -1692,19 +1692,19 @@ public class CommonFunction extends CoTopComponent {
 				}
 			}
 			
-			if(!checkForObligationLicenseList.isEmpty()) {
+			if (!checkForObligationLicenseList.isEmpty()) {
 				OssLicense obligationLicense = CommonFunction.getLicensePermissiveTypeLicense(checkForObligationLicenseList);
 				
-				if(obligationLicense != null) {
+				if (obligationLicense != null) {
 					// 선택한 license 중에서 가장 Strong한 라이선스의 obligation 설정에 따라 표시
 					LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(obligationLicense.getLicenseName()).toUpperCase());
 					
-					if(master != null) {
-						if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNeedsCheckYn()))) {
+					if (master != null) {
+						if (CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNeedsCheckYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK;
-						} else if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))) {
+						} else if (CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE;
-						} else if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNotificationYn()))) {
+						} else if (CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNotificationYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_NOTICE;
 						}
 					}
@@ -1716,13 +1716,13 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	private static boolean hasNeedCheckLicense(ProjectIdentification bean, boolean withSelectedLicense) {
-		if(bean != null && bean.getComponentLicenseList() != null && !bean.getComponentLicenseList().isEmpty()) {
-			for(ProjectIdentification license : bean.getComponentLicenseList()) {
-				if(withSelectedLicense && CoConstDef.FLAG_YES.equals(license.getExcludeYn())) {
+		if (bean != null && bean.getComponentLicenseList() != null && !bean.getComponentLicenseList().isEmpty()) {
+			for (ProjectIdentification license : bean.getComponentLicenseList()) {
+				if (withSelectedLicense && CoConstDef.FLAG_YES.equals(license.getExcludeYn())) {
 					continue;
 				}
 				
-				if(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(license.getObligationType())) {
+				if (CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(license.getObligationType())) {
 					return true;
 				}
 			}
@@ -1739,7 +1739,7 @@ public class CommonFunction extends CoTopComponent {
 		Map<String, String> compareSortMap = new LinkedHashMap<>(); // [Identification] Auto ID message있는 Row 정렬 필요.
 		int sortIdx = 0;
 		
-		for(String key : compareArray) {
+		for (String key : compareArray) {
 			compareSortMap.put(key, StringUtil.leftPad(Integer.toString(sortIdx++), 2, "0") );
 		}
 		
@@ -1747,20 +1747,20 @@ public class CommonFunction extends CoTopComponent {
 		String preSortKey = avoidNull(prevSortKey, "0");
 		boolean hasErrorCode = false;
 		
-		for(String key : compareSortMap.keySet()) {
+		for (String key : compareSortMap.keySet()) {
 			rtn += preSortKey + (list.contains(key) ? compareSortMap.get(key) : "99");
 			
-			if(list.contains(key)) {
+			if (list.contains(key)) {
 				hasErrorCode = true;
 			}
 		}
 		
 		// error code가 없고, obligation type이 need check 인 경우, error 와 warning 사이에 표시한다.
-		if(!isEmpty(obligationType) && CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(obligationType) && !hasErrorCode) {
+		if (!isEmpty(obligationType) && CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(obligationType) && !hasErrorCode) {
 			preSortKey = "1";
 			rtn = "";
 			
-			for(String key : compareSortMap.keySet()) {
+			for (String key : compareSortMap.keySet()) {
 				rtn += preSortKey + (list.contains(key) ? compareSortMap.get(key) : "99");
 			}
 		}
@@ -1775,9 +1775,9 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	private static String checkMultiLicenseError(Map<String, List<String>> addedIdList, List<ProjectIdentification> list) {
-		if(list != null) {
-			for(ProjectIdentification bean : list) {
-				if(addedIdList.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
+		if (list != null) {
+			for (ProjectIdentification bean : list) {
+				if (addedIdList.containsKey(avoidNull(bean.getGridId(), bean.getComponentId()))) {
 					return avoidNull(bean.getGridId(), bean.getComponentId());
 				}
 			}
@@ -1810,11 +1810,11 @@ public class CommonFunction extends CoTopComponent {
 			//}
 			// path 정보를 무시하고 binary 파일명만 추가 (binary file은 사전에 중복 제거되어 유니크하다)
 			noticeBinaryList.add(FilenameUtils.getName(binaryName));
-			if(binaryName.indexOf("/") > -1) {
+			if (binaryName.indexOf("/") > -1) {
 				noticeBinaryList.add(binaryName.substring(binaryName.lastIndexOf("/")));
 				noticeBinaryList.add(binaryName.substring(binaryName.lastIndexOf("/") + 1));
 			} else {
-				if(!noticeBinaryList.contains( ("/" + binaryName) )) {
+				if (!noticeBinaryList.contains( ("/" + binaryName) )) {
 					noticeBinaryList.add("/" + binaryName);
 				}
 			}
@@ -1825,8 +1825,8 @@ public class CommonFunction extends CoTopComponent {
 		for (Element em : binaryEmList) {
 			String _fileStr = (em.html()).replaceAll("<br>", "\n").replaceAll("<br />", "\n").replaceAll("<br/>", "\n").replaceAll("\r\n", "\n");
 			
-			for(String s : _fileStr.split("\n", -1)) {
-				if(isEmpty(s)) {
+			for (String s : _fileStr.split("\n", -1)) {
+				if (isEmpty(s)) {
 					continue;
 				}
 				
@@ -1843,7 +1843,7 @@ public class CommonFunction extends CoTopComponent {
 				noticeBinaryList.add("/" + s);
 				
 				// path 정보를 무시하고 binary 파일명만 추가 (binary file은 사전에 중복 제거되어 유니크하다)
-				if(!s.endsWith("/") && s.indexOf("/") > -1) {
+				if (!s.endsWith("/") && s.indexOf("/") > -1) {
 					noticeBinaryList.add(s.substring(s.lastIndexOf("/")));
 					noticeBinaryList.add(s.substring(s.lastIndexOf("/") + 1));
 				}
@@ -1861,15 +1861,15 @@ public class CommonFunction extends CoTopComponent {
 		
 		Elements fileList = doc.getElementsByTag("file-name");
 		
-		for(Element el : fileList) {
-			if(el.childNodeSize() == 0) {
+		for (Element el : fileList) {
+			if (el.childNodeSize() == 0) {
 				continue;
 			}
 			Node node = el.childNode(0);
             String nodeValue = node.toString();
             
             nodeValue = StringUtil.avoidNull(nodeValue, "").replace("\n", "");
-            if(StringUtil.isEmpty(nodeValue)) {
+            if (StringUtil.isEmpty(nodeValue)) {
             	continue;
             }
             noticeBinaryList.add(nodeValue);
@@ -1881,11 +1881,11 @@ public class CommonFunction extends CoTopComponent {
             }
             
             // path 정보를 무시하고 binary 파일명만 추가 (binary file은 사전에 중복 제거되어 유니크하다)
-            if(nodeValue.indexOf("/") > -1) {
+            if (nodeValue.indexOf("/") > -1) {
                 noticeBinaryList.add(nodeValue.substring(nodeValue.lastIndexOf("/")));
                 noticeBinaryList.add(nodeValue.substring(nodeValue.lastIndexOf("/") + 1));
             } else {
-                if(!noticeBinaryList.contains( ("/" + nodeValue) )) {
+                if (!noticeBinaryList.contains( ("/" + nodeValue) )) {
                     noticeBinaryList.add("/" + nodeValue);
                 }
             }
@@ -1912,11 +1912,11 @@ public class CommonFunction extends CoTopComponent {
 //            }
 //            
 //            // path 정보를 무시하고 binary 파일명만 추가 (binary file은 사전에 중복 제거되어 유니크하다)
-//            if(nodeValue.indexOf("/") > -1) {
+//            if (nodeValue.indexOf("/") > -1) {
 //                noticeBinaryList.add(nodeValue.substring(nodeValue.lastIndexOf("/")));
 //                noticeBinaryList.add(nodeValue.substring(nodeValue.lastIndexOf("/") + 1));
 //            } else {
-//                if(!noticeBinaryList.contains( ("/" + nodeValue) )) {
+//                if (!noticeBinaryList.contains( ("/" + nodeValue) )) {
 //                    noticeBinaryList.add("/" + nodeValue);
 //                }
 //            }
@@ -1943,18 +1943,18 @@ public class CommonFunction extends CoTopComponent {
 	public static String checkObligationSelectedLicense(List<OssComponentsLicense> licenseList) {
 		String rtnVal = "";
 		
-		if(licenseList != null) {
-			for(OssComponentsLicense bean : licenseList) {
-				if(!CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+		if (licenseList != null) {
+			for (OssComponentsLicense bean : licenseList) {
+				if (!CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 					// 확인 가능한 라이선스 중에서만 obligation 대상으로 한다.
-					if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(bean.getLicenseName()).toUpperCase())) {
+					if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(bean.getLicenseName()).toUpperCase())) {
 						LicenseMaster license = CoCodeManager.LICENSE_INFO_UPPER.get(bean.getLicenseName().toUpperCase());
 						
-						if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNeedsCheckYn()))) {
+						if (CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNeedsCheckYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK;
-						} else if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationDisclosingSrcYn()))) {
+						} else if (CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationDisclosingSrcYn()))) {
 							rtnVal = CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE;
-						} else if(isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNotificationYn()))) {
+						} else if (isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNotificationYn()))) {
 							rtnVal = CoConstDef.CD_DTL_OBLIGATION_NOTICE;
 						}
 					}
@@ -1968,18 +1968,18 @@ public class CommonFunction extends CoTopComponent {
 	public static String checkObligationSelectedLicense2(List<ProjectIdentification> licenseList) {
 		String rtnVal = "";
 		
-		if(licenseList != null) {
-			for(ProjectIdentification bean : licenseList) {
-				if(!CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+		if (licenseList != null) {
+			for (ProjectIdentification bean : licenseList) {
+				if (!CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 					// 확인 가능한 라이선스 중에서만 obligation 대상으로 한다.
-					if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(bean.getLicenseName()).toUpperCase())) {
+					if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(bean.getLicenseName()).toUpperCase())) {
 						LicenseMaster license = CoCodeManager.LICENSE_INFO_UPPER.get(bean.getLicenseName().toUpperCase());
 						
-						if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNeedsCheckYn()))) {
+						if (CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNeedsCheckYn()))) {
 							return CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK;
-						} else if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationDisclosingSrcYn()))) {
+						} else if (CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationDisclosingSrcYn()))) {
 							rtnVal = CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE;
-						} else if(isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNotificationYn()))) {
+						} else if (isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNotificationYn()))) {
 							rtnVal = CoConstDef.CD_DTL_OBLIGATION_NOTICE;
 						}
 					}
@@ -1991,7 +1991,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	public static String convertUrlLinkFormat(String url) {
-//		if(!isEmpty(url) && url.startsWith("www")) {
+//		if (!isEmpty(url) && url.startsWith("www")) {
 //			return "http://" + url;
 //		}
 		
@@ -2001,25 +2001,25 @@ public class CommonFunction extends CoTopComponent {
 	public static String makeOssTypeStr(String ossType) {
 		String rtn = "";
 		
-		if(!isEmpty(ossType)) {
+		if (!isEmpty(ossType)) {
 			ossType = ossType.toUpperCase();
 			
-			if(ossType.indexOf("M") > -1) {
-				if(!isEmpty(rtn)) {
+			if (ossType.indexOf("M") > -1) {
+				if (!isEmpty(rtn)) {
 					rtn += ", ";
 				}
 				rtn += "Multi";
 			}
 			
-			if(ossType.indexOf("D") > -1) {
-				if(!isEmpty(rtn)) {
+			if (ossType.indexOf("D") > -1) {
+				if (!isEmpty(rtn)) {
 					rtn += ", ";
 				}
 				rtn += "Dual";
 			}
 			
-			if(ossType.indexOf("V") > -1) {
-				if(!isEmpty(rtn)) {
+			if (ossType.indexOf("V") > -1) {
+				if (!isEmpty(rtn)) {
 					rtn += ", ";
 				}
 				rtn += "v-Diff";
@@ -2032,7 +2032,7 @@ public class CommonFunction extends CoTopComponent {
 	public static String getMsApplicationContentType(String fileName) {
 		String type = "";
 		
-		if(!isEmpty(fileName)) {
+		if (!isEmpty(fileName)) {
 			type = "application/octet-stream";
 		}
 		
@@ -2050,10 +2050,10 @@ public class CommonFunction extends CoTopComponent {
 	public static boolean isIgnoreLicense(String licenseName) {
 		boolean result = false;
 		
-		if(!isEmpty(CoCodeManager.CD_ROLE_OUT_LICENSE)) {
-			for(String license : avoidNull(licenseName).split(",")) {
-				for(String s : CoCodeManager.CD_ROLE_OUT_LICENSE.split("\\|")) {
-					if(s.trim().equalsIgnoreCase(license)) {
+		if (!isEmpty(CoCodeManager.CD_ROLE_OUT_LICENSE)) {
+			for (String license : avoidNull(licenseName).split(",")) {
+				for (String s : CoCodeManager.CD_ROLE_OUT_LICENSE.split("\\|")) {
+					if (s.trim().equalsIgnoreCase(license)) {
 						result = true;
 						break;
 					}
@@ -2062,11 +2062,11 @@ public class CommonFunction extends CoTopComponent {
 		}
 		
 		// license type이 NA가 아닌 라이선스가 포함되어 있거나, Unconfirmed license인 경우 false
-		if(result) {
-			for(String license : avoidNull(licenseName).split(",")) {
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(license.toUpperCase())) {
+		if (result) {
+			for (String license : avoidNull(licenseName).split(",")) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(license.toUpperCase())) {
 					LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(license.toUpperCase());
-					if(!"NA".equalsIgnoreCase(licenseMaster.getLicenseType())) {
+					if (!"NA".equalsIgnoreCase(licenseMaster.getLicenseType())) {
 						return false;
 					}
 				} else {
@@ -2079,7 +2079,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String htmlEscape(String s) {
-		if(!isEmpty(s)) {
+		if (!isEmpty(s)) {
 			try {
 				return CommonFunction.lineReplaceToBR(HtmlUtils.htmlEscape(brReplaceToLine(s)));
 			} catch (Exception e) {
@@ -2091,7 +2091,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static boolean isIgnoreLicense(List<OssComponentsLicense> list) {
-		if(list != null && !list.isEmpty()) {
+		if (list != null && !list.isEmpty()) {
 			return isIgnoreLicense(list.get(0));
 		}
 		
@@ -2124,43 +2124,43 @@ public class CommonFunction extends CoTopComponent {
 		Object sessionObj = getSessionObject(sessionKey);
 		Object sessionObjReport = null;
 		
-		if(!isEmpty(reportkey)) {
+		if (!isEmpty(reportkey)) {
 			sessionObjReport = getSessionObject(reportkey);
 		}
 		
-		if( (sessionObj != null || sessionObjReport != null) && ossComponents != null) {
+		if ( (sessionObj != null || sessionObjReport != null) && ossComponents != null) {
 			// session에 merge할 정보가 존재하면, 사용자 편집 정보와, session 정보를 모두  Map 형태로 변환하여 상위 grid정보를 기준으로 merge 한다.
 			Map<String, List<ProjectIdentification>> subGridInfo = new HashMap<>();
 			Map<String, Object> sessionMap = null;
 			Map<String, Object> sessionMapReport = null;
 			
-			if(sessionObj != null) {
+			if (sessionObj != null) {
 				sessionMap = (Map<String, Object>) sessionObj;
 			}
 			
-			if(sessionObjReport != null) {
+			if (sessionObjReport != null) {
 				sessionMapReport = (Map<String, Object>) sessionObjReport;
 			}
 			
-			if( (sessionMap != null && sessionMap.containsKey("subData"))  || (sessionMapReport != null && sessionMapReport.containsKey("subData"))) {
+			if ( (sessionMap != null && sessionMap.containsKey("subData"))  || (sessionMapReport != null && sessionMapReport.containsKey("subData"))) {
 				Map<String, List<ProjectIdentification>> subGridSessionInfo = null;
 				Map<String, List<ProjectIdentification>> subGridSessionInfoReport = null;
 				
-				if(sessionMap != null) {
+				if (sessionMap != null) {
 					subGridSessionInfo = (Map<String, List<ProjectIdentification>>) sessionMap.get("subData");
 				}
 				
-				if(sessionMapReport != null) {
+				if (sessionMapReport != null) {
 					subGridSessionInfoReport = (Map<String, List<ProjectIdentification>>) sessionMapReport.get("subData");
 				}
 				
-				if(ossComponentsLicense != null) {
-					for(List<ProjectIdentification> subTables : ossComponentsLicense) {
+				if (ossComponentsLicense != null) {
+					for (List<ProjectIdentification> subTables : ossComponentsLicense) {
 						String _key = subTables.get(0).getComponentId();
 						
 						// 최초저장이면 component id는 설정되어 있지 않음
 						// 이런경우는 grid id에서 "-" 앞자리를 키로 가져야함
-						if(isEmpty(_key)) {
+						if (isEmpty(_key)) {
 							_key = subTables.get(0).getGridId().split("-")[0];
 						}
 						
@@ -2168,15 +2168,15 @@ public class CommonFunction extends CoTopComponent {
 					}
 				}
 
-				if(subGridSessionInfo != null && !subGridSessionInfo.isEmpty()) {
-					for(ProjectIdentification bean : ossComponents) {
+				if (subGridSessionInfo != null && !subGridSessionInfo.isEmpty()) {
+					for (ProjectIdentification bean : ossComponents) {
 						// subGrid key에 주의 해야함 grid id로 매핑
-						if(!duplicateCheckList.contains(bean.getGridId()) && !subGridInfo.containsKey(bean.getGridId()) && subGridSessionInfo.containsKey(bean.getGridId())) {
+						if (!duplicateCheckList.contains(bean.getGridId()) && !subGridInfo.containsKey(bean.getGridId()) && subGridSessionInfo.containsKey(bean.getGridId())) {
 							duplicateCheckList.add(bean.getGridId());
 							
 							// multi => single로 변경한 경우 대응
 							// subGridInfo 에 해당 grid id 로 값이 없다는 것인 single을 의미한다.
-							if(CoConstDef.LICENSE_DIV_SINGLE.equals(bean.getLicenseDiv()) && subGridSessionInfo.get(bean.getGridId()) != null && subGridSessionInfo.get(bean.getGridId()).size() > 1) {
+							if (CoConstDef.LICENSE_DIV_SINGLE.equals(bean.getLicenseDiv()) && subGridSessionInfo.get(bean.getGridId()) != null && subGridSessionInfo.get(bean.getGridId()).size() > 1) {
 								
 							} else {
 								ossComponentsLicense.add(subGridSessionInfo.get(bean.getGridId()));
@@ -2185,10 +2185,10 @@ public class CommonFunction extends CoTopComponent {
 					}					
 				}
 				
-				if(subGridSessionInfoReport != null && !subGridSessionInfoReport.isEmpty()) {
-					for(ProjectIdentification bean : ossComponents) {
+				if (subGridSessionInfoReport != null && !subGridSessionInfoReport.isEmpty()) {
+					for (ProjectIdentification bean : ossComponents) {
 						// subGrid key에 주의 해야함 grid id로 매핑
-						if(!duplicateCheckList.contains(bean.getGridId()) && !subGridInfo.containsKey(bean.getGridId()) && subGridSessionInfoReport.containsKey(bean.getGridId())) {
+						if (!duplicateCheckList.contains(bean.getGridId()) && !subGridInfo.containsKey(bean.getGridId()) && subGridSessionInfoReport.containsKey(bean.getGridId())) {
 							duplicateCheckList.add(bean.getGridId());
 							ossComponentsLicense.add(subGridSessionInfoReport.get(bean.getGridId()));
 						}
@@ -2203,7 +2203,7 @@ public class CommonFunction extends CoTopComponent {
 	public static String makeSessionReportKey(String loginUserName, String code, String prjId) {
 		String reportKey = null;
 		
-		if(!isEmpty(code)) {
+		if (!isEmpty(code)) {
 			switch (code) {
 				case CoConstDef.CD_DTL_COMPONENT_ID_SRC:
 					reportKey = CoConstDef.SESSION_KEY_UPLOAD_REPORT_PROJECT_SRC;
@@ -2228,7 +2228,7 @@ public class CommonFunction extends CoTopComponent {
 			}
 		}
 		
-		if(!isEmpty(reportKey)) {
+		if (!isEmpty(reportKey)) {
 			return makeSessionKey(loginUserName(), reportKey, prjId);
 		}
 		
@@ -2244,7 +2244,7 @@ public class CommonFunction extends CoTopComponent {
 		// 2017-11-13 yuns 라이선스 ID 및 이름은 DB를 기준으로 재설정함
 		String licenseName = comLicense.getLicenseName();
 		
-		if(!isEmpty(licenseName)) {
+		if (!isEmpty(licenseName)) {
 			licenseName = licenseName.replaceAll("\\<.*\\>", ""); // 시점이 맞지않아서 licenseName에 valid Message가 포함되어 저장할 경우 제거 함.
 		}
 		
@@ -2257,7 +2257,7 @@ public class CommonFunction extends CoTopComponent {
 		license.setCopyrightText(comLicense.getCopyrightText());
 		
 		//TODO - License ExcludeYn값에 대해서 재점검해야 함. 
-		if(CoConstDef.LICENSE_DIV_SINGLE.equals(licenseDiv)) {
+		if (CoConstDef.LICENSE_DIV_SINGLE.equals(licenseDiv)) {
 			license.setExcludeYn(CoConstDef.FLAG_NO);
 		}else {
 			license.setExcludeYn(avoidNull(comLicense.getExcludeYn(), CoConstDef.FLAG_NO));
@@ -2272,7 +2272,7 @@ public class CommonFunction extends CoTopComponent {
 		boolean hasLicense = false;
 		List<String> licenseNameList = new ArrayList<String>();
 		
-		for(OssLicense bean : list) {
+		for (OssLicense bean : list) {
 			ProjectIdentification liBean = new ProjectIdentification();
 			liBean.setLicenseId(bean.getLicenseId());
 			liBean.setOssLicenseComb(bean.getOssLicenseComb());
@@ -2281,16 +2281,16 @@ public class CommonFunction extends CoTopComponent {
 			liBean.setComponentId(selectedLicenseBean.getComponentId());
 			liBean.setGridId(selectedLicenseBean.getGridId());
 			
-			if(bean.getLicenseName().toUpperCase().trim().equals(selectedLicenseName.toUpperCase().trim())) {
+			if (bean.getLicenseName().toUpperCase().trim().equals(selectedLicenseName.toUpperCase().trim())) {
 				boolean isDup = false;
 				
-				for(String licenseName : licenseNameList){
-					if(licenseName.toUpperCase().trim().equals(bean.getLicenseName().toUpperCase().trim())){
+				for (String licenseName : licenseNameList){
+					if (licenseName.toUpperCase().trim().equals(bean.getLicenseName().toUpperCase().trim())){
 						isDup = true;
 					}
 				}
 				
-				if(isDup){
+				if (isDup){
 					liBean.setExcludeYn(CoConstDef.FLAG_YES);
 				}else{
 					liBean.setExcludeYn(CoConstDef.FLAG_NO);
@@ -2305,7 +2305,7 @@ public class CommonFunction extends CoTopComponent {
 			licenseList.add(liBean);
 		}
 		
-		if(!hasLicense) {
+		if (!hasLicense) {
 			selectedLicenseBean.setOssLicenseComb("OR");
 			licenseList.add(selectedLicenseBean);
 		}
@@ -2314,12 +2314,12 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static List<ProjectIdentification> reMakeLicenseComponentListMultiToSingle(List<ProjectIdentification> list) {
-		if(list != null && !list.isEmpty()) {
+		if (list != null && !list.isEmpty()) {
 			List<ProjectIdentification> newLicenseList = new ArrayList<>();
 			
-			for(ProjectIdentification bean : list) {
-				if(!CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
-					if(!isEmpty(bean.getOssLicenseComb())) {
+			for (ProjectIdentification bean : list) {
+				if (!CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+					if (!isEmpty(bean.getOssLicenseComb())) {
 						bean.setOssLicenseComb("");
 					}
 					
@@ -2344,7 +2344,7 @@ public class CommonFunction extends CoTopComponent {
 			    String noticeFileName = noticeFile.getLogiNm();
 			    String fullName = noticeFile.getLogiPath() + "/" + noticeFileName;
 			    
-			    if("xml".equalsIgnoreCase(FilenameUtils.getExtension(noticeFileName))) {
+			    if ("xml".equalsIgnoreCase(FilenameUtils.getExtension(noticeFileName))) {
 			        noticeBinaryList = CommonFunction.getAndroidNoticeBinaryXmlList(fullName);
 			    } else {
     				noticeBinaryList = CommonFunction.getAndroidNoticeBinaryList(FileUtils.readFileToString(new File(fullName)));
@@ -2417,15 +2417,15 @@ public class CommonFunction extends CoTopComponent {
 			int idxTlsh = -1;
 			int idxChecksum = -1;
 			
-			for(String s : resultFileContents) {
-				if(isFirst) {
+			for (String s : resultFileContents) {
+				if (isFirst) {
 					isFirst = false;
 					
-					if(!isEmpty(s)) {
+					if (!isEmpty(s)) {
 						String[] resultCols = s.split("\t", -1);
 						int idx = 0;
 						
-						for(String idxStr : resultCols) {
+						for (String idxStr : resultCols) {
 							idxStr = avoidNull(idxStr).trim().toUpperCase();
 							
 							switch (idxStr) {
@@ -2472,18 +2472,18 @@ public class CommonFunction extends CoTopComponent {
 					continue;
 				}
 				
-				if(isEmpty(s)) {
+				if (isEmpty(s)) {
 					continue;
 				}
 				
-				if(avoidNull(s).startsWith("<Removed>")) {
+				if (avoidNull(s).startsWith("<Removed>")) {
 					log.debug("Removed : " + s);
 				} else {
 					//0 binary , 1 directory, 5 license
-					if(idxBinaryName > -1){
+					if (idxBinaryName > -1){
 						String[] resultCols = s.split("\t", -1);
 						
-						if(!isEmpty(resultCols[idxBinaryName])) {
+						if (!isEmpty(resultCols[idxBinaryName])) {
 							/*
 							0:Binary/Library file
 							1:Directory
@@ -2501,41 +2501,41 @@ public class CommonFunction extends CoTopComponent {
 							addComponent.setBinaryName(resultCols[idxBinaryName]);
 							addComponent.setFilePath(resultCols[idxBinaryName]); // binary name의 원본 정보를 등록한다.
 							
-							if(idxDirectory > -1 && resultCols.length >= idxDirectory +1) {
+							if (idxDirectory > -1 && resultCols.length >= idxDirectory +1) {
 								addComponent.setSourceCodePath(resultCols[idxDirectory]);
 							}
 							
-							if(idxNoticeHtml > -1 && resultCols.length >= idxNoticeHtml +1) {
+							if (idxNoticeHtml > -1 && resultCols.length >= idxNoticeHtml +1) {
 								addComponent.setBinaryNotice(resultCols[idxNoticeHtml]);
 							}
 							
-							if(idxOssName > -1 && resultCols.length >= idxOssName +1) {
+							if (idxOssName > -1 && resultCols.length >= idxOssName +1) {
 								addComponent.setOssName(resultCols[idxOssName]);
 							}
 							
-							if(idxOssVersion > -1 && resultCols.length >= idxOssVersion +1) {
+							if (idxOssVersion > -1 && resultCols.length >= idxOssVersion +1) {
 								addComponent.setOssVersion(resultCols[idxOssVersion]);
 							}
 							
-							if(idxLicense > -1 && resultCols.length >= idxLicense +1) {
+							if (idxLicense > -1 && resultCols.length >= idxLicense +1) {
 								OssComponentsLicense license = new OssComponentsLicense();
 								license.setLicenseName(resultCols[idxLicense]);
 								addComponent.addOssComponentsLicense(license);
 							}
 							
-							if(idxTlsh> -1 && resultCols.length >= idxTlsh +1) {
+							if (idxTlsh> -1 && resultCols.length >= idxTlsh +1) {
 								String _tlsh = avoidNull(resultCols[idxTlsh]);
-								if("-".equals(_tlsh)) {
+								if ("-".equals(_tlsh)) {
 									_tlsh = "0";
 								}
 								addComponent.setTlsh(_tlsh);
 							}
 							
-							if(idxChecksum > -1 && resultCols.length >= idxChecksum +1) {
+							if (idxChecksum > -1 && resultCols.length >= idxChecksum +1) {
 								addComponent.setCheckSum(resultCols[idxChecksum]);
 							}
 							
-							if(!existsBinaryName.contains(resultCols[idxBinaryName])) {
+							if (!existsBinaryName.contains(resultCols[idxBinaryName])) {
 								addCheckList.add(addComponent);
 							}
 							
@@ -2556,7 +2556,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	public static String getLicenseUrlByName(String licenseName) {
-		if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(licenseName).toUpperCase())) {
+		if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(licenseName).toUpperCase())) {
 			return avoidNull(CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(licenseName).toUpperCase()).getWebpage());
 		}
 		
@@ -2566,10 +2566,10 @@ public class CommonFunction extends CoTopComponent {
 	public static String getSelectedLicenseString(List<ProjectIdentification> list) {
 		String rtn = "";
 		
-		if(list != null) {
-			for(ProjectIdentification license : list) {
-				if(!CoConstDef.FLAG_YES.equals(license.getExcludeYn())) {
-					if(!isEmpty(rtn)) {
+		if (list != null) {
+			for (ProjectIdentification license : list) {
+				if (!CoConstDef.FLAG_YES.equals(license.getExcludeYn())) {
+					if (!isEmpty(rtn)) {
 						rtn += ",";
 					}
 					
@@ -2591,7 +2591,7 @@ public class CommonFunction extends CoTopComponent {
                 Object property1 = propUtils.getProperty(oldObject, propertyName);
                 Object property2 = propUtils.getProperty(newObject, propertyName);
                 
-                if(property1 == null) {
+                if (property1 == null) {
                 	continue;
                 }
                 
@@ -2618,7 +2618,7 @@ public class CommonFunction extends CoTopComponent {
                 Object property1 = propUtils.getProperty(oldObject, propertyName);
                 Object property2 = propUtils.getProperty(newObject, propertyName);
                 
-                if(property1 == null) {
+                if (property1 == null) {
                 	continue;
                 }
                 
@@ -2645,7 +2645,7 @@ public class CommonFunction extends CoTopComponent {
                 Object property1 = propUtils.getProperty(oldObject, propertyName);
                 Object property2 = propUtils.getProperty(newObject, propertyName);
                 
-                if(property1 == null) {
+                if (property1 == null) {
                 	continue;
                 }
                 
@@ -2663,10 +2663,10 @@ public class CommonFunction extends CoTopComponent {
     }
 	
 	public static boolean existsLicenseName(List<ProjectIdentification> list) {
-		if(list != null) {
-			for(ProjectIdentification bean : list) {
+		if (list != null) {
+			for (ProjectIdentification bean : list) {
 				// license detail 아이콘 표시 여부를 위해 여기서 license id를 검증한다.
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(bean.getLicenseName().toUpperCase().trim()))) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(bean.getLicenseName().toUpperCase().trim()))) {
 					return true;
 				}
 			}
@@ -2676,11 +2676,11 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	public static String makeLicenseInternalUrl(LicenseMaster licenseMaster, boolean distributionFlag) {
-		if(licenseMaster != null) {
+		if (licenseMaster != null) {
 			String filePath = appEnv.getProperty("internal.url.dir.path");
 			String licenseName = !isEmpty(licenseMaster.getShortIdentifier()) ? licenseMaster.getShortIdentifier() : !isEmpty(licenseMaster.getLicenseNameTemp()) ? licenseMaster.getLicenseNameTemp() : licenseMaster.getLicenseName();
 			
-			if(!isEmpty(licenseName)) {
+			if (!isEmpty(licenseName)) {
 				String fileName = licenseName.replaceAll(" ", "_").replaceAll("/", "_").replaceAll("\"", "&#34;") + ".html";
 				boolean DEFAULT_URL_FLAG = !CoConstDef.FLAG_YES.equals(CoCodeManager.getCodeExpString(CoConstDef.CD_SYSTEM_SETTING, CoConstDef.CD_NOTICE_INTERNAL_URL));
 				if (DEFAULT_URL_FLAG) {
@@ -2703,7 +2703,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String makeHtmlLinkTagWithText(String s) {
-		if(!isEmpty(s)) {
+		if (!isEmpty(s)) {
 			  /* 아래과 같이 사용하여되 되지만 만약 작성자가 직접 태그를 이용하여
 			  * 링크를 거는경우 링크가 이상하게 잡히는 경우를 막기위해
 			  * < 값은 자동링크생성에서 제외하였습니다.
@@ -2723,19 +2723,19 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String checkLicenseUserGuide(List<ProjectIdentification> componentLicenseList) {
-		if(componentLicenseList != null) {
+		if (componentLicenseList != null) {
 			String guideStr = "";
 			
-			for(ProjectIdentification bean : componentLicenseList) {
-				if(CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+			for (ProjectIdentification bean : componentLicenseList) {
+				if (CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 					continue;
 				}
 				
-				if(CoCodeManager.LICENSE_USER_GUIDE_LIST.contains(avoidNull(bean.getLicenseName()).toUpperCase())) {
+				if (CoCodeManager.LICENSE_USER_GUIDE_LIST.contains(avoidNull(bean.getLicenseName()).toUpperCase())) {
 					LicenseMaster license = CoCodeManager.LICENSE_INFO_UPPER.get(bean.getLicenseName().trim().toUpperCase());
 					
-					if(license != null && !isEmpty(license.getDescription())) {
-						if(!isEmpty(guideStr)) {
+					if (license != null && !isEmpty(license.getDescription())) {
+						if (!isEmpty(guideStr)) {
 							guideStr += "<br>";
 						}
 						
@@ -2745,7 +2745,7 @@ public class CommonFunction extends CoTopComponent {
 				}
 			}
 			
-			if(!isEmpty(guideStr)) {
+			if (!isEmpty(guideStr)) {
 				return CommonFunction.makeHtmlLinkTagWithText(CommonFunction.lineReplaceToBR(guideStr));
 			}
 		}
@@ -2760,13 +2760,13 @@ public class CommonFunction extends CoTopComponent {
 	public static String makeValidMsgTohtml(Map<String, String> validMessageMap) {
 		String rtnStr = "<b>Please check your entry and try again.</b><br />";
 		
-		if(validMessageMap != null) {
-			for(String key : validMessageMap.keySet()) {
-				if("isValid".equalsIgnoreCase(key)) {
+		if (validMessageMap != null) {
+			for (String key : validMessageMap.keySet()) {
+				if ("isValid".equalsIgnoreCase(key)) {
 					continue;
 				}
 				String msg = removeLineSeparator(validMessageMap.get(key));
-				if(key.indexOf(".") > -1) {
+				if (key.indexOf(".") > -1) {
 					rtnStr += "<br />" + key.substring(0, key.indexOf(".")) + " : " + msg;
 				} else {
 					rtnStr += "<br />" + key + " : " + msg;
@@ -2781,23 +2781,23 @@ public class CommonFunction extends CoTopComponent {
 		List<String> rtnStrList = new ArrayList<>();
 		String rtnStr = getMessage("msg.oss.check.ossName.format");
 		
-		if(validMessageMap != null) {
-			for(String key : validMessageMap.keySet()) {
-				if(rtnStrList.size() == 10) {
+		if (validMessageMap != null) {
+			for (String key : validMessageMap.keySet()) {
+				if (rtnStrList.size() == 10) {
 					break;
 				}
 				
-				for(ProjectIdentification pi : ossComponents) {
-					if(pi.getGridId().equals(key.substring(key.indexOf(".") + 1, key.length()))) {
+				for (ProjectIdentification pi : ossComponents) {
+					if (pi.getGridId().equals(key.substring(key.indexOf(".") + 1, key.length()))) {
 						String replaceString = "";
-						if(pi.getOssName().contains(",")) {
+						if (pi.getOssName().contains(",")) {
 							replaceString = pi.getOssName().replace(",", "&#44;");
-						}else if(pi.getOssName().contains("<")) {
+						}else if (pi.getOssName().contains("<")) {
 							replaceString = pi.getOssName().replace("<", "&#60;");
-						}else if(pi.getOssName().contains(">")) {
+						}else if (pi.getOssName().contains(">")) {
 							replaceString = pi.getOssName().replace(">", "&#62;");
 						}
-						if(!isEmpty(replaceString) && !rtnStrList.contains(replaceString)) {
+						if (!isEmpty(replaceString) && !rtnStrList.contains(replaceString)) {
 							rtnStrList.add(replaceString);
 							rtnStr += "<br />" + "- " + replaceString;
 							break;
@@ -2813,15 +2813,15 @@ public class CommonFunction extends CoTopComponent {
 	public static Boolean booleanOssNameFormatForValidMsg(Map<String, String> validMessageMap) {
 		boolean validFlag = false;
 		
-		if(validMessageMap != null) {
-			for(String key : validMessageMap.keySet()) {
-				if("isValid".equalsIgnoreCase(key)) {
+		if (validMessageMap != null) {
+			for (String key : validMessageMap.keySet()) {
+				if ("isValid".equalsIgnoreCase(key)) {
 					continue;
 				}
 				
 				String msg = removeLineSeparator(validMessageMap.get(key));
-				if(key.indexOf(".") > -1) {
-					if(msg.contains("Formatting") && key.substring(0, key.indexOf(".")).equals("ossName")) {
+				if (key.indexOf(".") > -1) {
+					if (msg.contains("Formatting") && key.substring(0, key.indexOf(".")).equals("ossName")) {
 						validFlag = true;
 						break;
 					}
@@ -2847,13 +2847,13 @@ public class CommonFunction extends CoTopComponent {
 		Map<String, List<ProjectIdentification>> licenseMap = new HashMap<>();
 		boolean isChanged = false;
 		
-		if(ossComponents != null && ossComponentsLicense != null) {
-			if(ossComponentsLicense != null && !ossComponentsLicense.isEmpty()) {
-				for(List<ProjectIdentification> list : ossComponentsLicense) {
-					for(ProjectIdentification licenseBean : list) {
+		if (ossComponents != null && ossComponentsLicense != null) {
+			if (ossComponentsLicense != null && !ossComponentsLicense.isEmpty()) {
+				for (List<ProjectIdentification> list : ossComponentsLicense) {
+					for (ProjectIdentification licenseBean : list) {
 						String componentId = isEmpty(licenseBean.getComponentId()) ? licenseBean.getGridId().split("-")[0] : licenseBean.getComponentId();
 						
-						if(!isEmpty(componentId)) {
+						if (!isEmpty(componentId)) {
 							licenseMap.put(componentId, list);
 							
 							break;
@@ -2862,27 +2862,27 @@ public class CommonFunction extends CoTopComponent {
 				}
 			}
 			
-			for(ProjectIdentification bean : ossComponents) {
-				//if(!"-".equals(bean.getOssName()) && !isEmpty(bean.getOssName()) && !StringUtil.contains(bean.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX) && !isEmpty(bean.getComponentId())) {
-				if(!"-".equals(bean.getOssName()) && !isEmpty(bean.getOssName()) ) {
+			for (ProjectIdentification bean : ossComponents) {
+				//if (!"-".equals(bean.getOssName()) && !isEmpty(bean.getOssName()) && !StringUtil.contains(bean.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX) && !isEmpty(bean.getComponentId())) {
+				if (!"-".equals(bean.getOssName()) && !isEmpty(bean.getOssName()) ) {
 					String key = bean.getOssName().toUpperCase().trim() + "_" + avoidNull(bean.getOssVersion()).trim().toUpperCase();
 					String componentId = isEmpty(bean.getComponentId()) ? bean.getGridId().split("-")[0] : bean.getComponentId();
 					
-					if(CoCodeManager.OSS_INFO_UPPER.containsKey(key)) {
+					if (CoCodeManager.OSS_INFO_UPPER.containsKey(key)) {
 						OssMaster ossMaster = CoCodeManager.OSS_INFO_UPPER.get(key);
 						
-						if(CoConstDef.LICENSE_DIV_MULTI.equals(ossMaster.getLicenseDiv())) {
+						if (CoConstDef.LICENSE_DIV_MULTI.equals(ossMaster.getLicenseDiv())) {
 							//boolean isDiff = false;
 							List<ProjectIdentification> licenseList = new ArrayList<>();
 							
-							if(licenseMap.containsKey(componentId)) {
+							if (licenseMap.containsKey(componentId)) {
 								licenseList = licenseMap.get(componentId);
 							}
 							
 							// licnese list를 찾는다. 지금은 사용하지 않으나, multi => single로 변경한 경우 사용예정
 							// 해당 license 정보를 제외한 list를 만든다.
 							
-							if(CoConstDef.LICENSE_DIV_SINGLE.equals(avoidNull(bean.getLicenseDiv(), CoConstDef.LICENSE_DIV_SINGLE))) {
+							if (CoConstDef.LICENSE_DIV_SINGLE.equals(avoidNull(bean.getLicenseDiv(), CoConstDef.LICENSE_DIV_SINGLE))) {
 								// oss master는 multi license이고, component는 single license로 정의된 경우
 								// multi license의 첫번째 license를 선택한 상태로 적용한다.
 								// oss master에 해당 license가 없는 경우 마지막에 or 조건으로 추가한다.
@@ -2890,7 +2890,7 @@ public class CommonFunction extends CoTopComponent {
 								ProjectIdentification paramBean = bean;
 								// 새로만든 license list를 추가한다.						
 								
-								if(StringUtil.contains(bean.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
+								if (StringUtil.contains(bean.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
 									licenseMap.put(bean.getGridId(), CommonFunction.reMakeLicenseComponentList(ossMaster.getOssLicenses(), paramBean));
 								}else{
 									licenseMap.replace(componentId, CommonFunction.reMakeLicenseComponentList(ossMaster.getOssLicenses(), paramBean));
@@ -2899,7 +2899,7 @@ public class CommonFunction extends CoTopComponent {
 								bean.setLicenseDiv(CoConstDef.LICENSE_DIV_MULTI);
 								isChanged = true;
 							}
-						} else if(CoConstDef.LICENSE_DIV_SINGLE.equals(ossMaster.getLicenseDiv()) 
+						} else if (CoConstDef.LICENSE_DIV_SINGLE.equals(ossMaster.getLicenseDiv()) 
 								&& CoConstDef.LICENSE_DIV_MULTI.equals(avoidNull(bean.getLicenseDiv(), CoConstDef.LICENSE_DIV_SINGLE))) {
 							
 						}
@@ -2908,16 +2908,16 @@ public class CommonFunction extends CoTopComponent {
 			}
 		}
 		
-		if(!ossComponentsAddList.isEmpty()) {
+		if (!ossComponentsAddList.isEmpty()) {
 			ossComponents.addAll(ossComponentsAddList);
 		}
 		
 		resultMap.put("mainList", ossComponents);
 		
-		if(isChanged) {
+		if (isChanged) {
 			List<List<ProjectIdentification>> newOssComponentsLicense = new ArrayList<>();
 			
-			for(List<ProjectIdentification> _tmp : licenseMap.values()) {
+			for (List<ProjectIdentification> _tmp : licenseMap.values()) {
 				newOssComponentsLicense.add(_tmp);
 			}
 			
@@ -2932,10 +2932,10 @@ public class CommonFunction extends CoTopComponent {
 	public static String makeSearchQuery(String schKeyword, String field) {
 		StringBuffer sb = new StringBuffer();
 		
-		if(!isEmpty(schKeyword)) {
-			for(String s : schKeyword.split(" ")) {
-				if(!isEmpty(s)) {
-					if(sb.length() > 0) {
+		if (!isEmpty(schKeyword)) {
+			for (String s : schKeyword.split(" ")) {
+				if (!isEmpty(s)) {
+					if (sb.length() > 0) {
 						sb.append(" AND ");
 					}
 					
@@ -2944,7 +2944,7 @@ public class CommonFunction extends CoTopComponent {
 			}
 		}
 		
-		if(sb.length() > 0) {
+		if (sb.length() > 0) {
 			sb.insert(0, " (");
 			sb.append(") ");
 		}
@@ -2953,20 +2953,20 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	public static void setOssDownloadLocation(List<Map<String, Object>> binaryList) {
-		for(Map<String, Object> binaryMap : binaryList) {
+		for (Map<String, Object> binaryMap : binaryList) {
 			String ossName = "";
 			String ossVersion = "";
 			String downloadlocation = "";
 			
-			if(binaryMap.containsKey("ossName")) {
+			if (binaryMap.containsKey("ossName")) {
 				ossName = (String) binaryMap.get("ossName");
 				
-				if(binaryMap.containsKey("ossVersion")) {
+				if (binaryMap.containsKey("ossVersion")) {
 					ossVersion = (String) binaryMap.get("ossVersion");
 				}
 				
 				String key = (ossName + "_" + avoidNull(ossVersion)).toUpperCase();
-				if(CoCodeManager.OSS_INFO_UPPER.containsKey(key)){
+				if (CoCodeManager.OSS_INFO_UPPER.containsKey(key)){
 					downloadlocation = avoidNull(CoCodeManager.OSS_INFO_UPPER.get( (ossName + "_" + avoidNull(ossVersion)).toUpperCase() ).getDownloadLocation());
 				}
 			}
@@ -2976,17 +2976,17 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	public static String getPlatformName(String str) {
-		if(!isEmpty(str)) {
+		if (!isEmpty(str)) {
 			String arr[]  = str.trim().split(" ");
 			
-			if(arr.length > 1) {
+			if (arr.length > 1) {
 				String version = arr[arr.length -1];
 				
-				if(StringUtil.isFormattedString(version, "[\\.0-9]+")) {
+				if (StringUtil.isFormattedString(version, "[\\.0-9]+")) {
 					String _temp = "";
 					
-					for(int i=0; i<arr.length -1; i++) {
-						if(!isEmpty(_temp)) {
+					for (int i=0; i<arr.length -1; i++) {
+						if (!isEmpty(_temp)) {
 							_temp += " ";
 						}
 						
@@ -3002,13 +3002,13 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	public static String getPlatformVersion(String str) {
-		if(!isEmpty(str)) {
+		if (!isEmpty(str)) {
 			String arr[] = str.trim().split(" ");
 			
-			if(arr.length > 1) {
+			if (arr.length > 1) {
 				String version = arr[arr.length -1];
 				
-				if(StringUtil.isFormattedString(version, "[\\.0-9]+")) {
+				if (StringUtil.isFormattedString(version, "[\\.0-9]+")) {
 					return version.trim();
 				}
 			}
@@ -3019,28 +3019,28 @@ public class CommonFunction extends CoTopComponent {
 	
 	@SuppressWarnings("unused")
 	public static String getObligationTypeWithAndLicense(List<OssLicense> andlicenseGroup) {
-		if(andlicenseGroup != null) {
+		if (andlicenseGroup != null) {
 			boolean sourceCode = false;
 			boolean notice = false;
 			boolean needcheck = false;
 			
-			for(OssLicense bean : andlicenseGroup) {
+			for (OssLicense bean : andlicenseGroup) {
 				LicenseMaster license = CoCodeManager.LICENSE_INFO_BY_ID.get(bean.getLicenseId());
 				
-				if(license != null) {
-					if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationDisclosingSrcYn()))) {
+				if (license != null) {
+					if (CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationDisclosingSrcYn()))) {
 						sourceCode = true;
 					}
 					
-					if(CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNotificationYn()))) {
+					if (CoConstDef.FLAG_YES.equals(avoidNull(license.getObligationNotificationYn()))) {
 						notice = true;
 					}
 				}
 			}
 			
-			if(sourceCode) {
+			if (sourceCode) {
 				return CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE;
-			} else if(notice) {
+			} else if (notice) {
 				return CoConstDef.CD_DTL_OBLIGATION_NOTICE;
 			}
 		}
@@ -3052,7 +3052,7 @@ public class CommonFunction extends CoTopComponent {
 	public static List<String> getBinaryListBinBinaryTxt(T2File binaryTextFile) {
 		List<String> binaryList = Lists.newArrayList();
 		
-		if(binaryTextFile != null) {
+		if (binaryTextFile != null) {
 			try {
 				List<String> resultFileContents =FileUtils.readLines(new File(binaryTextFile.getLogiPath() + "/" + binaryTextFile.getLogiNm()), "UTF-8");
 				boolean isFirst = true;
@@ -3061,15 +3061,15 @@ public class CommonFunction extends CoTopComponent {
 				int idxTlsh = -1;
 				int idxChecksum = -1;
 				
-				for(String s : resultFileContents) {
-					if(isFirst) {
+				for (String s : resultFileContents) {
+					if (isFirst) {
 						isFirst = false;
 						
-						if(!isEmpty(s)) {
+						if (!isEmpty(s)) {
 							String[] resultCols = s.split("\t", -1);
 							int idx = 0;
 							
-							for(String idxStr : resultCols) {
+							for (String idxStr : resultCols) {
 								idxStr = avoidNull(idxStr).trim().toUpperCase();
 								
 								switch (idxStr) {
@@ -3096,15 +3096,15 @@ public class CommonFunction extends CoTopComponent {
 						continue;
 					}
 					
-					if(isEmpty(s)) {
+					if (isEmpty(s)) {
 						continue;
 					}
 
 					//0 binary , 1 directory, 5 license
-					if(idxBinaryName > -1){
+					if (idxBinaryName > -1){
 						String[] resultCols = s.split("\t", -1);
 						
-						if(!isEmpty(resultCols[idxBinaryName])) {
+						if (!isEmpty(resultCols[idxBinaryName])) {
 							/*
 							0:Binary/Library file
 							1: checksum
@@ -3126,13 +3126,13 @@ public class CommonFunction extends CoTopComponent {
 	public static String setLicenseRestrictionList(List<ProjectIdentification> componentLicenseList) {
 		String returnStr = "";
 		
-		if(componentLicenseList != null) {
+		if (componentLicenseList != null) {
 			String restrictionStr = "";
 			
-			for(ProjectIdentification bean : componentLicenseList) {
+			for (ProjectIdentification bean : componentLicenseList) {
 				LicenseMaster license = CoCodeManager.LICENSE_INFO_UPPER.get(bean.getLicenseName().trim().toUpperCase());
 				
-				if(license != null && !isEmpty(license.getRestriction()) && !CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+				if (license != null && !isEmpty(license.getRestriction()) && !CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 					restrictionStr += (isEmpty(restrictionStr)?"":",") + license.getRestriction(); 
 				}
 			}
@@ -3142,17 +3142,17 @@ public class CommonFunction extends CoTopComponent {
 			List<String> distinctList = new ArrayList<String>();
 			
 			// String 배열 -> String 리스트
-			for(int i = 0 ; i < restrictionArr.length ; i++){
+			for (int i = 0 ; i < restrictionArr.length ; i++){
 				restrictionList.add(restrictionArr[i]);
 			}
 			// 중복 제거
-            for(String str : restrictionList){
+            for (String str : restrictionList){
                 if (!distinctList.contains(str)) {
                 	distinctList.add(str);
                 }
             }
             
-            for(String str : distinctList){
+            for (String str : distinctList){
             	returnStr += (isEmpty(returnStr)?"":"\n") + CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, str.trim().toUpperCase());
             }
 		}
@@ -3164,17 +3164,17 @@ public class CommonFunction extends CoTopComponent {
 	public static String setLicenseRestrictionList(String restrictionStr) {
 		String returnStr = "";
 		
-		if(!isEmpty(restrictionStr)) {
+		if (!isEmpty(restrictionStr)) {
 			String restrictionArr[] = restrictionStr.split(",");
 			List<String> restrictionList = new ArrayList<>();
 			List<String> distinctList = new ArrayList<String>();
 			
 			// String 배열 -> String 리스트
-			for(int i = 0 ; i < restrictionArr.length ; i++){
+			for (int i = 0 ; i < restrictionArr.length ; i++){
 				restrictionList.add(restrictionArr[i]);
 			}
 			
-            for(String str : restrictionList){
+            for (String str : restrictionList){
             	returnStr += (isEmpty(returnStr)?"":"\n") + CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, str.trim().toUpperCase());
             }
 		}
@@ -3185,13 +3185,13 @@ public class CommonFunction extends CoTopComponent {
 	public static String setLicenseRestrictionListById(String licenseIdStr) {
 		String returnStr = "";
 		
-		if(licenseIdStr != null) {
+		if (licenseIdStr != null) {
 			String restrictionStr = "";
 			String licenseIdArr[] = licenseIdStr.split(",");
 			
-			for(int i = 0 ; i < licenseIdArr.length ; i++) {
+			for (int i = 0 ; i < licenseIdArr.length ; i++) {
 				LicenseMaster license = CoCodeManager.LICENSE_INFO_BY_ID.get(licenseIdArr[i]);
-				if(license != null && !isEmpty(license.getRestriction())) {
+				if (license != null && !isEmpty(license.getRestriction())) {
 					restrictionStr += (isEmpty(restrictionStr)?"":",") + license.getRestriction(); 
 				}
 			}
@@ -3201,18 +3201,18 @@ public class CommonFunction extends CoTopComponent {
 			List<String> distinctList = new ArrayList<String>();
 			
 			// String 배열 -> String 리스트
-			for(int i = 0 ; i < restrictionArr.length ; i++){
+			for (int i = 0 ; i < restrictionArr.length ; i++){
 				restrictionList.add(restrictionArr[i]);
 			}
 			
 			// 중복 제거
-            for(String str : restrictionList){
+            for (String str : restrictionList){
                 if (!distinctList.contains(str)) {
                 	distinctList.add(str);
                 }
             }
             
-            for(String str : distinctList){
+            for (String str : distinctList){
             	returnStr += (isEmpty(returnStr)?"":"\n") + CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, str.trim().toUpperCase());
             }
 		}
@@ -3235,14 +3235,14 @@ public class CommonFunction extends CoTopComponent {
 	
 	@SuppressWarnings("unchecked")
 	public static String getFilterToString(String filters, Map<String, String> ambiguousInfo, Map<String, String> exceptionMap, boolean upperFlag) {
-		if(ambiguousInfo == null) {
+		if (ambiguousInfo == null) {
 			ambiguousInfo = new HashMap<>();
 		}
 		
 		String filterCondition = "";
 		String[] dateField = {"creationDate", "publDate", "modiDate", "regDt"};
 		
-		if(exceptionMap == null) {
+		if (exceptionMap == null) {
 			exceptionMap = new HashMap<>();
 		}
 		
@@ -3250,12 +3250,12 @@ public class CommonFunction extends CoTopComponent {
 		List<String> numberFormatColumns = new ArrayList<>();
 		numberFormatColumns.add("CVSS_SCORE");
 		
-		if(!isEmpty(filters)) {
+		if (!isEmpty(filters)) {
 			Type collectionType1 = new TypeToken<Map<String, Object>>() {}.getType();
 			Map<String, Object> filtersMap = (Map<String, Object>) fromJson(filters, collectionType1);
 			
-			if(filters != null && filtersMap.containsKey("rules")) {
-				for(Map<String, String> ruleMap : (List<LinkedTreeMap<String, String>>)filtersMap.get("rules")) {
+			if (filters != null && filtersMap.containsKey("rules")) {
+				for (Map<String, String> ruleMap : (List<LinkedTreeMap<String, String>>)filtersMap.get("rules")) {
 					String field = ruleMap.get("field");
 					String op =  ruleMap.get("op");
 					String data = ruleMap.get("data");
@@ -3263,25 +3263,25 @@ public class CommonFunction extends CoTopComponent {
 					String endCondition = "";
 					boolean isNumberFormat = numberFormatColumns.contains(StringUtil.convertToUnderScore(field).toUpperCase());
 					
-					if(!isEmpty(field) && !isEmpty(data)) {
-						for( String key : exceptionMap.keySet() ){ 
-							if(field.equalsIgnoreCase(key)) {
+					if (!isEmpty(field) && !isEmpty(data)) {
+						for ( String key : exceptionMap.keySet() ){ 
+							if (field.equalsIgnoreCase(key)) {
 								field = exceptionMap.get(key);
 							}
 						}
 						
 						boolean dateB = false;
 						
-						for(String dateF : dateField) {
-							if(field.equalsIgnoreCase(dateF)) {
+						for (String dateF : dateField) {
+							if (field.equalsIgnoreCase(dateF)) {
 								dateB = true;
 							}
 						}
 						
 						switch(op) {
 							case "eq":
-								if(!isNumberFormat) {
-									if(upperFlag){
+								if (!isNumberFormat) {
+									if (upperFlag){
 										startCondition = " = UPPER('";
 										endCondition = "')";
 									}else {
@@ -3294,7 +3294,7 @@ public class CommonFunction extends CoTopComponent {
 								
 								break;
 							case "ne":
-								if(!isNumberFormat) {
+								if (!isNumberFormat) {
 									startCondition = " <> '";
 									endCondition = "'";
 								} else {
@@ -3323,7 +3323,7 @@ public class CommonFunction extends CoTopComponent {
 								
 								break;
 							case "cn":
-								if(upperFlag){
+								if (upperFlag){
 									startCondition = " LIKE UPPER('%";
 									endCondition = "%')";
 								}else{
@@ -3338,7 +3338,7 @@ public class CommonFunction extends CoTopComponent {
 								
 								break;
 							case "lt":
-								if(!isNumberFormat) {
+								if (!isNumberFormat) {
 									startCondition = " < '";
 									endCondition = "'";
 								} else {
@@ -3347,7 +3347,7 @@ public class CommonFunction extends CoTopComponent {
 								
 								break;
 							case "le":
-								if(!isNumberFormat) {
+								if (!isNumberFormat) {
 									startCondition = " <= '";
 									endCondition = "'";
 								} else {
@@ -3356,7 +3356,7 @@ public class CommonFunction extends CoTopComponent {
 								
 								break;
 							case "gt":
-								if(!isNumberFormat) {
+								if (!isNumberFormat) {
 									startCondition = " > '";
 									endCondition = "'";
 								} else {
@@ -3365,7 +3365,7 @@ public class CommonFunction extends CoTopComponent {
 								
 								break;
 							case "ge":
-								if(!isNumberFormat) {
+								if (!isNumberFormat) {
 									startCondition = " >= '";
 									endCondition = "'";
 								} else {
@@ -3374,7 +3374,7 @@ public class CommonFunction extends CoTopComponent {
 								
 								break;
 							default:
-								if(dateB) {
+								if (dateB) {
 									startCondition = " = '";
 									endCondition = "'";
 								}else{
@@ -3385,16 +3385,16 @@ public class CommonFunction extends CoTopComponent {
 								break;
 						}
 						
-						if(!upperFlag){
+						if (!upperFlag){
 							field = StringUtil.convertToUnderScore(field).toUpperCase();
 						}
 						
-						if(ambiguousInfo.containsKey(field) && !isEmpty(ambiguousInfo.get(field))) {
+						if (ambiguousInfo.containsKey(field) && !isEmpty(ambiguousInfo.get(field))) {
 							field = ambiguousInfo.get(field) + "." + field;
 						}
 						
 						// 예외조건
-						if(dateB) {
+						if (dateB) {
 							filterCondition += " AND " + "DATE_FORMAT(" + field + ", '%Y-%m-%d') " + startCondition + CommonFunction.formatDateSimple(data) + endCondition;
 						} else {
 							filterCondition += " AND " + field + startCondition + data + endCondition;
@@ -3420,15 +3420,15 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static ProjectIdentification findOssIdAndName(ProjectIdentification bean) {
-		if(bean != null && !isEmpty(bean.getOssName())) {
-			if("N/A".equals(bean.getOssVersion())) {
+		if (bean != null && !isEmpty(bean.getOssName())) {
+			if ("N/A".equals(bean.getOssVersion())) {
 				bean.setOssVersion("");
 			}
 			
 			String findKey = (bean.getOssName().trim() +"_" + avoidNull(bean.getOssVersion()).trim()).toUpperCase();
 			OssMaster masterBean = CoCodeManager.OSS_INFO_UPPER.get(findKey);
 			
-			if(masterBean != null) {
+			if (masterBean != null) {
 				bean.setOssId(masterBean.getOssId());
 				bean.setOssName(masterBean.getOssName());
 			}
@@ -3444,11 +3444,11 @@ public class CommonFunction extends CoTopComponent {
 	public static List<OssComponentsLicense> findOssLicenseIdAndName(String ossId,
 			List<OssComponentsLicense> ossComponentsLicenseList) {
 		// 먼저 license Id는 찾을수 있으면 모두 설정한다.
-		if(ossComponentsLicenseList != null) {
-			for(OssComponentsLicense licenseBean : ossComponentsLicenseList) {
+		if (ossComponentsLicenseList != null) {
+			for (OssComponentsLicense licenseBean : ossComponentsLicenseList) {
 				LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(licenseBean.getLicenseName(), "").trim().toUpperCase());
 				
-				if(licenseMaster != null) {
+				if (licenseMaster != null) {
 					licenseBean.setLicenseId(licenseMaster.getLicenseId());
 					licenseBean.setLicenseName(avoidNull(licenseMaster.getShortIdentifier(),licenseMaster.getLicenseName()));
 					
@@ -3459,25 +3459,25 @@ public class CommonFunction extends CoTopComponent {
 		}
 		
 		// oss에서 추가설정한 license text 및 oss copyright 설정
-		if(!isEmpty(ossId)) {
+		if (!isEmpty(ossId)) {
 			OssMaster ossMaster = CoCodeManager.OSS_INFO_BY_ID.get(ossId);
 			
-			if(ossMaster != null) {
+			if (ossMaster != null) {
 				// oss master에 등록된 licnese순서 기준으로 찾는다 (기본적으로 size가 일치 해야함, multi dual license의 경우)
 				int idx=0;
 				
-				for(OssLicense ossLicense : ossMaster.getOssLicenses()) {
-					if(ossComponentsLicenseList != null 
+				for (OssLicense ossLicense : ossMaster.getOssLicenses()) {
+					if (ossComponentsLicenseList != null 
 							&&ossComponentsLicenseList.size() >= idx+1 
 							&& ossLicense.getLicenseId().equals(ossComponentsLicenseList.get(idx).getLicenseId())) {
 						// license text
 						// oss_license에 존재하는 경우만 설정
-						if(!isEmpty(ossLicense.getOssLicenseText())) {
+						if (!isEmpty(ossLicense.getOssLicenseText())) {
 							ossComponentsLicenseList.get(idx).setLicenseText(ossLicense.getOssLicenseText());
 						}
 						
 						// oss copyright
-						if(!isEmpty(ossLicense.getOssCopyright())) {
+						if (!isEmpty(ossLicense.getOssCopyright())) {
 							ossComponentsLicenseList.get(idx).setCopyrightText(ossLicense.getOssCopyright());
 						}
 					}
@@ -3497,32 +3497,32 @@ public class CommonFunction extends CoTopComponent {
 	public static List<List<ProjectIdentification>> setOssComponentLicense(List<ProjectIdentification> ossComponent, boolean excludeFlag) {
 		List<List<ProjectIdentification>> ossComponentLicense = new ArrayList<List<ProjectIdentification>>(); 
 		
-		for(ProjectIdentification pi : ossComponent) {
-			if(excludeFlag && CoConstDef.FLAG_YES.equals(pi.getExcludeYn()) && isEmpty(pi.getLicenseName())) {
+		for (ProjectIdentification pi : ossComponent) {
+			if (excludeFlag && CoConstDef.FLAG_YES.equals(pi.getExcludeYn()) && isEmpty(pi.getLicenseName())) {
 				continue;
 			}
 			
 			String convertLicenseName = pi.getLicenseName();
 			
-			if(convertLicenseName.contains("\n")) { // 사용자가 oss-report를 통해 license 정보를 입력할 경우 개행이 있을 case가 존재하여 추가함. 
+			if (convertLicenseName.contains("\n")) { // 사용자가 oss-report를 통해 license 정보를 입력할 경우 개행이 있을 case가 존재하여 추가함. 
 				pi.setLicenseName(convertLicenseName.replace("\n", " "));
 			}
 			
-			if(StringUtil.isEmpty(pi.getComponentId()) && StringUtil.contains(pi.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)) {
+			if (StringUtil.isEmpty(pi.getComponentId()) && StringUtil.contains(pi.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)) {
 				List<ProjectIdentification> licenseList = new ArrayList<ProjectIdentification>();
 				
-				if(pi.getLicenseName().contains(",")) {
+				if (pi.getLicenseName().contains(",")) {
 					List<String> licenseNames = Arrays.asList(pi.getLicenseName().split(","));
 					pi.setLicenseDiv("M");
 					
-					for(String nm : licenseNames) {
+					for (String nm : licenseNames) {
 						ProjectIdentification license = new ProjectIdentification();
 						nm = nm.trim(); // license 정보를 입력할때 license 정보 trim 처리함.
 						
 						license.setGridId(pi.getGridId());
 						license.setExcludeYn(CoConstDef.FLAG_NO);
 						
-						if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(nm.toUpperCase())) {
+						if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(nm.toUpperCase())) {
 							LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(nm.toUpperCase());
 							
 							license.setLicenseId(licenseMaster.getLicenseId());
@@ -3542,11 +3542,11 @@ public class CommonFunction extends CoTopComponent {
 			} else {
 				List<ProjectIdentification> licenseList = new ArrayList<ProjectIdentification>();
 				
-				if(pi.getLicenseName().contains(",")) {
+				if (pi.getLicenseName().contains(",")) {
 					List<String> licenseNames = Arrays.asList(pi.getLicenseName().split(","));
 					pi.setLicenseDiv("M");
 					
-					for(String nm : licenseNames) {
+					for (String nm : licenseNames) {
 						ProjectIdentification license = new ProjectIdentification();
 						nm = nm.trim(); // license 정보를 입력할때 license 정보 trim 처리함.
 						
@@ -3554,7 +3554,7 @@ public class CommonFunction extends CoTopComponent {
 						license.setGridId(pi.getGridId()+"-");
 						license.setExcludeYn(CoConstDef.FLAG_NO);
 						
-						if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(nm.toUpperCase())) {
+						if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(nm.toUpperCase())) {
 							LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(nm.toUpperCase());
 							
 							license.setLicenseId(licenseMaster.getLicenseId());
@@ -3581,8 +3581,8 @@ public class CommonFunction extends CoTopComponent {
 		String[] result = licenseName.split(",");
 		boolean resultBoolean = true;
 		
-		for(String name : result) {
-			if(!CoCodeManager.LICENSE_INFO_UPPER.containsKey(name.toUpperCase())) {
+		for (String name : result) {
+			if (!CoCodeManager.LICENSE_INFO_UPPER.containsKey(name.toUpperCase())) {
 				resultBoolean = false;
 				break;
 			}
@@ -3621,7 +3621,7 @@ public class CommonFunction extends CoTopComponent {
 		List<String> deactivateOssList = ossService.getDeactivateOssList();
 		deactivateOssList.replaceAll(String::toUpperCase);
 		
-		for(OssAnalysis bean : analysisResultList) {
+		for (OssAnalysis bean : analysisResultList) {
 			OssAnalysis userData = analysisList
 										.stream()
 										.filter(e -> e.getComponentId().equals(bean.getGridId()))
@@ -3629,11 +3629,11 @@ public class CommonFunction extends CoTopComponent {
 			
 			userData.setGroupId(userData.getGridId()); // groupId는 user가 입력한 row의 grid Id임.
 			
-			if(CoConstDef.FLAG_YES.equals(userData.getCompleteYn()) && !isEmpty(userData.getReferenceOssId())) {
+			if (CoConstDef.FLAG_YES.equals(userData.getCompleteYn()) && !isEmpty(userData.getReferenceOssId())) {
 				
 				OssAnalysis successOssInfo = ossService.getAutoAnalysisSuccessOssInfo(userData.getReferenceOssId());
 				
-				if(!isEmpty(successOssInfo.getDownloadLocationGroup())) {
+				if (!isEmpty(successOssInfo.getDownloadLocationGroup())) {
 					successOssInfo.setDownloadLocation(successOssInfo.getDownloadLocationGroup());
 				}
 				
@@ -3650,7 +3650,7 @@ public class CommonFunction extends CoTopComponent {
 			
 			userData.setTitle("사용자 작성 정보");
 			
-			if(bean.getResult().toUpperCase().equals("TRUE")) {
+			if (bean.getResult().toUpperCase().equals("TRUE")) {
 				int ossNameCnt = errorMsg.entrySet()
 						.stream()
 						.filter(e -> e.getKey().indexOf(bean.getGridId()) > -1 && e.getKey().indexOf("ossName") > -1)
@@ -3671,9 +3671,9 @@ public class CommonFunction extends CoTopComponent {
 				
 				String duplicateNickname = bean.getOssNickname();
 				
-				if(ossNameCnt == 0 && ossVersionCnt > 0) { // ossVersion 대상
+				if (ossNameCnt == 0 && ossVersionCnt > 0) { // ossVersion 대상
 					// 사용자 작성정보의 oss name이 취합정보의 nickname에 들어가는 case를 방지함.
-					if(!userData.getOssName().toUpperCase().equals(bean.getOssName().toUpperCase())) {
+					if (!userData.getOssName().toUpperCase().equals(bean.getOssName().toUpperCase())) {
 						duplicateNickname = String.join(",", Arrays.asList(duplicateNickname.split(","))
 								.stream()
 								.filter(n -> !n.equals(userData.getOssName()))
@@ -3696,22 +3696,22 @@ public class CommonFunction extends CoTopComponent {
 				int idx = 1;
 				OssMaster param = new OssMaster();
 				
-				for(String nick : duplicateNickname.split(",")) {
-					if(CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(nick.toUpperCase())) {
+				for (String nick : duplicateNickname.split(",")) {
+					if (CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(nick.toUpperCase())) {
 						String ossNameByNick = CoCodeManager.OSS_INFO_UPPER_NAMES.get(nick.toUpperCase());
 						param.setOssName(ossNameByNick);
 						List<OssMaster> ossInfoByNickList = ossService.getOssListByName(param);
 						
-						if(ossInfoByNickList != null) {
+						if (ossInfoByNickList != null) {
 							int deactivateCnt = ossInfoByNickList.stream().filter(e -> e.getDeactivateFlag().equals(CoConstDef.FLAG_YES)).collect(Collectors.toList()).size();
-							if(deactivateCnt > 0) {
+							if (deactivateCnt > 0) {
 								continue;
 							}
 							
-							if(ossAnalysisByNickList.size() > 0) {
+							if (ossAnalysisByNickList.size() > 0) {
 								String checkDuplicateOssName = ossInfoByNickList.get(0).getOssName();
 								int checkDuplicateCnt = ossAnalysisByNickList.stream().filter(e -> e.getOssName().equalsIgnoreCase(checkDuplicateOssName)).collect(Collectors.toList()).size();
-								if(checkDuplicateCnt > 0) {
+								if (checkDuplicateCnt > 0) {
 									continue;
 								}
 							}
@@ -3721,8 +3721,8 @@ public class CommonFunction extends CoTopComponent {
 							
 							List<OssLicense> liList = ossInfoByNickList.get(0).getOssLicenses();
 							String license = "";
-							for(OssLicense li : liList) {
-								if(!isEmpty(li.getLicenseId())) {
+							for (OssLicense li : liList) {
+								if (!isEmpty(li.getLicenseId())) {
 									LicenseMaster lm = CoCodeManager.LICENSE_INFO_BY_ID.get(li.getLicenseId());
 									license += !isEmpty(lm.getShortIdentifier()) ? lm.getShortIdentifier() + "," : li.getLicenseName() + ",";
 								} else {
@@ -3731,7 +3731,7 @@ public class CommonFunction extends CoTopComponent {
 							}
 							
 							String analysisTitle = ossInfoByNickList.get(0).getOssName();
-							if(!isEmpty(ossInfoByNickList.get(0).getOssVersion())) {
+							if (!isEmpty(ossInfoByNickList.get(0).getOssVersion())) {
 								analysisTitle += " (" + ossInfoByNickList.get(0).getOssVersion() + ")";
 							}
 							
@@ -3747,7 +3747,7 @@ public class CommonFunction extends CoTopComponent {
 				
 				userData.setResult("true");
 				
-				if(ossNameCnt == 0 && ossVersionCnt > 0) { // ossVersion 대상
+				if (ossNameCnt == 0 && ossVersionCnt > 0) { // ossVersion 대상
 					totalAnalysis.setGridId(""+gridSeq++);
 					askalono.setGridId(""+gridSeq++);
 					scancode.setGridId(""+gridSeq++);
@@ -3756,15 +3756,15 @@ public class CommonFunction extends CoTopComponent {
 					
 					try {
 						newestOssInfo = ossService.getNewestOssInfo(userData); // 사용자 정보의 ossName기준 최신 등록정보
-						if(newestOssInfo != null) {
+						if (newestOssInfo != null) {
 							newestOssInfo.setGridId(""+gridSeq++);
 							newestOssInfo.setOssVersion(userData.getOssVersion());
 							newestOssInfo.setComment(comment);
 						}
 						
-						if(userData.getOssName().toUpperCase().equals(totalAnalysis.getOssName().toUpperCase())) {
+						if (userData.getOssName().toUpperCase().equals(totalAnalysis.getOssName().toUpperCase())) {
 							String newestMergeNickName = "";
-							if(newestOssInfo != null) {
+							if (newestOssInfo != null) {
 								newestMergeNickName = CommonFunction.mergeNickname(totalAnalysis, newestOssInfo.getOssNickname()); // 사용자 작성 정보 & 최신등록정보 nickname Merge
 								newestOssInfo.setOssNickname(newestMergeNickName);
 							}else {
@@ -3779,7 +3779,7 @@ public class CommonFunction extends CoTopComponent {
 							totalNewestOssInfo = ossService.getNewestOssInfo(totalAnalysis); // 사용자 정보의 ossName기준 최신 등록정보
 							String totalNewestMergeNickName = "";
 							
-							if(totalNewestOssInfo != null) {
+							if (totalNewestOssInfo != null) {
 								totalNewestOssInfo.setGridId(""+gridSeq++);
 								totalNewestOssInfo.setOssVersion(userData.getOssVersion());
 								totalNewestMergeNickName = CommonFunction.mergeNickname(totalAnalysis, totalNewestOssInfo.getOssNickname()); // 사용자 작성 정보 & 최신등록정보 nickname Merge
@@ -3799,15 +3799,15 @@ public class CommonFunction extends CoTopComponent {
 					
 					changeAnalysisResultList.add(totalAnalysis); // seq 1 : 취합 정보
 					
-					if(ossAnalysisByNickList != null && !ossAnalysisByNickList.isEmpty()) {
-						for(OssAnalysis oa : ossAnalysisByNickList) {
-							if(totalNewestOssInfo != null) {
-								if(!totalNewestOssInfo.getOssName().equalsIgnoreCase(oa.getOssName()) && !totalNewestOssInfo.getOssVersion().equals(oa.getOssVersion())) {
+					if (ossAnalysisByNickList != null && !ossAnalysisByNickList.isEmpty()) {
+						for (OssAnalysis oa : ossAnalysisByNickList) {
+							if (totalNewestOssInfo != null) {
+								if (!totalNewestOssInfo.getOssName().equalsIgnoreCase(oa.getOssName()) && !totalNewestOssInfo.getOssVersion().equals(oa.getOssVersion())) {
 									changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
 								}
 							} else {
-								if(newestOssInfo != null) {
-									if(!newestOssInfo.getOssName().equalsIgnoreCase(oa.getOssName()) && !newestOssInfo.getOssVersion().equals(oa.getOssVersion())) {
+								if (newestOssInfo != null) {
+									if (!newestOssInfo.getOssName().equalsIgnoreCase(oa.getOssName()) && !newestOssInfo.getOssVersion().equals(oa.getOssVersion())) {
 										changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
 									}
 								} else {
@@ -3817,18 +3817,18 @@ public class CommonFunction extends CoTopComponent {
 						}
 					}
 					
-					if(totalNewestOssInfo != null && !deactivateOssList.contains(totalNewestOssInfo.getOssName().toUpperCase())) {
+					if (totalNewestOssInfo != null && !deactivateOssList.contains(totalNewestOssInfo.getOssName().toUpperCase())) {
 						changeAnalysisResultList.add(totalNewestOssInfo); // seq 3 : 취합정보 최신등록 정보
 					}
 					
-					if(newestOssInfo != null && !deactivateOssList.contains(newestOssInfo.getOssName().toUpperCase())) {
+					if (newestOssInfo != null && !deactivateOssList.contains(newestOssInfo.getOssName().toUpperCase())) {
 						changeAnalysisResultList.add(newestOssInfo); // seq 4 : 최신등록 정보
 						
-						if(newestOssInfo.getOssName().toUpperCase().equals(userData.getOssName().toUpperCase())) {
-							if(newestOssInfo.getOssNickname() != null) {
+						if (newestOssInfo.getOssName().toUpperCase().equals(userData.getOssName().toUpperCase())) {
+							if (newestOssInfo.getOssNickname() != null) {
 								userData.setOssNickname(CommonFunction.mergeNickname(userData, newestOssInfo.getOssNickname()));
 							}
-							if(userData.getOssNickname() != null) {
+							if (userData.getOssNickname() != null) {
 								newestOssInfo.setOssNickname(CommonFunction.mergeNickname(newestOssInfo, userData.getOssNickname()));
 							}
 						}
@@ -3842,7 +3842,7 @@ public class CommonFunction extends CoTopComponent {
 					
 					OssAnalysis totalNewestOssInfo = ossService.getNewestOssInfo(totalAnalysis); // 사용자 정보의 ossName기준 최신 등록정보
 					
-					if(totalNewestOssInfo != null) {
+					if (totalNewestOssInfo != null) {
 						totalNewestOssInfo.setGridId(""+gridSeq++);
 						totalNewestOssInfo.setOssVersion(userData.getOssVersion());
 						totalNewestOssInfo.setComment(comment);
@@ -3862,10 +3862,10 @@ public class CommonFunction extends CoTopComponent {
 					
 					changeAnalysisResultList.add(totalAnalysis); // seq 1 : 취합 정보
 					
-					if(ossAnalysisByNickList != null && !ossAnalysisByNickList.isEmpty()) {
-						for(OssAnalysis oa : ossAnalysisByNickList) {
-							if(totalNewestOssInfo != null) {
-								if(!totalNewestOssInfo.getOssName().equalsIgnoreCase(oa.getOssName()) && !totalNewestOssInfo.getOssVersion().equals(oa.getOssVersion())) {
+					if (ossAnalysisByNickList != null && !ossAnalysisByNickList.isEmpty()) {
+						for (OssAnalysis oa : ossAnalysisByNickList) {
+							if (totalNewestOssInfo != null) {
+								if (!totalNewestOssInfo.getOssName().equalsIgnoreCase(oa.getOssName()) && !totalNewestOssInfo.getOssVersion().equals(oa.getOssVersion())) {
 									changeAnalysisResultList.add(oa); // seq 2 : oss 최신등록 정보
 								}
 							} else {
@@ -3874,7 +3874,7 @@ public class CommonFunction extends CoTopComponent {
 						}
 					}
 					
-					if(totalNewestOssInfo != null && !deactivateOssList.contains(totalNewestOssInfo.getOssName().toUpperCase())) {
+					if (totalNewestOssInfo != null && !deactivateOssList.contains(totalNewestOssInfo.getOssName().toUpperCase())) {
 						changeAnalysisResultList.add(totalNewestOssInfo); // seq 3 : 취합정보 최신등록 정보
 					}
 					
@@ -3899,11 +3899,11 @@ public class CommonFunction extends CoTopComponent {
 						.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()))
 						.size();
 				
-				if(ossNameCnt == 0 && ossVersionCnt > 0){
+				if (ossNameCnt == 0 && ossVersionCnt > 0){
 					try {
 						OssAnalysis newestOssInfo = ossService.getNewestOssInfo(userData); // 사용자 정보의 ossName기준 최신 등록정보
 						
-						if(newestOssInfo != null && !deactivateOssList.contains(newestOssInfo.getOssName().toUpperCase())) {
+						if (newestOssInfo != null && !deactivateOssList.contains(newestOssInfo.getOssName().toUpperCase())) {
 							newestOssInfo.setGridId(""+gridSeq++);
 							newestOssInfo.setOssVersion(userData.getOssVersion());
 							
@@ -3924,8 +3924,8 @@ public class CommonFunction extends CoTopComponent {
 	public static ArrayList<Object> checkXlsxFileLimit(List<UploadFile> list){
 		ArrayList<Object> result = new ArrayList<Object>();
 		
-		for(UploadFile f : list) {
-			if(f.getSize() > CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT && f.getFileExt().contains("xls")){
+		for (UploadFile f : list) {
+			if (f.getSize() > CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT && f.getFileExt().contains("xls")){
 				result.add("FILE_SIZE_LIMIT_OVER");
 				result.add("The excel file exceeded 5MB.<br>Please delete the blank row or unnecessary data, and then upload it.");
 				
@@ -3940,24 +3940,24 @@ public class CommonFunction extends CoTopComponent {
 		ArrayList<Object> result = new ArrayList<Object>();
 		boolean nextCheck = false;
 		
-		for(UploadFile f : list) {
-			if(f.getSize() > CoConstDef.CD_CSV_UPLOAD_FILE_SIZE_LIMIT && f.getFileExt().contains("csv")){
+		for (UploadFile f : list) {
+			if (f.getSize() > CoConstDef.CD_CSV_UPLOAD_FILE_SIZE_LIMIT && f.getFileExt().contains("csv")){
 				result.add("FILE_SIZE_LIMIT_OVER");
 				result.add("The file exceeded 5MB.<br>Please delete the blank row or unnecessary data, and then upload it.");
 				nextCheck = true;
 				break;
 			}
 			
-			if(!nextCheck) {
+			if (!nextCheck) {
 				boolean tabGubnBoolean = false;
 				String commaData = "";
 				Scanner sc = null;
 				
 				try {
 					sc = new Scanner(new FileInputStream(new File(f.getFilePath() + "/" + f.getFileName())));
-					while(sc.hasNext()) {
+					while (sc.hasNext()) {
 						String readLine = sc.nextLine();
-						if(!isEmpty(readLine) && !readLine.contains("\t")) {
+						if (!isEmpty(readLine) && !readLine.contains("\t")) {
 							tabGubnBoolean = true;
 							break;
 						}
@@ -3967,7 +3967,7 @@ public class CommonFunction extends CoTopComponent {
 				} finally {
 					sc.close();
 					
-					if(tabGubnBoolean) {
+					if (tabGubnBoolean) {
 						result.add("TAB_GUBN_ERROR");
 						result.add(commaData);
 						break;
@@ -3987,8 +3987,8 @@ public class CommonFunction extends CoTopComponent {
 		List<File> xmlFiles = new ArrayList<File>();
 		File outPath = null;
 		
-		if(!isDir) {
-			if(XmlFile.exists()) {
+		if (!isDir) {
+			if (XmlFile.exists()) {
 				String Path = XmlFile.getPath().split("\\.")[0];
 				outPath = new File(Path);
 				outPath.mkdirs(); // xml file은 upload/android_notice/projectId/* 에 올려두기 때문에 dir를 생성해야 함.
@@ -3996,8 +3996,8 @@ public class CommonFunction extends CoTopComponent {
 				xmlFiles.add(XmlFile);
 			}
 		} else {
-			if(XmlFile.exists()) {
-				for(File f : XmlFile.listFiles()) {
+			if (XmlFile.exists()) {
+				for (File f : XmlFile.listFiles()) {
 					xmlFiles.add((File) f);
 				}
 			}
@@ -4015,10 +4015,10 @@ public class CommonFunction extends CoTopComponent {
 	public static String mergeNickname(OssAnalysis bean, String newestNickName) {
 		String mergeNickname = newestNickName;
 		
-		if(!isEmpty(mergeNickname)) {
+		if (!isEmpty(mergeNickname)) {
 			List<String> nicknameList = new ArrayList<String>();
 			
-			if(!isEmpty(bean.getOssNickname())) { // nickname이 빈값이 있을 경우 담지 않음.
+			if (!isEmpty(bean.getOssNickname())) { // nickname이 빈값이 있을 경우 담지 않음.
 				nicknameList.addAll(Arrays.asList(bean.getOssNickname().split(",")));
 			}
 			
@@ -4059,8 +4059,8 @@ public class CommonFunction extends CoTopComponent {
 		VelocityEngine ve = new VelocityEngine();
 		Properties props = new Properties();
 		
-		for(String key : model.keySet()) {
-			if(!"templateURL".equals(key)) {
+		for (String key : model.keySet()) {
+			if (!"templateURL".equals(key)) {
 				context.put(key, model.get(key));
 			}
 		}
@@ -4090,25 +4090,25 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String getNoticeFileName(String prjId, String prjName, String prjVersion, String fileName, String dateStr, String fileType) {
-		if(isEmpty(fileName)) {
+		if (isEmpty(fileName)) {
 			fileName = "OSSNotice-";
 			fileName += prjId + "_" + prjName;
 			
-			if(!isEmpty(prjVersion)) {
+			if (!isEmpty(prjVersion)) {
 				fileName += "_" + prjVersion;
 			}
 		}
 		
 		// file명에 사용할 수 없는 특수문자 체크
-		if(!FileUtil.isValidFileName(fileName)) {
+		if (!FileUtil.isValidFileName(fileName)) {
 			fileName = FileUtil.makeValidFileName(fileName, "_");
 		}
 		
 		fileName += "_" + dateStr;
 		
-		if(isEmpty(fileType) || fileType == "html"){
+		if (isEmpty(fileType) || fileType == "html"){
 			fileName += ".html";
-		}else if(fileType == "text"){
+		}else if (fileType == "text"){
 			fileName += ".txt";
 		} else {
 			fileName += fileType;
@@ -4122,17 +4122,17 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	public static String getReviewReportFileName(String prjId, String prjName, String prjVersion, String fileName, String dateStr, String fileType) {
-		if(isEmpty(fileName)) {
+		if (isEmpty(fileName)) {
 			fileName = "FOSSLight-Review-";
 			fileName += prjId + "_" + prjName;
 
-			if(!isEmpty(prjVersion)) {
+			if (!isEmpty(prjVersion)) {
 				fileName += "_" + prjVersion;
 			}
 		}
 
 		// file명에 사용할 수 없는 특수문자 체크
-		if(!FileUtil.isValidFileName(fileName)) {
+		if (!FileUtil.isValidFileName(fileName)) {
 			fileName = FileUtil.makeValidFileName(fileName, "_");
 		}
 
@@ -4143,7 +4143,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static String mergedString(String fromStr, String toStr, int compareTo, String separator) {
-		if(compareTo >= 0){
+		if (compareTo >= 0){
 			return fromStr + separator + toStr;
 		} else {
 			return toStr + separator + fromStr;
@@ -4166,7 +4166,7 @@ public class CommonFunction extends CoTopComponent {
 		String match = "[^\uAC00-\uD7A3xfe0-9a-zA-Z\\s]";
 		target = target.replaceAll(match, "");
 		
-		if(limit > 0) {
+		if (limit > 0) {
 			target = target.substring(0, limit);
 		}
 		
@@ -4177,21 +4177,21 @@ public class CommonFunction extends CoTopComponent {
 	public static String removeDuplicateStringToken(String str, String token){ 
 		String removeDubString = ""; 
 		
-		if(!StringUtil.isEmpty(str)){
+		if (!StringUtil.isEmpty(str)){
 			String[] arr = StringUtil.split(str, token.trim());
 			LinkedHashSet<String> ls = new LinkedHashSet<>();
 			
-			for(int i=0; i<arr.length; i++){
+			for (int i=0; i<arr.length; i++){
 				ls.add(arr[i]);
 			}
 			
 			Iterator<String> it = ls.iterator();
 			
-			while(it.hasNext()){
+			while (it.hasNext()){
 				removeDubString +=it.next()+token.trim();
 			}
 			
-			if(!StringUtil.isEmpty(removeDubString)){
+			if (!StringUtil.isEmpty(removeDubString)){
 				removeDubString=removeDubString.substring(0, removeDubString.lastIndexOf(token.trim()));
 			}
 		}
@@ -4200,7 +4200,7 @@ public class CommonFunction extends CoTopComponent {
 	}
 	
 	public static void splitDate(String str, Map<String, Object> paramMap, String separator, String prefix) {
-		if(!isEmpty(str)) {
+		if (!isEmpty(str)) {
 			String[] strArr = str.split(separator);
 			
 			paramMap.put(prefix+"From", strArr[0]);
@@ -4211,7 +4211,7 @@ public class CommonFunction extends CoTopComponent {
 	public static String tabTitleSubStr(String code, String value) {
 		String tabData = CoCodeManager.getCodeString(code, value);
 		
-		if(tabData.length() > 12) {
+		if (tabData.length() > 12) {
 			return tabData.substring(0, 11) + "...";
 		} else {
 			return tabData;
@@ -4233,55 +4233,55 @@ public class CommonFunction extends CoTopComponent {
 	public static String getDiffItemComment(Project beforeBean, Project afterBean, boolean booleanFlag) {
 		String comment = "";
 		
-		if(booleanFlag) {
+		if (booleanFlag) {
 			// Project Name
-			if(!beforeBean.getPrjName().equals(afterBean.getPrjName())) {
+			if (!beforeBean.getPrjName().equals(afterBean.getPrjName())) {
 				comment += "<p><strong>Project Name</strong><br />";
 				comment += "Before : " + beforeBean.getPrjName() + "<br />";
 				comment += "After : " + afterBean.getPrjName() + "<br /></p>";
 			}
 
 			// Project Version
-			if(!beforeBean.getPrjVersion().equals(afterBean.getPrjVersion())) {
+			if (!beforeBean.getPrjVersion().equals(afterBean.getPrjVersion())) {
 				comment += "<p><strong>Project Version</strong><br />";
 				comment += "Before : " + beforeBean.getPrjVersion() + "<br />";
 				comment += "After : " + afterBean.getPrjVersion() + "<br /></p>";
 			}
 			
 			// Operating System
-			if(!beforeBean.getOsType().equals(afterBean.getOsType())) {
+			if (!beforeBean.getOsType().equals(afterBean.getOsType())) {
 				comment += "<p><strong>Operating System</strong><br />";
 				comment += "Before : " + beforeBean.getOsType() + "<br />";
 				comment += "After : " + afterBean.getOsType() + "<br /></p>";
 			}
 			
 			// Distribution Type
-			if(!beforeBean.getDistributionType().equals(afterBean.getDistributionType())) {
+			if (!beforeBean.getDistributionType().equals(afterBean.getDistributionType())) {
 				comment += "<p><strong>Distribution Type</strong><br />";
 				comment += "Before : " + beforeBean.getDistributionType() + "<br />";
 				comment += "After : " + afterBean.getDistributionType() + "<br /></p>";
 			}
 			
 			
-			if(!beforeBean.getNetworkServerType().equals(afterBean.getNetworkServerType())) {
+			if (!beforeBean.getNetworkServerType().equals(afterBean.getNetworkServerType())) {
 				comment += "<p><strong>Network Service only?</strong><br />";
 				comment += "Before : " + beforeBean.getNetworkServerType() + "<br />";
 				comment += "After : " + afterBean.getNetworkServerType() + "<br /></p>";
 			}
 			
-			if(!beforeBean.getDistributeTarget().equals(afterBean.getDistributeTarget())) {
+			if (!beforeBean.getDistributeTarget().equals(afterBean.getDistributeTarget())) {
 				comment += "<p><strong>Distribution Site</strong><br />";
 				comment += "Before : " + beforeBean.getDistributeTarget() + "<br />";
 				comment += "After : " + afterBean.getDistributeTarget() + "<br /></p>";
 			}
 			
-			if(!beforeBean.getNoticeType().equals(afterBean.getNoticeType())) {
+			if (!beforeBean.getNoticeType().equals(afterBean.getNoticeType())) {
 				comment += "<p><strong>OSS Notice</strong><br />";
 				comment += "Before : " + beforeBean.getNoticeType() + "<br />";
 				comment += "After : " + afterBean.getNoticeType() + "<br /></p>";
 			}
 			
-			if(!beforeBean.getPriority().equals(afterBean.getPriority())) {
+			if (!beforeBean.getPriority().equals(afterBean.getPriority())) {
 				comment += "<p><strong>Priority</strong><br />";
 				comment += "Before : " + beforeBean.getPriority() + "<br />";
 				comment += "After : " + afterBean.getPriority() + "</p>";
@@ -4289,14 +4289,14 @@ public class CommonFunction extends CoTopComponent {
 			
 			String before = beforeBean.getComment().replaceAll("(\r\n|\r|\n|\n\r)", "");
 			String after = afterBean.getComment().replaceAll("(\r\n|\r|\n|\n\r)", "");
-			if(!before.equals(after)) {
+			if (!before.equals(after)) {
 				comment += "<p><strong>Additional Information</strong><br />";
 				comment += "Before : " + beforeBean.getComment() + "<br />";
 				comment += "After : " + afterBean.getComment() + "</p>";
 			}
 		} else {
 			// Project Division
-			if(!beforeBean.getDivision().equals(afterBean.getDivision())) {
+			if (!beforeBean.getDivision().equals(afterBean.getDivision())) {
 				comment += "<p><strong>Division</strong><br />";
 				comment += "Before : " + CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, beforeBean.getDivision()) + "<br />";
 				comment += "After : <span style='background-color:yellow'>" + CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, afterBean.getDivision()) + "</span><br /></p>";
@@ -4312,7 +4312,7 @@ public class CommonFunction extends CoTopComponent {
 		int curPage = Integer.parseInt((String) map.get("page"));
 		int blockSize = 10;
 		
-		if(map.containsKey("blockSize")) {
+		if (map.containsKey("blockSize")) {
 			blockSize = Integer.parseInt((String) map.get("blockSize"));
 		}
 		
@@ -4383,23 +4383,23 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	public static String makeJdbcUrl(String jdbcUrl) {
-		if(StringUtil.isEmpty(jdbcUrl)) {
+		if (StringUtil.isEmpty(jdbcUrl)) {
 			return jdbcUrl;
 		}
-		if(!jdbcUrl.startsWith("jdbc:")) {
+		if (!jdbcUrl.startsWith("jdbc:")) {
 			jdbcUrl = "jdbc:mysql://" + jdbcUrl;
 		}
-		if(!jdbcUrl.contains("serverTimezone")) {
+		if (!jdbcUrl.contains("serverTimezone")) {
 			jdbcUrl += (jdbcUrl.contains("?") ? "&" : "?") + "serverTimezone=UTC";
 		}
-		if(!jdbcUrl.contains("autoReconnect")) {
+		if (!jdbcUrl.contains("autoReconnect")) {
 			jdbcUrl += (jdbcUrl.contains("?") ? "&" : "?") + "autoReconnect=true";
 		}
 		return jdbcUrl;
 	}
 	
 	public static String getOssDownloadLocation(String ossName, String ossVersion) {
-		if(!isEmpty(ossName) && CoCodeManager.OSS_INFO_UPPER.containsKey( (ossName + "_" + avoidNull(ossVersion)).toUpperCase() )) {
+		if (!isEmpty(ossName) && CoCodeManager.OSS_INFO_UPPER.containsKey( (ossName + "_" + avoidNull(ossVersion)).toUpperCase() )) {
 			return avoidNull( CoCodeManager.OSS_INFO_UPPER.get( (ossName + "_" + avoidNull(ossVersion)).toUpperCase() ).getDownloadLocation() );
 		}
 		return "";
@@ -4474,20 +4474,20 @@ public class CommonFunction extends CoTopComponent {
 
 	public static List<ProjectIdentification> removeDuplicateLicense(List<ProjectIdentification> ossComponents) {
 		for (ProjectIdentification pri : ossComponents) {
-			if(pri.getLicenseName().contains(",")) {
+			if (pri.getLicenseName().contains(",")) {
 				List<String> licenseNameList = Arrays.asList(pri.getLicenseName().split(","));
 				List<String> licenseNameNicknameCheckList = new ArrayList<>();
 				List<String> duplicateList = new ArrayList<>();
 				List<Integer> indexList = new ArrayList<>();
 				
-				for(int j=0; j<licenseNameList.size(); j++) {
+				for (int j=0; j<licenseNameList.size(); j++) {
 	                String licenseName = licenseNameList.get(j).trim();
-	                if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
+	                if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
 	                	LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(licenseName.toUpperCase());
-	                    if(licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
+	                    if (licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
 	                    	boolean flag = false;
-	                    	for(String s : licenseMaster.getLicenseNicknameList()) {
-	                    		if(licenseName.equalsIgnoreCase(s)) {
+	                    	for (String s : licenseMaster.getLicenseNicknameList()) {
+	                    		if (licenseName.equalsIgnoreCase(s)) {
 	                    			String disp = avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseNameTemp());
 	                    			licenseNameNicknameCheckList.add(disp);
 	                    			flag = true;
@@ -4495,7 +4495,7 @@ public class CommonFunction extends CoTopComponent {
 	                    		}
 	                    	}
 	                    	
-	                    	if(!flag) {
+	                    	if (!flag) {
 	                    		licenseNameNicknameCheckList.add(licenseName);
 	                    	}
 	                    }else {
@@ -4506,15 +4506,15 @@ public class CommonFunction extends CoTopComponent {
 	                }
 				}
 				
-				for(int i=0; i<licenseNameNicknameCheckList.size(); i++) {
-					if(!duplicateList.contains(licenseNameNicknameCheckList.get(i))) {
+				for (int i=0; i<licenseNameNicknameCheckList.size(); i++) {
+					if (!duplicateList.contains(licenseNameNicknameCheckList.get(i))) {
 						duplicateList.add(licenseNameNicknameCheckList.get(i));
 						indexList.add(i);
 					}
 				}
 				
 				duplicateList = new ArrayList<>();
-				for(int i=0; i<indexList.size(); i++) {
+				for (int i=0; i<indexList.size(); i++) {
 					duplicateList.add(licenseNameList.get(indexList.get(i)));
 				}
 				
@@ -4544,51 +4544,51 @@ public class CommonFunction extends CoTopComponent {
 		List<String> unclearObligationList = new ArrayList<>();
 		List<String> unclearObligationNotLicenseList = new ArrayList<>();
 		
-		if(errorCodeMap != null) {
-			for(String key : errorCodeMap.keySet()) {
-				if(key.indexOf(".") > -1 && UNCLEAR_OBLIGATION_CODE_LIST.contains(errorCodeMap.get(key))) {
+		if (errorCodeMap != null) {
+			for (String key : errorCodeMap.keySet()) {
+				if (key.indexOf(".") > -1 && UNCLEAR_OBLIGATION_CODE_LIST.contains(errorCodeMap.get(key))) {
 					unclearObligationList.add(key.substring(key.indexOf(".") + 1, key.length()));
 				}
-				if(key.indexOf(".") > -1 && UNCLEAR_OBLIGATION_CODE_NOTLICENSE_LIST.contains(errorCodeMap.get(key))) {
+				if (key.indexOf(".") > -1 && UNCLEAR_OBLIGATION_CODE_NOTLICENSE_LIST.contains(errorCodeMap.get(key))) {
 					unclearObligationNotLicenseList.add(key.substring(key.indexOf(".") + 1, key.length()));
 				}
 			}
 		}
-		if(warningCodeMap != null) {
-			for(String key : warningCodeMap.keySet()) {
-				if(key.indexOf(".") > -1 && UNCLEAR_OBLIGATION_CODE_LIST.contains(warningCodeMap.get(key))) {
+		if (warningCodeMap != null) {
+			for (String key : warningCodeMap.keySet()) {
+				if (key.indexOf(".") > -1 && UNCLEAR_OBLIGATION_CODE_LIST.contains(warningCodeMap.get(key))) {
 					unclearObligationList.add(key.substring(key.indexOf(".") + 1, key.length()));
 				}
-				if(key.indexOf(".") > -1 && UNCLEAR_OBLIGATION_CODE_NOTLICENSE_LIST.contains(warningCodeMap.get(key))) {
+				if (key.indexOf(".") > -1 && UNCLEAR_OBLIGATION_CODE_NOTLICENSE_LIST.contains(warningCodeMap.get(key))) {
 					unclearObligationNotLicenseList.add(key.substring(key.indexOf(".") + 1, key.length()));
 				}
 			}
 		}
 		
-		if(list != null) {
-			for(ProjectIdentification bean : list) {
-				if("-".equals(bean.getOssName())  
+		if (list != null) {
+			for (ProjectIdentification bean : list) {
+				if ("-".equals(bean.getOssName())  
 						&& !unclearObligationList.contains(bean.getGridId()) 
 						&& isEmpty(bean.getObligationType()) 
 						&& !checkIncludeUnconfirmedLicense(bean.getComponentLicenseList())) {
 					String obligationType = CommonFunction.getObligationTypeWithSelectedLicense(bean);
-					if(!isEmpty(obligationType)) {
+					if (!isEmpty(obligationType)) {
 						bean.setObligationType(obligationType);
 						continue;
 					}
 				}
 				
 				// Check unconfirmed license, the actual message is (Declared : ~~), so check again registered license.
-				if(unclearObligationList.contains(bean.getGridId())
+				if (unclearObligationList.contains(bean.getGridId())
 						|| (!isEmpty(bean.getObligationType()) && (checkIncludeUnconfirmedLicense(bean.getComponentLicenseList()) || checkIncludeNotDeclaredLicense(bean.getOssName(), bean.getOssVersion(), bean.getComponentLicenseList())))) {
 					bean.setObligationGrayFlag(CoConstDef.FLAG_YES);
 					bean.setObligationMsg(getMessage("msg.project.obligation.unclear"));
 				}
 				 
-				if(unclearObligationNotLicenseList.contains(bean.getGridId())) {
-					if(isEmpty(bean.getObligationType())){
+				if (unclearObligationNotLicenseList.contains(bean.getGridId())) {
+					if (isEmpty(bean.getObligationType())){
 						String obligationType = CommonFunction.getObligationTypeWithSelectedLicense(bean);
-						if(!isEmpty(obligationType)) {
+						if (!isEmpty(obligationType)) {
 							bean.setObligationType(obligationType);
 							continue;
 						}
@@ -4603,8 +4603,8 @@ public class CommonFunction extends CoTopComponent {
 			List<ProjectIdentification> licenseList) {
 		
 		List<String> licenseNameList = getAllAvailableLicenseUpperCaseName(ossName, ossVer);
-		for(ProjectIdentification license : licenseList) {
-			if(!licenseNameList.contains(license.getLicenseName().toUpperCase())) {
+		for (ProjectIdentification license : licenseList) {
+			if (!licenseNameList.contains(license.getLicenseName().toUpperCase())) {
 				return true;
 			}
 		}
@@ -4614,23 +4614,23 @@ public class CommonFunction extends CoTopComponent {
 	private static List<String> getAllAvailableLicenseUpperCaseName(String ossName, String ossVer) {
 		String key = (avoidNull(ossName).trim() + "_" + avoidNull(ossVer).trim()).toUpperCase();
 		List<String> licenseNameList = new ArrayList<>();
-		if(CoCodeManager.OSS_INFO_UPPER.containsKey(key)) {
+		if (CoCodeManager.OSS_INFO_UPPER.containsKey(key)) {
 			OssMaster bean = CoCodeManager.OSS_INFO_UPPER.get(key);
-			for(OssLicense _temp : Optional.ofNullable(bean.getOssLicenses()).orElse(new ArrayList<>())) {
+			for (OssLicense _temp : Optional.ofNullable(bean.getOssLicenses()).orElse(new ArrayList<>())) {
 				licenseNameList.add(_temp.getLicenseName().toUpperCase());
 				LicenseMaster _license = CoCodeManager.LICENSE_INFO_BY_ID.get(_temp.getLicenseId());
-				if(_license != null) {
-					for(String _nick : Optional.ofNullable(_license.getLicenseNicknameList()).orElse(new ArrayList<>())) {
+				if (_license != null) {
+					for (String _nick : Optional.ofNullable(_license.getLicenseNicknameList()).orElse(new ArrayList<>())) {
 						licenseNameList.add(_nick.toUpperCase());
 					}
 				}
 			}
 			
-			for(String _temp : Optional.ofNullable(bean.getDetectedLicenses()).orElse(new ArrayList<>())) {
+			for (String _temp : Optional.ofNullable(bean.getDetectedLicenses()).orElse(new ArrayList<>())) {
 				licenseNameList.add(_temp.toUpperCase());
 				LicenseMaster _license = CoCodeManager.LICENSE_INFO_UPPER.get(_temp.toUpperCase());
-				if(_license != null) {
-					for(String _nick : Optional.ofNullable(_license.getLicenseNicknameList()).orElse(new ArrayList<>())) {
+				if (_license != null) {
+					for (String _nick : Optional.ofNullable(_license.getLicenseNicknameList()).orElse(new ArrayList<>())) {
 						licenseNameList.add(_nick.toUpperCase());
 					}
 				}
@@ -4640,9 +4640,9 @@ public class CommonFunction extends CoTopComponent {
 	}
 
 	private static boolean checkIncludeUnconfirmedLicense(List<ProjectIdentification> licenseList) {
-		if(licenseList != null) {
-			for(ProjectIdentification bean : licenseList) {
-				if(!isEmpty(bean.getLicenseName()) && !CoCodeManager.LICENSE_INFO_UPPER.containsKey(bean.getLicenseName().toUpperCase())) {
+		if (licenseList != null) {
+			for (ProjectIdentification bean : licenseList) {
+				if (!isEmpty(bean.getLicenseName()) && !CoCodeManager.LICENSE_INFO_UPPER.containsKey(bean.getLicenseName().toUpperCase())) {
 					return true;
 				}
 			}
@@ -4653,8 +4653,8 @@ public class CommonFunction extends CoTopComponent {
 	public static List<ProjectIdentification> makeLicensePermissiveList(List<ProjectIdentification> licenses, String currentLicense) {
 		List<List<ProjectIdentification>> andCombLicenseList = new ArrayList<>();
 		
-		for(ProjectIdentification bean : licenses) {
-			if(andCombLicenseList.size() == 0 || "OR".equals(bean.getOssLicenseComb())) {
+		for (ProjectIdentification bean : licenses) {
+			if (andCombLicenseList.size() == 0 || "OR".equals(bean.getOssLicenseComb())) {
 				andCombLicenseList.add(new ArrayList<>());
 			}
 			
@@ -4668,38 +4668,38 @@ public class CommonFunction extends CoTopComponent {
 		int pfCnt = 0;
 		int naCnt = 0;
 		
-		for(List<ProjectIdentification> andList : andCombLicenseList) {
+		for (List<ProjectIdentification> andList : andCombLicenseList) {
 			switch(getLicensePermissive(andList)) {
 				case CoConstDef.CD_LICENSE_TYPE_PMS:
-					if(pmsCnt == 0) {
+					if (pmsCnt == 0) {
 						licenseList = andList;
 						pmsCnt++;
 					}
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_WCP:
-					if(pmsCnt == 0 && wcpCnt == 0) {
+					if (pmsCnt == 0 && wcpCnt == 0) {
 						licenseList = andList;
 						wcpCnt++;
 					}
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_CP:
-					if(pmsCnt == 0 && wcpCnt == 0 && cpCnt == 0) {
+					if (pmsCnt == 0 && wcpCnt == 0 && cpCnt == 0) {
 						licenseList = andList;
 						cpCnt++;
 					}
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_PF:
-					if(pmsCnt == 0 && wcpCnt == 0 && cpCnt == 0 && pfCnt == 0) {
+					if (pmsCnt == 0 && wcpCnt == 0 && cpCnt == 0 && pfCnt == 0) {
 						licenseList = andList;
 						pfCnt++;
 					}
 					
 					break;
 				case CoConstDef.CD_LICENSE_TYPE_NA:
-					if(pmsCnt == 0 && wcpCnt == 0 && cpCnt == 0 && pfCnt == 0 && naCnt == 0) {
+					if (pmsCnt == 0 && wcpCnt == 0 && cpCnt == 0 && pfCnt == 0 && naCnt == 0) {
 						licenseList = andList;
 						naCnt++;
 					}
@@ -4719,21 +4719,21 @@ public class CommonFunction extends CoTopComponent {
 		
 		case "project":
 			Project param = new Project();
-			for(int i=0; i<prjIds.length; i++) {
+			for (int i=0; i<prjIds.length; i++) {
 				userIdList = new ArrayList<>();
 				param.setPrjId(prjIds[i]);
 				Project bean = projectService.getProjectDetail(param);
 				
 				userIdList.add(bean.getCreator());
-				if(bean.getWatcherList() != null) {
-					for(String watcher : bean.getWatcherList().stream().map(e -> e.getPrjUserId()).collect(Collectors.toList())) {
+				if (bean.getWatcherList() != null) {
+					for (String watcher : bean.getWatcherList().stream().map(e -> e.getPrjUserId()).collect(Collectors.toList())) {
 						userIdList.add(watcher);
 					}
 				}
 				
 				userIdList = userIdList.stream().distinct().collect(Collectors.toList());
-				if(!isEmpty(userId)) {
-					if(!userIdList.contains(userId)) {
+				if (!isEmpty(userId)) {
+					if (!userIdList.contains(userId)) {
 						notPermissionList.add(prjIds[i]);
 					}
 				} else {
@@ -4744,21 +4744,21 @@ public class CommonFunction extends CoTopComponent {
 		
 		case "partner":
 			PartnerMaster partner = new PartnerMaster();
-			for(int i=0; i<prjIds.length; i++) {
+			for (int i=0; i<prjIds.length; i++) {
 				userIdList = new ArrayList<>();
 				partner.setPartnerId(prjIds[i]);
 				PartnerMaster bean = partnerService.getPartnerMasterOne(partner);
 				
 				userIdList.add(bean.getCreator());
-				if(bean.getPartnerWatcher() != null) {
-					for(String watcher : bean.getPartnerWatcher().stream().map(e -> e.getUserId()).collect(Collectors.toList())) {
+				if (bean.getPartnerWatcher() != null) {
+					for (String watcher : bean.getPartnerWatcher().stream().map(e -> e.getUserId()).collect(Collectors.toList())) {
 						userIdList.add(watcher);
 					}
 				}
 				
 				userIdList = userIdList.stream().distinct().collect(Collectors.toList());
-				if(!isEmpty(userId)) {
-					if(!userIdList.contains(userId)) {
+				if (!isEmpty(userId)) {
+					if (!userIdList.contains(userId)) {
 						notPermissionList.add(prjIds[i]);
 					}
 				} else {

--- a/src/main/java/oss/fosslight/common/CorsFilter.java
+++ b/src/main/java/oss/fosslight/common/CorsFilter.java
@@ -34,7 +34,7 @@ public class CorsFilter implements Filter {
         response.setHeader("Access-Control-Max-Age", "3600");
         response.setHeader("Access-Control-Allow-Headers", "*");
         
-        if("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
             response.setStatus(HttpServletResponse.SC_OK);
         }else {
             chain.doFilter(req, res);

--- a/src/main/java/oss/fosslight/common/CustomXssFilter.java
+++ b/src/main/java/oss/fosslight/common/CustomXssFilter.java
@@ -21,7 +21,7 @@ import oss.fosslight.domain.PartnerMaster;
 public class CustomXssFilter {
 
     public static void licenseMasterFilter(List<LicenseMaster> list) {
-        for(LicenseMaster licenseMaster : list) {
+        for (LicenseMaster licenseMaster : list) {
 
             licenseMasterFilter(licenseMaster);
         }
@@ -42,7 +42,7 @@ public class CustomXssFilter {
     }
 
     public static void ossMasterFilter(List<OssMaster> list) {
-        for(OssMaster ossMaster : list) {
+        for (OssMaster ossMaster : list) {
 
             ossMasterFilter(ossMaster);
         }
@@ -63,7 +63,7 @@ public class CustomXssFilter {
     }
 
     public static void projectFilter(List<Project> list) {
-        for(Project project : list) {
+        for (Project project : list) {
 
             projectFilter(project);
         }
@@ -76,7 +76,7 @@ public class CustomXssFilter {
     }
 
     public static void partnerFilter(List<PartnerMaster> list) {
-        for(PartnerMaster partner : list) {
+        for (PartnerMaster partner : list) {
 
             partnerFilter(partner);
         }

--- a/src/main/java/oss/fosslight/common/ShellCommander.java
+++ b/src/main/java/oss/fosslight/common/ShellCommander.java
@@ -31,24 +31,24 @@ public class ShellCommander extends CoTopComponent {
 			br = new BufferedReader(isr);
 			String line;
 			
-			while((line = br.readLine()) != null) {
+			while ((line = br.readLine()) != null) {
 				list.add(line);
 			}
 			
 		} finally {
-			if(br != null) { 
+			if (br != null) { 
 				try {br.close();} catch (Exception e) {}
 			}
 			
-			if(isr != null) {
+			if (isr != null) {
 				try {isr.close();} catch (Exception e) {}
 			}
 			
-			if(is != null) {
+			if (is != null) {
 				try {is.close();} catch (Exception e) {}
 			}
 			
-			if(process != null) {
+			if (process != null) {
 				try {process.destroy();} catch (Exception e) {}
 			}
 	}
@@ -69,23 +69,23 @@ public class ShellCommander extends CoTopComponent {
 			br = new BufferedReader(isr);
 			String line;
 			
-			while((line = br.readLine()) != null) {
+			while ((line = br.readLine()) != null) {
 				list.add(line);
 			}
 		} finally {
-			if(br != null) { 
+			if (br != null) { 
 				try {br.close();} catch (Exception e) {}
 			}
 			
-			if(isr != null) {
+			if (isr != null) {
 				try {isr.close();} catch (Exception e) {}
 			}
 			
-			if(is != null) {
+			if (is != null) {
 				try {is.close();} catch (Exception e) {}
 			}
 			
-			if(process != null) {
+			if (process != null) {
 				try {process.destroy();} catch (Exception e) {}
 			}
 		}
@@ -106,23 +106,23 @@ public class ShellCommander extends CoTopComponent {
 			br = new BufferedReader(isr);
 			String line;
 			
-			while((line = br.readLine()) != null) {
+			while ((line = br.readLine()) != null) {
 				log.debug("ShellCommander : "+line);
 			}
 		} finally {
-			if(br != null) { 
+			if (br != null) { 
 				try {br.close();} catch (Exception e) {}
 			}
 			
-			if(isr != null) {
+			if (isr != null) {
 				try {isr.close();} catch (Exception e) {}
 			}
 			
-			if(is != null) {
+			if (is != null) {
 				try {is.close();} catch (Exception e) {}
 			}
 			
-			if(process != null) {
+			if (process != null) {
 				try {process.destroy();} catch (Exception e) {}
 			}
 		}

--- a/src/main/java/oss/fosslight/config/AppConfig.java
+++ b/src/main/java/oss/fosslight/config/AppConfig.java
@@ -33,7 +33,7 @@ public class AppConfig {
 		JavaMailSenderImpl mailSenderImpl = new JavaMailSenderImpl();
 		String smtpUseFlag = CommonFunction.getProperty("mail.smtp.useflag");
 		
-		if(CoConstDef.FLAG_YES.equals(smtpUseFlag)) {
+		if (CoConstDef.FLAG_YES.equals(smtpUseFlag)) {
 			try {
 				final String	MAIL_SERVICE_HOST		= CommonFunction.getProperty("mail.smtp.host");
 				final int		MAIL_SERVICE_PORT		= Integer.parseInt(StringUtil.avoidNull(CommonFunction.getProperty("mail.smtp.port"), "25"));
@@ -45,7 +45,7 @@ public class AppConfig {
 				final Properties MAIL_SERVICE_PROP = new Properties() {
 					private static final long serialVersionUID = 1L;
 					{
-						if(checkFlag) {
+						if (checkFlag) {
 							setProperty("mail.smtp.host", MAIL_SERVICE_HOST);
 							setProperty("mail.smtp.user", MAIL_SERVICE_USERNAME);
 							setProperty("mail.smtp.port", String.valueOf(MAIL_SERVICE_PORT));
@@ -62,7 +62,7 @@ public class AppConfig {
 				mailSenderImpl.setDefaultEncoding(MAIL_SERVICE_ENCODING);
 				mailSenderImpl.setJavaMailProperties(MAIL_SERVICE_PROP);
 				
-				if(!checkFlag) {
+				if (!checkFlag) {
 					mailSenderImpl.setUsername(MAIL_SERVICE_USERNAME);
 					mailSenderImpl.setPassword(MAIL_SERVICE_PASSWORD);
 				}

--- a/src/main/java/oss/fosslight/config/CustomAuthenticationProvider.java
+++ b/src/main/java/oss/fosslight/config/CustomAuthenticationProvider.java
@@ -51,26 +51,26 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
         String ldapFlag = CoCodeManager.getCodeExpString(CoConstDef.CD_SYSTEM_SETTING, CoConstDef.CD_LDAP_USED_FLAG);
         List<String> customAccounts = Arrays.asList(CommonFunction.emptyCheckProperty("custom.accounts", "").split(","));
         
-        if(CoConstDef.FLAG_YES.equals(ldapFlag) && !customAccounts.contains(user_id)) {
+        if (CoConstDef.FLAG_YES.equals(ldapFlag) && !customAccounts.contains(user_id)) {
         	rtnMap = checkByADUser(user_id, user_pw, rtnMap);
         	loginSuccess = (boolean) rtnMap.get("isAuthenticated");
         } else {
         	loginSuccess = checkSystemUser(user_id, user_pw);
         }
         
-        if(loginSuccess) {
+        if (loginSuccess) {
             List<GrantedAuthority> roles = new ArrayList<GrantedAuthority>();
             T2Users user = new T2Users();
             user.setUserId(user_id);
             T2Users getUser = userService.getUserAndAuthorities(user);
             
-            for(T2Authorities auth : getUser.getAuthoritiesList()) {
+            for (T2Authorities auth : getUser.getAuthoritiesList()) {
             	roles.add(new SimpleGrantedAuthority(auth.getAuthority()));
             }
             
             return new UsernamePasswordAuthenticationToken(user_id, user_pw, roles);          
         } else {
-        	if(rtnMap.containsKey("msg")) {
+        	if (rtnMap.containsKey("msg")) {
         		throw new BadCredentialsException((String) rtnMap.get("msg"));
         	} else {
                 throw new BadCredentialsException("Bad credentials");
@@ -106,7 +106,7 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 				rtnMap.put("isAuthenticated", false);
 				return rtnMap;
 			} finally {
-				if(con != null) {
+				if (con != null) {
 					try {
 						con.close();
 					} catch (Exception e) {}
@@ -114,7 +114,7 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 			}
 			
 			// 사용자 가입여부 체크
-			if(!userService.existUserIdOrEmail(user_id)){
+			if (!userService.existUserIdOrEmail(user_id)){
 				T2Users vo = new T2Users();
 				vo.setUserId(user_id);
 				vo.setCreatedDateCurrentTime();
@@ -127,13 +127,13 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 				String userEmail = info[1];
 				String userEmailCnt = info[2];
 				
-				if(StringUtil.isEmptyTrimmed(userEmail) || StringUtil.isEmptyTrimmed(userName)) {
+				if (StringUtil.isEmptyTrimmed(userEmail) || StringUtil.isEmptyTrimmed(userName)) {
 					log.debug("Cannot find Ldap user information : " + vo.getUserId());
 					rtnMap.put("isAuthenticated", false);
 					return rtnMap;
 				}
 				
-				if(Integer.parseInt(userEmailCnt) > 1 && StringUtil.isNotEmpty(userEmail)) {
+				if (Integer.parseInt(userEmailCnt) > 1 && StringUtil.isNotEmpty(userEmail)) {
 					log.debug("ldap user email duplicate : " + vo.getUserId());
 					rtnMap.put("isAuthenticated", false);
 					rtnMap.put("msg", "enter email");

--- a/src/main/java/oss/fosslight/config/SecurityConfig.java
+++ b/src/main/java/oss/fosslight/config/SecurityConfig.java
@@ -151,7 +151,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             T2Users userInfo = userService.getUserAndAuthorities(user);
             
             HashMap<String, Object> info = new HashMap<String, Object>();
-			if(StringUtil.isEmptyTrimmed(userInfo.getDivision())){
+			if (StringUtil.isEmptyTrimmed(userInfo.getDivision())){
 				userInfo.setDivision(CoConstDef.CD_USER_DIVISION_EMPTY);
 			}
             info.put("sessUserInfo", userInfo);
@@ -205,11 +205,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			String error = "true";
 			String message = "Invalid ID or password. Please try again.";
 			
-			if(exception.getMessage().equals("enter email")) {
+			if (exception.getMessage().equals("enter email")) {
 				message = exception.getMessage();
 			}
 			
-			if( StringUtil.indexOf(accept, "html") > -1 ) {
+			if ( StringUtil.indexOf(accept, "html") > -1 ) {
 				String redirectUrl = request.getParameter(this.targetUrlParameter);
 			   
 				if (redirectUrl != null) {
@@ -235,7 +235,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				out.print(data);
 				out.flush();
 				out.close();
-			} else if( StringUtil.indexOf(accept, "json") > -1 ) {
+			} else if ( StringUtil.indexOf(accept, "json") > -1 ) {
 				response.setContentType("application/json");
 				response.setCharacterEncoding("utf-8");
 				

--- a/src/main/java/oss/fosslight/controller/AdviceController.java
+++ b/src/main/java/oss/fosslight/controller/AdviceController.java
@@ -30,7 +30,7 @@ public class AdviceController extends CoTopComponent{
 	public String getSessUserId(){
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		
-		if(auth != null) {
+		if (auth != null) {
 			return auth.getName();
 		}
 		
@@ -44,13 +44,13 @@ public class AdviceController extends CoTopComponent{
 		HashMap<String, Object> sessDetailInfo = null;
 		T2Users sessUserInfo = null;
 		
-		if(auth != null) {			
+		if (auth != null) {			
 			try{
 				sessDetailInfo = (HashMap<String, Object>) auth.getDetails();
 			}catch(Exception e){
 			}
 			
-			if(sessDetailInfo != null){
+			if (sessDetailInfo != null){
 				sessUserInfo = (T2Users)sessDetailInfo.get("sessUserInfo");
 			}else{
 			}

--- a/src/main/java/oss/fosslight/controller/CodeController.java
+++ b/src/main/java/oss/fosslight/controller/CodeController.java
@@ -86,7 +86,7 @@ public class CodeController extends CoTopComponent {
 			, Model model) throws Exception{
 		T2CoValidationResult vResult = validateWithAppendix(req, "PROC_MODE", "ADD");
 		
-		if(!vResult.isValid()) {
+		if (!vResult.isValid()) {
 			return makeJsonResponseHeader(vResult.getValidMessageMap());
 		}
 		
@@ -107,7 +107,7 @@ public class CodeController extends CoTopComponent {
 
 		T2CoValidationResult vResult = validate(vo.getT2codeDtl());
 		
-		if(!vResult.isValid()) {
+		if (!vResult.isValid()) {
 			return makeJsonResponseHeader(vResult.getValidMessageMap());
 		}
 		

--- a/src/main/java/oss/fosslight/controller/CommentController.java
+++ b/src/main/java/oss/fosslight/controller/CommentController.java
@@ -64,16 +64,16 @@ public class CommentController extends CoTopComponent {
 		commentsHistory.setReferenceId(rId);
 		model.addAttribute("basicInfo", commentsHistory);
 		
-		if("prj".equalsIgnoreCase(rDiv)) {
+		if ("prj".equalsIgnoreCase(rDiv)) {
 			model.addAttribute("project", projectService.getProjectBasicInfo(rId));
-		} else if("3rd".equalsIgnoreCase(rDiv)) {
+		} else if ("3rd".equalsIgnoreCase(rDiv)) {
 		    PartnerMaster partnerMaster = new PartnerMaster();
 	        partnerMaster.setPartnerId(rId);
 	        
 		    model.addAttribute("partner", partnerService.getPartnerMasterOne(partnerMaster));
-		} else if("oss".equalsIgnoreCase(rDiv)) {
+		} else if ("oss".equalsIgnoreCase(rDiv)) {
 			
-		} else if("license".equalsIgnoreCase(rDiv)) {
+		} else if ("license".equalsIgnoreCase(rDiv)) {
 			
 		}
 		

--- a/src/main/java/oss/fosslight/controller/ComplianceController.java
+++ b/src/main/java/oss/fosslight/controller/ComplianceController.java
@@ -73,10 +73,10 @@ public class ComplianceController extends CoTopComponent {
 		partnerMaster.setSortField(sidx);
 		partnerMaster.setSortOrder(sord);
 		
-		if(partnerMaster.getStatus() != null) {
+		if (partnerMaster.getStatus() != null) {
 			String statuses = partnerMaster.getStatus();
 			
-			if(!isEmpty(statuses)) {
+			if (!isEmpty(statuses)) {
 				String[] arrStatuses = statuses.split(",");
 				partnerMaster.setArrStatuses(arrStatuses);
 			}
@@ -98,12 +98,12 @@ public class ComplianceController extends CoTopComponent {
 	@PostMapping(value = COMPLIANCE.MODEL_LIST_AJAX)
 	public @ResponseBody ResponseEntity<Object> modelListAjax(@RequestBody Project project, HttpServletRequest req,
 			HttpServletResponse res, Model model) {
-		if(!isEmpty(project.getModelName())){
+		if (!isEmpty(project.getModelName())){
 			String[] modelNames = project.getModelName().split(",");
 			List<String> modelListInfo = new ArrayList<String>();
 			
-			for(String modelName : modelNames){
-				if(modelListInfo.indexOf(modelName) == -1){
+			for (String modelName : modelNames){
+				if (modelListInfo.indexOf(modelName) == -1){
 					modelListInfo.add(modelName);
 				}
 			}
@@ -123,7 +123,7 @@ public class ComplianceController extends CoTopComponent {
 		//엑셀 분석
 		List<Project> modelList = ExcelUtil.getModelList(req, CommonFunction.emptyCheckProperty("upload.path", "/upload"));
 		
-		if(modelList == null) {
+		if (modelList == null) {
 			return makeJsonResponseHeader(false, "");
 		}
 		

--- a/src/main/java/oss/fosslight/controller/ConfigurationController.java
+++ b/src/main/java/oss/fosslight/controller/ConfigurationController.java
@@ -68,7 +68,7 @@ public class ConfigurationController extends CoTopComponent {
 
         Object searchFilter = searchService.getSearchFilter(configuration.getDefaultSearchType(), loginUserName());
 
-        if(searchFilter != null) {
+        if (searchFilter != null) {
 			model.addAttribute("searchBean", searchFilter);
         } else {
 			switch (SearchType.valueOf(configuration.getDefaultSearchType())) {
@@ -101,14 +101,14 @@ public class ConfigurationController extends CoTopComponent {
 			
 			// Check Comma separated Multiple Checkbox values
 			List<String> unnecessaryKeys = new ArrayList<>();
-			for(String key : params.keySet()) {
-				if(key.startsWith("chk_")) {
+			for (String key : params.keySet()) {
+				if (key.startsWith("chk_")) {
 					params.put(key.replaceFirst("chk_", ""), params.get(key));
 					unnecessaryKeys.add(key);
 				}
 			}
-			if(!unnecessaryKeys.isEmpty()) {
-				for(String key : unnecessaryKeys) {
+			if (!unnecessaryKeys.isEmpty()) {
+				for (String key : unnecessaryKeys) {
 					params.remove(key);
 				}
 			}

--- a/src/main/java/oss/fosslight/controller/DownloadProcController.java
+++ b/src/main/java/oss/fosslight/controller/DownloadProcController.java
@@ -48,7 +48,7 @@ public class DownloadProcController extends CoTopComponent {
 		fileVo.setFileSeq(seq);
 		fileVo = fileMapper.getFileInfo(fileVo);
 		
-		if(fileVo == null){
+		if (fileVo == null){
 			HttpHeaders responseHeaders = new HttpHeaders();
 			responseHeaders.add(HttpHeaders.CONTENT_LENGTH, Long.toString(0));
 			responseEntity = new ResponseEntity<FileSystemResource>(null, responseHeaders, HttpStatus.NOT_FOUND);
@@ -58,11 +58,11 @@ public class DownloadProcController extends CoTopComponent {
 			String downName = "";
 			
 			// 파일명이 같을 경우만 다운로드되도록 한다.
-			if(logiNm.equals(fName)){
+			if (logiNm.equals(fName)){
 				//파일 인코딩
 				String browser = req.getHeader("User-Agent");
 				
-		        if(browser.contains("MSIE") || browser.contains("Trident") || browser.contains("Chrome")){
+		        if (browser.contains("MSIE") || browser.contains("Trident") || browser.contains("Chrome")){
 		            downName = URLEncoder.encode(origNm,"UTF-8").replaceAll("\\+", "%20");
 		        } else {
 		            downName = new String(origNm.getBytes("UTF-8"), "ISO-8859-1");
@@ -103,7 +103,7 @@ public class DownloadProcController extends CoTopComponent {
 		ResponseEntity<FileSystemResource> responseEntity = null;
 		String baseImageUrl = "http://" + req.getServerName();
 		
-		if(req.getServerPort() != 80) {
+		if (req.getServerPort() != 80) {
 			baseImageUrl += ":" + Integer.toString(req.getServerPort());
 		}
 		
@@ -115,13 +115,13 @@ public class DownloadProcController extends CoTopComponent {
 		File file = new File(filePath);
 		
 		// 파일명이 같을 경우만 다운로드되도록 한다.
-		if(file.exists() && file.isFile()){
+		if (file.exists() && file.isFile()){
 			fileName+=".html";
 		    String encodedFilename = URLEncoder.encode(fileName,"UTF-8").replace("+", "%20");
 		    File tempFile = Paths.get(CommonFunction.emptyCheckProperty("image.temp.path", "/imagetemp")).resolve("BAT").resolve(batId).resolve(file.getName()).toFile();
 		   
 		    try {
-		    	if(!tempFile.exists()) {
+		    	if (!tempFile.exists()) {
 		    		String content = FileUtils.readFileToString(file, "UTF-8");
 		    		content = content.replaceAll("img src=\"../images/", "img src=\""+baseImageUrl+"");
 		    		

--- a/src/main/java/oss/fosslight/controller/ExcelDownloadController.java
+++ b/src/main/java/oss/fosslight/controller/ExcelDownloadController.java
@@ -57,13 +57,13 @@ public class ExcelDownloadController extends CoTopComponent {
 		String downloadId = null;
 		
 		try {
-			if(map.containsKey("extParam")) {
+			if (map.containsKey("extParam")) {
 				downloadId = ExcelDownLoadUtil.getExcelDownloadId((String)map.get("type"), (String)map.get("parameter"), RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX, (String)map.get("extParam"));				
 			} else {
 				downloadId = ExcelDownLoadUtil.getExcelDownloadId((String)map.get("type"), (String)map.get("parameter"), RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 			}
 			
-			if(isEmpty(downloadId)){
+			if (isEmpty(downloadId)){
 				return makeJsonResponseHeader(false, "overflow");
 			}
 		} catch (Exception e) {
@@ -82,7 +82,7 @@ public class ExcelDownloadController extends CoTopComponent {
 		try {
 			downloadId = ExcelDownLoadUtil.getExcelDownloadIdOss("OSS", ossMaster , RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 			
-			if(isEmpty(downloadId)){
+			if (isEmpty(downloadId)){
 				return makeJsonResponseHeader(false, "overflow");
 			}
 		} catch (Exception e) {
@@ -119,7 +119,7 @@ public class ExcelDownloadController extends CoTopComponent {
 		try {
 			downloadId = ExcelDownLoadUtil.getChartExcel(params, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 			
-			if(isEmpty(downloadId)){
+			if (isEmpty(downloadId)){
 				return makeJsonResponseHeader(false, "overflow");
 			}
 		} catch (Exception e) {

--- a/src/main/java/oss/fosslight/controller/ImageUploadProcController.java
+++ b/src/main/java/oss/fosslight/controller/ImageUploadProcController.java
@@ -39,18 +39,18 @@ public class ImageUploadProcController extends CoTopComponent {
 		fileInfo.setGubn(CoConstDef.FILE_GUBUN_EDITOR_IMAGE);
 		List<UploadFile> fList = fileService.uploadFile(req, fileInfo);
 		
-		if(fList != null && !fList.isEmpty()) {
-			for(UploadFile f : fList) {
-				if(f.isUploadSucc()) {
+		if (fList != null && !fList.isEmpty()) {
+			for (UploadFile f : fList) {
+				if (f.isUploadSucc()) {
 					res.setCharacterEncoding("utf-8");
 					res.setContentType("text/html;charset=utf-8");
 					printWriter = res.getWriter();
 					String _host = req.getScheme() + "://" + req.getServerName();
 					
-					if(req.getServerPort() > 0) {
+					if (req.getServerPort() > 0) {
 						int _port = req.getServerPort();
 						
-						if(80 != _port && 443 != _port) {
+						if (80 != _port && 443 != _port) {
 							_host += ":" + String.valueOf(_port);
 						}
 					}
@@ -74,17 +74,17 @@ public class ImageUploadProcController extends CoTopComponent {
 		List<UploadFile> fList = fileService.uploadFile(req, fileInfo);
 		Map<String, Object> resultMap = new HashMap<>();
 		
-		if(fList != null && !fList.isEmpty()) {
-			for(UploadFile f : fList) {
-				if(f.isUploadSucc()) {
+		if (fList != null && !fList.isEmpty()) {
+			for (UploadFile f : fList) {
+				if (f.isUploadSucc()) {
 					resultMap.put("uploaded", 1);
 					resultMap.put("fileName", f.getOriginalFilename());
 					String _host = req.getScheme() + "://" + req.getServerName();
 					
-					if(req.getServerPort() > 0) {
+					if (req.getServerPort() > 0) {
 						int _port = req.getServerPort();
 						
-						if(80 != _port && 443 != _port) {
+						if (80 != _port && 443 != _port) {
 							_host += ":" + String.valueOf(_port);
 						}
 					}
@@ -96,7 +96,7 @@ public class ImageUploadProcController extends CoTopComponent {
 			}
 		}
 		
-		if(resultMap.isEmpty()) {
+		if (resultMap.isEmpty()) {
 			resultMap.put("uploaded", 0);
 		}
 		

--- a/src/main/java/oss/fosslight/controller/ImageViewController.java
+++ b/src/main/java/oss/fosslight/controller/ImageViewController.java
@@ -54,7 +54,7 @@ public class ImageViewController extends CoTopComponent {
 		Path reportImagePath = Paths.get(dirPath).resolve(imageName);
 		File reportImageFile = reportImagePath.toFile();
 		
-		if(reportImageFile.exists()) {
+		if (reportImageFile.exists()) {
 			T2File f = new T2File();
 			
 			try {

--- a/src/main/java/oss/fosslight/controller/LicenseController.java
+++ b/src/main/java/oss/fosslight/controller/LicenseController.java
@@ -51,17 +51,17 @@ public class LicenseController extends CoTopComponent{
 	public String list(HttpServletRequest req, HttpServletResponse res, Model model) throws Exception{
 		LicenseMaster searchBean = null;
 		
-		if(!CoConstDef.FLAG_YES.equals(req.getParameter("gnbF"))) {
+		if (!CoConstDef.FLAG_YES.equals(req.getParameter("gnbF"))) {
 			deleteSession(SESSION_KEY_SEARCH);
 			searchBean = searchService.getLicenseSearchFilter(loginUserName());
-			if(searchBean == null) {
+			if (searchBean == null) {
 				searchBean = new LicenseMaster();
 			}
-		} else if(getSessionObject(SESSION_KEY_SEARCH) != null) {
+		} else if (getSessionObject(SESSION_KEY_SEARCH) != null) {
 			searchBean = (LicenseMaster) getSessionObject(SESSION_KEY_SEARCH);
 		}
 		
-		if(getSessionObject("defaultLoadYn") != null) {
+		if (getSessionObject("defaultLoadYn") != null) {
 			model.addAttribute("defaultLoadYn", CoConstDef.FLAG_YES);
 			
 			deleteSession("defaultLoadYn");
@@ -79,7 +79,7 @@ public class LicenseController extends CoTopComponent{
 			, HttpServletResponse res
 			, Model model){
 		
-		if("Y".equals(req.getParameter("ignoreSearchFlag"))) {
+		if ("Y".equals(req.getParameter("ignoreSearchFlag"))) {
 			return makeJsonResponseHeader(new HashMap<String, Object>());
 		}
 		
@@ -93,17 +93,17 @@ public class LicenseController extends CoTopComponent{
 		licenseMaster.setSortField(sidx);
 		licenseMaster.setSortOrder(sord);
 
-		if("search".equals(req.getParameter("act"))) {
+		if ("search".equals(req.getParameter("act"))) {
 			// 검색 조건 저장
 			putSessionObject(SESSION_KEY_SEARCH, licenseMaster);
-		} else if(getSessionObject(SESSION_KEY_SEARCH) != null) {
+		} else if (getSessionObject(SESSION_KEY_SEARCH) != null) {
 			licenseMaster = (LicenseMaster) getSessionObject(SESSION_KEY_SEARCH);
 		}
 		
 		Map<String, Object> map = null;
 		
 		try {
-			if(isEmpty(licenseMaster.getLicenseNameAllSearchFlag())) {
+			if (isEmpty(licenseMaster.getLicenseNameAllSearchFlag())) {
 				licenseMaster.setLicenseNameAllSearchFlag(CoConstDef.FLAG_NO);
 			}
 			
@@ -128,11 +128,11 @@ public class LicenseController extends CoTopComponent{
 		licenseMaster = licenseService.getLicenseMasterOne(licenseMaster);
 		boolean distributionFlag = CommonFunction.propertyFlagCheck("distribution.use.flag", CoConstDef.FLAG_YES);
 		
-		if(licenseMaster != null) {
+		if (licenseMaster != null) {
 			licenseMaster.setDomain(CommonFunction.getDomain(req));
 			licenseMaster.setInternalUrl(CommonFunction.makeLicenseInternalUrl(licenseMaster, distributionFlag));
 
-			if(!"ROLE_ADMIN".equals(loginUserRole())) {
+			if (!"ROLE_ADMIN".equals(loginUserRole())) {
 				// html link 형식으로 변환
 				licenseMaster.setDescription(CommonFunction.makeHtmlLinkTagWithText(licenseMaster.getDescription()));
 			}
@@ -141,7 +141,7 @@ public class LicenseController extends CoTopComponent{
 		
 		model.addAttribute("detail", toJson(licenseMaster));
 		
-		if("ROLE_ADMIN".equals(loginUserRole())) {
+		if ("ROLE_ADMIN".equals(loginUserRole())) {
 			return LICENSE.EDIT_JSP;
 		} else {
 			return LICENSE.LICENSE_VIEW_JSP;
@@ -172,7 +172,7 @@ public class LicenseController extends CoTopComponent{
 		lv.setAppendix("licenseId", licenseMaster.getLicenseId());
 		T2CoValidationResult vr = lv.validate(new HashMap<>());
 		
-		if(!vr.isValid()) {
+		if (!vr.isValid()) {
 			return makeJsonResponseHeader(false, vr.getValidMessage("LICENSE_NAME"));
 		}
 		
@@ -230,32 +230,32 @@ public class LicenseController extends CoTopComponent{
 		boolean distributionFlag = CommonFunction.propertyFlagCheck("distribution.use.flag", CoConstDef.FLAG_YES);
 		List<OssMaster> typeChangeOssIdList = null;
 
-		if(!isNew) {
+		if (!isNew) {
 			beforeBean =  licenseService.getLicenseMasterOne(licenseMaster);
 		}
 		
 		// webpages이 n건일때 0번째 값은 oss Master로 저장.
 		String[] webpages = licenseMaster.getWebpages();
-		if(webpages != null){
-			if(webpages.length >= 1){
-				for(String url : webpages){
-					if(!isEmpty(url)){
+		if (webpages != null){
+			if (webpages.length >= 1){
+				for (String url : webpages){
+					if (!isEmpty(url)){
 						licenseMaster.setWebpage(url); // 등록된 url 중 공백을 제외한 나머지에서 첫번째 url을 만나게 되면 등록을 함.
 						break;
 					}
 				}
 			}
-		} else if(webpages == null){
+		} else if (webpages == null){
 			licenseMaster.setWebpage("");
 		}
 		
 		result = licenseService.registLicenseMaster(licenseMaster);
 		
-		if(!isNew) {
+		if (!isNew) {
 			afterBean =  licenseService.getLicenseMasterOne(licenseMaster);
 
 			// licnese type이 변경된 경우, 해당 라이선스를 사용하는 oss의 license type을 재확인 한다.
-			if(!avoidNull(beforeBean.getLicenseType()).equals(avoidNull(afterBean.getLicenseType()))) {
+			if (!avoidNull(beforeBean.getLicenseType()).equals(avoidNull(afterBean.getLicenseType()))) {
 				typeChangeOssIdList = licenseService.updateOssLicenseType(result);
 			}
 			
@@ -278,10 +278,10 @@ public class LicenseController extends CoTopComponent{
 		boolean successType = false;
 		
 		try {			
-			if(isNew) {
+			if (isNew) {
 				successType = licenseService.distributeLicense(result, distributionFlag);
-			} else if(beforeBean != null && afterBean != null) {
-				if(!avoidNull(beforeBean.getLicenseName()).equals(afterBean.getLicenseName())
+			} else if (beforeBean != null && afterBean != null) {
+				if (!avoidNull(beforeBean.getLicenseName()).equals(afterBean.getLicenseName())
 						|| !avoidNull(beforeBean.getShortIdentifier()).equals(afterBean.getShortIdentifier())
 						|| !avoidNull(beforeBean.getLicenseText()).equals(afterBean.getLicenseText())) {
 					successType = licenseService.distributeLicense(result, distributionFlag);
@@ -298,18 +298,18 @@ public class LicenseController extends CoTopComponent{
 			mailBean.setParamLicenseId(result);
 			String comment = licenseMaster.getComment();
 			
-			if(!successType) { // internal url 생성 실패시 comment 남김
+			if (!successType) { // internal url 생성 실패시 comment 남김
 				comment += (isEmpty(comment) ? "" : "<br>") + "[Error] An error occurred when creating an internal URL file.";
 			}
 			
 			mailBean.setComment(comment);
 			
-			if(!isNew) {
+			if (!isNew) {
 				
 				mailBean.setParamOssList(typeChangeOssIdList);
 				
 				// code convert
-				if(beforeBean != null) {
+				if (beforeBean != null) {
 					beforeBean.setLicenseType(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_TYPE, beforeBean.getLicenseType()));
 					beforeBean.setObligation(CommonFunction.makeLicenseObligationStr(beforeBean.getObligationNotificationYn(), beforeBean.getObligationDisclosingSrcYn(), beforeBean.getObligationNeedsCheckYn()));
 					beforeBean.setModifiedDate(DateUtil.dateFormatConvert(beforeBean.getModifiedDate(), DateUtil.TIMESTAMP_PATTERN, DateUtil.DATE_PATTERN_DASH));
@@ -317,10 +317,10 @@ public class LicenseController extends CoTopComponent{
 					beforeBean.setDescription(CommonFunction.lineReplaceToBR(beforeBean.getDescription()));
 					beforeBean.setLicenseText(CommonFunction.lineReplaceToBR(beforeBean.getLicenseText()));
 					beforeBean.setAttribution(CommonFunction.lineReplaceToBR(beforeBean.getAttribution()));
-					if(beforeBean.getWebpages().length > 0) beforeBean.setWebpage(licenseService.webPageStringFormat(beforeBean.getWebpages()));
+					if (beforeBean.getWebpages().length > 0) beforeBean.setWebpage(licenseService.webPageStringFormat(beforeBean.getWebpages()));
 				}
 				
-				if(afterBean != null) {
+				if (afterBean != null) {
 					afterBean.setLicenseType(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_TYPE, afterBean.getLicenseType()));
 					afterBean.setObligation(CommonFunction.makeLicenseObligationStr(afterBean.getObligationNotificationYn(), afterBean.getObligationDisclosingSrcYn(), afterBean.getObligationNeedsCheckYn()));
 					afterBean.setModifiedDate(DateUtil.dateFormatConvert(afterBean.getModifiedDate(), DateUtil.TIMESTAMP_PATTERN, DateUtil.DATE_PATTERN_DASH));
@@ -328,7 +328,7 @@ public class LicenseController extends CoTopComponent{
 					afterBean.setDescription(CommonFunction.lineReplaceToBR(afterBean.getDescription()));
 					afterBean.setLicenseText(CommonFunction.lineReplaceToBR(afterBean.getLicenseText()));
 					afterBean.setAttribution(CommonFunction.lineReplaceToBR(afterBean.getAttribution()));
-					if(afterBean.getWebpages().length > 0) afterBean.setWebpage(licenseService.webPageStringFormat(afterBean.getWebpages()));
+					if (afterBean.getWebpages().length > 0) afterBean.setWebpage(licenseService.webPageStringFormat(afterBean.getWebpages()));
 				}
 				
 				mailBean.setCompareDataBefore(beforeBean);
@@ -344,18 +344,18 @@ public class LicenseController extends CoTopComponent{
 			// RESTRICTION(2) => Network Redistribution
 			String netWorkRestriction = CoConstDef.CD_LICENSE_NETWORK_RESTRICTION;
 			
-			if(isNew) {
-				if(licenseMaster.getRestriction().contains(netWorkRestriction)){
+			if (isNew) {
+				if (licenseMaster.getRestriction().contains(netWorkRestriction)){
 					licenseService.registNetworkServerLicense(licenseMaster.getLicenseId(), "NEW");
 				}
 			} else {
 				String type = "";
 				
-				if(beforeBean.getRestriction().contains(netWorkRestriction) && afterBean.getRestriction().contains(netWorkRestriction)){
+				if (beforeBean.getRestriction().contains(netWorkRestriction) && afterBean.getRestriction().contains(netWorkRestriction)){
 					type = "";
-				}else if(beforeBean.getRestriction().contains(netWorkRestriction) && !afterBean.getRestriction().contains(netWorkRestriction)){
+				}else if (beforeBean.getRestriction().contains(netWorkRestriction) && !afterBean.getRestriction().contains(netWorkRestriction)){
 					type = "DEL";
-				}else if(!beforeBean.getRestriction().contains(netWorkRestriction) && afterBean.getRestriction().contains(netWorkRestriction)){
+				}else if (!beforeBean.getRestriction().contains(netWorkRestriction) && afterBean.getRestriction().contains(netWorkRestriction)){
 					type = "INS";
 				}
 				
@@ -386,7 +386,7 @@ public class LicenseController extends CoTopComponent{
 			log.error(e.getMessage());
 		}
 		
-		if(!vResult.isValid()){
+		if (!vResult.isValid()){
 			return makeJsonResponseHeader(vResult.getValidMessageMap());
 		}
 		try{
@@ -433,7 +433,7 @@ public class LicenseController extends CoTopComponent{
 			, HttpServletResponse res
 			, Model model){
 		try{
-			if(!isEmpty(licenseMaster.getLicenseName()) && CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseMaster.getLicenseName().trim().toUpperCase())) {
+			if (!isEmpty(licenseMaster.getLicenseName()) && CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseMaster.getLicenseName().trim().toUpperCase())) {
 				return makeJsonResponseHeader(true, CommonFunction.lineReplaceToBR(avoidNull(CoCodeManager.LICENSE_INFO_UPPER.get(licenseMaster.getLicenseName().trim().toUpperCase()).getLicenseText())));
 			}
 		}catch(Exception e){

--- a/src/main/java/oss/fosslight/controller/NoticeController.java
+++ b/src/main/java/oss/fosslight/controller/NoticeController.java
@@ -62,7 +62,7 @@ public class NoticeController extends CoTopComponent {
 			, Model model) throws Exception{
 		T2CoValidationResult vResult = validateWithAppendix(req, "PROC_MODE", "ADD");
 		
-		if(!vResult.isValid()) {
+		if (!vResult.isValid()) {
 			return makeJsonResponseHeader(vResult.getValidMessageMap());
 		}
 		

--- a/src/main/java/oss/fosslight/controller/OssController.java
+++ b/src/main/java/oss/fosslight/controller/OssController.java
@@ -76,20 +76,20 @@ public class OssController extends CoTopComponent{
 	public String list(HttpServletRequest req, HttpServletResponse res, Model model){
 		OssMaster searchBean = null;
 		
-		if(!CoConstDef.FLAG_YES.equals(req.getParameter("gnbF"))) {
+		if (!CoConstDef.FLAG_YES.equals(req.getParameter("gnbF"))) {
 			deleteSession(SESSION_KEY_SEARCH);
 			searchBean = searchService.getOssSearchFilter(loginUserName());
-			if(searchBean == null) {
+			if (searchBean == null) {
 				searchBean = new OssMaster();
 			}
-		} else if(getSessionObject(SESSION_KEY_SEARCH) != null) {
+		} else if (getSessionObject(SESSION_KEY_SEARCH) != null) {
 			searchBean = (OssMaster) getSessionObject(SESSION_KEY_SEARCH);
 			
-			if(searchBean != null && searchBean.getCopyrights() != null && searchBean.getCopyrights().length > 0) {
+			if (searchBean != null && searchBean.getCopyrights() != null && searchBean.getCopyrights().length > 0) {
 				String _str = "";
 				
-				for(String s : searchBean.getCopyrights()) {
-					if(!isEmpty(_str)) {
+				for (String s : searchBean.getCopyrights()) {
+					if (!isEmpty(_str)) {
 						_str += "\r\n";
 					}
 					_str += s;
@@ -99,15 +99,15 @@ public class OssController extends CoTopComponent{
 			}
 		}
 		
-		if(req.getParameter("ossName") != null) { // OSS List 로드 시 Default로 ossName 검색조건에 추가
-			if(searchBean == null) {
+		if (req.getParameter("ossName") != null) { // OSS List 로드 시 Default로 ossName 검색조건에 추가
+			if (searchBean == null) {
 				searchBean = new OssMaster();
 			}
 			
 			searchBean.setOssName(req.getParameter("ossName"));
 		}
 		
-		if(getSessionObject("defaultLoadYn") != null) {
+		if (getSessionObject("defaultLoadYn") != null) {
 			model.addAttribute("defaultLoadYn", CoConstDef.FLAG_YES);
 			
 			deleteSession("defaultLoadYn");
@@ -122,8 +122,8 @@ public class OssController extends CoTopComponent{
 	public String listLink(@PathVariable String ossName, HttpServletRequest req, HttpServletResponse res, Model model) throws Exception{
 		OssMaster searchBean = null;
 		
-		if(!isEmpty(ossName)) {
-			if(searchBean == null) {
+		if (!isEmpty(ossName)) {
+			if (searchBean == null) {
 				searchBean = new OssMaster();
 			}
 			
@@ -132,7 +132,7 @@ public class OssController extends CoTopComponent{
 			searchBean.setLinkFlag(CoConstDef.FLAG_YES);
 		}
 		
-		if(getSessionObject("defaultLoadYn") != null) {
+		if (getSessionObject("defaultLoadYn") != null) {
 			model.addAttribute("defaultLoadYn", CoConstDef.FLAG_YES);
 			
 			deleteSession("defaultLoadYn");
@@ -152,7 +152,7 @@ public class OssController extends CoTopComponent{
 		
 		Map<String, Object> map = null;
 		
-		if("Y".equals(req.getParameter("ignoreSearchFlag"))) {
+		if ("Y".equals(req.getParameter("ignoreSearchFlag"))) {
 			map = new HashMap<>();
 			map.put("rows", new ArrayList<>());
 			return makeJsonResponseHeader(map);
@@ -162,7 +162,7 @@ public class OssController extends CoTopComponent{
 		int rows = Integer.parseInt(req.getParameter("rows"));
 		String sidx = req.getParameter("sidx");
 		
-		if(sidx != null) {
+		if (sidx != null) {
 			sidx  = sidx.split("[,]")[1].trim();
 		}
 		
@@ -174,15 +174,15 @@ public class OssController extends CoTopComponent{
 		// download location check
 		List<String> values = Arrays.asList("https://", "http://", "www.");
 		String homepage =req.getParameter("homepage");
-		if(!values.contains(homepage)){
+		if (!values.contains(homepage)){
 			homepage = homepage.replaceFirst("^((http|https)://)?(www.)*", "");
 			ossMaster.setHomepage(homepage);
 		}
 
-		if("search".equals(req.getParameter("act"))) {
+		if ("search".equals(req.getParameter("act"))) {
 			// 검색 조건 저장
 			putSessionObject(SESSION_KEY_SEARCH, ossMaster);
-		} else if(getSessionObject(SESSION_KEY_SEARCH) != null) {
+		} else if (getSessionObject(SESSION_KEY_SEARCH) != null) {
 			ossMaster = (OssMaster) getSessionObject(SESSION_KEY_SEARCH);
 		}
 		
@@ -210,7 +210,7 @@ public class OssController extends CoTopComponent{
 
 	@GetMapping(value={OSS.EDIT}, produces = "text/html; charset=utf-8")
 	public String edit(HttpServletRequest req, HttpServletResponse res, Model model) throws Exception{
-		if(getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_NEWOSS_DEFAULT_DATA, null)) != null) {
+		if (getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_NEWOSS_DEFAULT_DATA, null)) != null) {
 			OssMaster bean = (OssMaster) getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_NEWOSS_DEFAULT_DATA, null), true);
 			
 			model.addAttribute("ossName", avoidNull(bean.getOssName()));
@@ -218,19 +218,19 @@ public class OssController extends CoTopComponent{
 			model.addAttribute("downloadLocation", avoidNull(bean.getDownloadLocation()));
 			model.addAttribute("homepage", avoidNull(bean.getHomepage()));
 			
-			if(!isEmpty(avoidNull(bean.getLicenseName()))) {
+			if (!isEmpty(avoidNull(bean.getLicenseName()))) {
 				List<OssLicense> licenseList = new ArrayList<OssLicense>();
 				HashMap<String, Object> map = new HashMap<String, Object>();
 				int idx = 1;
 				
-				for(String licenseNm : bean.getLicenseName().split(",")) {
+				for (String licenseNm : bean.getLicenseName().split(",")) {
 					LicenseMaster master = CoCodeManager.LICENSE_INFO.get(licenseNm);
 					OssLicense result = new OssLicense();
 					
 					result.setOssLicenseIdx(""+idx);
 					result.setOssLicenseComb(idx == 1 ? "" : "AND");
 					
-					if(master != null) {
+					if (master != null) {
 						String shortIDentifier = isEmpty(master.getShortIdentifier()) ? master.getLicenseName() : master.getShortIdentifier();
 						result.setLicenseId(master.getLicenseId());
 						result.setLicenseName(master.getLicenseName());
@@ -279,11 +279,11 @@ public class OssController extends CoTopComponent{
 		Map<String, Object> map = ossService.getOssLicenseList(ossMaster);
 		ossMaster = ossService.getOssMasterOne(ossMaster);
 
-		if(ossMaster.getOssVersion() == null) {
+		if (ossMaster.getOssVersion() == null) {
 			ossMaster.setOssVersion("");
 		}
 		//getDetectedLicenses()는 detectedLicenses가 null이면 비어있는 ArrayList객체를 생성해서 반환함.
-		if(!ossMaster.getDetectedLicenses().get(0).isEmpty()) {
+		if (!ossMaster.getDetectedLicenses().get(0).isEmpty()) {
 			List<String> detectedLicenseNames = ossMaster.getDetectedLicenses();
 			Map<String, String> detectedLicenseIdByName = new HashMap<>();
 			for (String name : detectedLicenseNames) {
@@ -300,7 +300,7 @@ public class OssController extends CoTopComponent{
 		// 참조 프로젝트 목록 조회
 		boolean projectListFlag = CommonFunction.propertyFlagCheck("menu.project.use.flag", CoConstDef.FLAG_YES);
 		
-		if(projectListFlag) {
+		if (projectListFlag) {
 			// 성능이슈로 이전 son system의 프로젝트 조회와 신규 FOSSLight Hub 프로젝트 조회를 union 하지 않고 각각 조회한다.
 			List<OssComponents> components = projectMapper.selectOssRefPrjList1(ossMaster);
 			
@@ -309,7 +309,7 @@ public class OssController extends CoTopComponent{
 			
 			boolean partnerFlag = CommonFunction.propertyFlagCheck("menu.partner.use.flag", CoConstDef.FLAG_YES);
 			
-			if(partnerFlag) {
+			if (partnerFlag) {
 				componentsPartner = partnerMapper.selectOssRefPartnerList(ossMaster);
 			}
 			
@@ -321,10 +321,10 @@ public class OssController extends CoTopComponent{
 		
 		List<Vulnerability> vulnInfoList = ossService.getOssVulnerabilityList2(ossMaster);
 		
-		if(vulnInfoList != null && !vulnInfoList.isEmpty()) {
-			if(vulnInfoList.size() >= 5) {
+		if (vulnInfoList != null && !vulnInfoList.isEmpty()) {
+			if (vulnInfoList.size() >= 5) {
 				List<Vulnerability> newVulnInfoList = new ArrayList<>();
-				for(int i=0; i<5; i++) {
+				for (int i=0; i<5; i++) {
 					newVulnInfoList.add(vulnInfoList.get(i));
 				}
 				model.addAttribute("vulnListMore", "vulnListMore");
@@ -367,14 +367,14 @@ public class OssController extends CoTopComponent{
 		String _version = req.getParameter("ossVersion");
 		boolean isVersionup = false;
 		
-		if(_version != null) {
+		if (_version != null) {
 			isVersionup = true;
 		}
 		
 		Map<String, Object> map = ossService.getOssLicenseList(ossMaster);
 		ossMaster = ossService.getOssMasterOne(ossMaster);
 		
-		if(isVersionup) {
+		if (isVersionup) {
 			ossMaster.setOssVersion(_version);
 		} else {
 			ossMaster.setOssName(ossMaster.getOssName());
@@ -423,7 +423,7 @@ public class OssController extends CoTopComponent{
 		// mail 발송을 위해 삭제전 data 취득
 		OssMaster ossMailInfo = ossService.getOssInfo(ossMaster.getOssId(), true);
 		
-		if(ossMailInfo.getOssNicknames() != null) {
+		if (ossMailInfo.getOssNicknames() != null) {
 			ossMailInfo.setOssNickname(CommonFunction.arrayToString(ossMailInfo.getOssNicknames(), "<br>"));	
 		}
 
@@ -507,29 +507,29 @@ public class OssController extends CoTopComponent{
 		
 		T2CoValidationResult vr = validator.validateObject(reqMap, list, "OSS"); 
 		
-		if(CoConstDef.FLAG_YES.equals(ossMaster.getRenameFlag())) {
+		if (CoConstDef.FLAG_YES.equals(ossMaster.getRenameFlag())) {
 			boolean sameNameFlag = false;
 			boolean ossNicknameFlag= false;
 			
 			OssMaster ossInfo = ossService.getOssInfo(ossMaster.getOssId(), false);
 			
-			if(ossInfo != null && ossInfo.getOssName().equals(ossMaster.getOssName())) {
-				if(ossMaster.getOssNicknames() != null) {
-					if(ossInfo.getOssNicknames() != null) {
-						if(ossMaster.getOssNicknames().length == ossInfo.getOssNicknames().length) {
+			if (ossInfo != null && ossInfo.getOssName().equals(ossMaster.getOssName())) {
+				if (ossMaster.getOssNicknames() != null) {
+					if (ossInfo.getOssNicknames() != null) {
+						if (ossMaster.getOssNicknames().length == ossInfo.getOssNicknames().length) {
 							List<String> duplicateOssNicknames = Arrays.asList(ossMaster.getOssNicknames()).stream().filter(e -> !Arrays.asList(ossInfo.getOssNicknames()).contains(e.toString())).collect(Collectors.toList());
-							if(duplicateOssNicknames == null || duplicateOssNicknames.size() == 0) {
+							if (duplicateOssNicknames == null || duplicateOssNicknames.size() == 0) {
 								ossNicknameFlag = true;
 							}
 						}
 					}
 				}else {
-					if(ossInfo.getOssNicknames() == null) {
+					if (ossInfo.getOssNicknames() == null) {
 						ossNicknameFlag = true;
 					}
 				}
 				
-				if(ossNicknameFlag) {
+				if (ossNicknameFlag) {
 					return makeJsonResponseHeader(false, "rename");
 				}
 			}
@@ -539,43 +539,43 @@ public class OssController extends CoTopComponent{
 			
 			checkList.add(ossMaster.getOssName());
 			
-			if(CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossMaster.getOssName().toUpperCase())) {
+			if (CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossMaster.getOssName().toUpperCase())) {
 				duplicatedList.add(ossMaster.getOssName());
 				return makeJsonResponseHeader(false, "rename", duplicatedList);
 			}
 			
-			if(ossMaster.getOssNicknames() != null) {
-				for(String _nick : ossMaster.getOssNicknames()) {
-					if(!isEmpty(_nick)) {
-						if(ossMaster.getOssName().equals(_nick) || checkList.contains(_nick)) {
+			if (ossMaster.getOssNicknames() != null) {
+				for (String _nick : ossMaster.getOssNicknames()) {
+					if (!isEmpty(_nick)) {
+						if (ossMaster.getOssName().equals(_nick) || checkList.contains(_nick)) {
 							duplicatedList.add(_nick + " (The same OSS Name or Nick Name exists.)");
 							sameNameFlag = true;
 							break;
 						}
 						
-						if(checkList.isEmpty() || !checkList.contains(_nick)) {
+						if (checkList.isEmpty() || !checkList.contains(_nick)) {
 							checkList.add(_nick);
 						}
 					}
 				}
 			}
 			
-			if(sameNameFlag) {
+			if (sameNameFlag) {
 				return makeJsonResponseHeader(false, "rename", duplicatedList);
 			}
 			
 			duplicatedList = ossService.getOssNicknameListWithoutOwn(ossInfo, checkList, duplicatedList);
 			
-			if(duplicatedList != null && duplicatedList.size() > 0) {
+			if (duplicatedList != null && duplicatedList.size() > 0) {
 				return makeJsonResponseHeader(false, "rename", duplicatedList);
 			}
 			
-			if(!vr.isValid()) {
+			if (!vr.isValid()) {
 				Map<String, String> errMap = vr.getErrorCodeMap();
 				Map<String, String> checkErrMap = new HashMap<>();
 				
-				for(String key : errMap.keySet()) {
-					if(!key.contains("OSS_NAME") && !key.contains("OSS_NICKNAMES")) {
+				for (String key : errMap.keySet()) {
+					if (!key.contains("OSS_NAME") && !key.contains("OSS_NICKNAMES")) {
 						checkErrMap.put(key, errMap.get(key));
 					}
 				}
@@ -584,14 +584,14 @@ public class OssController extends CoTopComponent{
 			}
 		}
 		
-		if(!vr.isValid()) {
+		if (!vr.isValid()) {
 			return makeJsonResponseHeader(vr.getValidMessageMap());
 		}
 		
-		if(isEmpty(ossMaster.getOssId())) {
+		if (isEmpty(ossMaster.getOssId())) {
 			OssMaster checkOssInfo = ossService.getOssInfo(ossMaster.getOssId(), ossMaster.getOssName(), false);
 			
-			if(checkOssInfo != null && CoConstDef.FLAG_YES.equals(checkOssInfo.getDeactivateFlag())) {
+			if (checkOssInfo != null && CoConstDef.FLAG_YES.equals(checkOssInfo.getDeactivateFlag())) {
 				return makeJsonResponseHeader(false, "deactivate");
 			} else {
 				// 신규 등록인 경우 nick name 체크(변경된 사항이 있는 경우, 삭제는 불가)
@@ -599,7 +599,7 @@ public class OssController extends CoTopComponent{
 				
 				// 삭제는 불가능하기 때문에, 건수가 다르면 기존에 등록된 닉네임이 있다는 의미
 				// null을 반환하지는 않는다.
-				if(_mergeNicknames.length > 0) {
+				if (_mergeNicknames.length > 0) {
 					return makeJsonResponseHeader(false, null, _mergeNicknames);
 				}
 			}
@@ -608,23 +608,23 @@ public class OssController extends CoTopComponent{
 			// 변경전 정보를 취득
 			OssMaster orgBean = ossService.getOssInfo(ossMaster.getOssId(), false);
 			
-			if(CoConstDef.FLAG_YES.equals(ossMaster.getDeactivateFlag()) 
+			if (CoConstDef.FLAG_YES.equals(ossMaster.getDeactivateFlag()) 
 					&& CoConstDef.FLAG_YES.equals(orgBean.getDeactivateFlag())) {
 				return makeJsonResponseHeader(false, "deactivate");
 			}
 			
 			// oss name 변경 여부 확인
-			if(orgBean != null && !ossMaster.getOssName().equalsIgnoreCase(orgBean.getOssNameTemp())) {
+			if (orgBean != null && !ossMaster.getOssName().equalsIgnoreCase(orgBean.getOssNameTemp())) {
 				// 기존 oss name 이 변경되었는데, oss nick name 까지 동시에 변경 할 경우 제외
 				String[] orgNickNames = ossService.getOssNickNameListByOssName(orgBean.getOssNameTemp());
-				if(orgNickNames != null && orgNickNames.length > 0) {
+				if (orgNickNames != null && orgNickNames.length > 0) {
 					boolean ossNameCheck = false;
 					
-					if(ossMaster.getOssNicknames() != null) {
-						if(orgNickNames.length != ossMaster.getOssNicknames().length) {
+					if (ossMaster.getOssNicknames() != null) {
+						if (orgNickNames.length != ossMaster.getOssNicknames().length) {
 							ossNameCheck = true;
 						} else {
-							if(!Arrays.equals(orgNickNames, ossMaster.getOssNicknames())){
+							if (!Arrays.equals(orgNickNames, ossMaster.getOssNicknames())){
 								ossNameCheck = true;
 							}
 						}
@@ -632,7 +632,7 @@ public class OssController extends CoTopComponent{
 						ossNameCheck = true;
 					}
 					
-					if(ossNameCheck) {
+					if (ossNameCheck) {
 						return makeJsonResponseHeader(false, "notChange");
 					}
 				}
@@ -643,19 +643,19 @@ public class OssController extends CoTopComponent{
 				Map<String, List<String>> diffMap = new HashMap<>();
 				String[] orgNicks = ossService.getOssNickNameListByOssName(ossMaster.getOssName());
 				
-				if(orgNicks != null && orgNicks.length > 0) {
-					for(String s : orgNicks) {
+				if (orgNicks != null && orgNicks.length > 0) {
+					for (String s : orgNicks) {
 						orgNickList.add(s);
 					}
 				}
 				
 				// 기존 oss name에 물려있는 nick name이 존재하는 경우, nick name은 무시됨
 				// 변경 후 oss name에 nick name이 존재하는 경우 이관됨
-				if(ossMaster.getOssNicknames() != null) {
-					for(String _nick : ossMaster.getOssNicknames()) {
-						if(!isEmpty(_nick)) {
+				if (ossMaster.getOssNicknames() != null) {
+					for (String _nick : ossMaster.getOssNicknames()) {
+						if (!isEmpty(_nick)) {
 							// 삭제되는 oss
-							if(orgNickList.isEmpty() || !orgNickList.contains(_nick)) {
+							if (orgNickList.isEmpty() || !orgNickList.contains(_nick)) {
 								delNickList.add(_nick);
 							}
 						}
@@ -663,37 +663,37 @@ public class OssController extends CoTopComponent{
 				}
 				
 				// 변경하려는 oss name에 nick name이 등록되어 있는 상태이면 merge 해야함
-				if(!orgNickList.isEmpty()) {
+				if (!orgNickList.isEmpty()) {
 					boolean isChange = !delNickList.isEmpty();
 					
-					if(!isChange) {
+					if (!isChange) {
 						// 대상 nick name과 현재 oss name이 동일하면 pass
 						List<String> currNickNameList = new ArrayList<>();
 						
-						if(ossMaster.getOssNicknames() != null) {
-							for(String _nick : ossMaster.getOssNicknames()) {
-								if(!isEmpty(_nick)) {
+						if (ossMaster.getOssNicknames() != null) {
+							for (String _nick : ossMaster.getOssNicknames()) {
+								if (!isEmpty(_nick)) {
 									currNickNameList.add(_nick);
 								}
 							}
 						}
 						
-						if(orgNickList.size() != currNickNameList.size()) {
+						if (orgNickList.size() != currNickNameList.size()) {
 							isChange = true;
 						}
 						
-						for(String s : orgNickList) {
-							if(!currNickNameList.contains(s)) {
+						for (String s : orgNickList) {
+							if (!currNickNameList.contains(s)) {
 								isChange = true;
 								break;
 							}
 						}
 					}
 					
-					if(isChange) {
+					if (isChange) {
 						diffMap.put("addNickArr", orgNickList);
 						
-						if(!delNickList.isEmpty()) {
+						if (!delNickList.isEmpty()) {
 							diffMap.put("delNickArr", delNickList);
 						}
 						return makeJsonResponseHeader(false, "hasDelNick", diffMap);
@@ -772,7 +772,7 @@ public class OssController extends CoTopComponent{
 			log.error(e.getMessage());
 		}
 		
-		if(!vResult.isValid()) {
+		if (!vResult.isValid()) {
 			return makeJsonResponseHeader(vResult.getValidMessageMap());
 		}
 		
@@ -803,17 +803,17 @@ public class OssController extends CoTopComponent{
 		validator.setAppendix("ossMaster", ossMaster);
 		String validType = ossMaster.getValidationType();
 		
-		if(validator.VALID_DOWNLOADLOCATION.equals(validType)){
+		if (validator.VALID_DOWNLOADLOCATION.equals(validType)){
 			validator.setVALIDATION_TYPE(validator.VALID_DOWNLOADLOCATION);
-		} else if(validator.VALID_DOWNLOADLOCATIONS.equals(validType)){
+		} else if (validator.VALID_DOWNLOADLOCATIONS.equals(validType)){
 			validator.setVALIDATION_TYPE(validator.VALID_DOWNLOADLOCATIONS);
-		}else if(validator.VALID_HOMEPAGE.equals(validType)){
+		}else if (validator.VALID_HOMEPAGE.equals(validType)){
 			validator.setVALIDATION_TYPE(validator.VALID_HOMEPAGE);
 		}
 		
 		T2CoValidationResult vr = validator.validateObject(ossMaster);
 		
-		if(!vr.isDiff()) {
+		if (!vr.isDiff()) {
 			return makeJsonResponseHeader(true, null, null, null, vr.getDiffMessageMap());
 		}
 		
@@ -828,19 +828,19 @@ public class OssController extends CoTopComponent{
 			, Model model){
 		OssMaster orgMaster = null;
 		
-		if(!isEmpty(ossMaster.getOssName())) {
-			if(CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossMaster.getOssName().toUpperCase())) {
+		if (!isEmpty(ossMaster.getOssName())) {
+			if (CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossMaster.getOssName().toUpperCase())) {
 				orgMaster = ossService.getLastModifiedOssInfoByName(ossMaster);
 			}else {
 				orgMaster = ossService.getSaveSesstionOssInfoByName(ossMaster);
 			}
 		}
 		
-		if(orgMaster != null && !isEmpty(orgMaster.getOssId())) {
+		if (orgMaster != null && !isEmpty(orgMaster.getOssId())) {
 			return makeJsonResponseHeader(true, orgMaster.getOssId());
 		} else {
 			try {
-				if(!putSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_NEWOSS_DEFAULT_DATA, null), ossMaster)) {
+				if (!putSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_NEWOSS_DEFAULT_DATA, null), ossMaster)) {
 					log.error("failed save session oss edit (new) "); 
 					return makeJsonResponseHeader(false, null);
 				}
@@ -885,26 +885,26 @@ public class OssController extends CoTopComponent{
 //		List<ProjectIdentification> componentList = projectMapper.selectIdentificationGridList(paramBean);
 //		int gridIdSeq = 0;
 //
-//		if(componentList != null) {
+//		if (componentList != null) {
 //			// 미등록 OSS List 정보를 추출한다.
-//			for(ProjectIdentification bean : componentList) {
-//				if(isEmpty(bean.getOssName()) || "-".equals(bean.getOssName())) {
+//			for (ProjectIdentification bean : componentList) {
+//				if (isEmpty(bean.getOssName()) || "-".equals(bean.getOssName())) {
 //					continue;
 //				}
 //
 //				String chkKey = (bean.getOssName().trim() + "_" + avoidNull(bean.getOssVersion()).trim()).toUpperCase();
 //
 //				// 중복체크
-//				if(dupCheckList.contains(chkKey)) {
+//				if (dupCheckList.contains(chkKey)) {
 //					continue;
 //				}
 //
 //				// exclude 제외
-//				if(CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+//				if (CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 //					continue;
 //				}
 //
-//				if(!CoCodeManager.OSS_INFO_UPPER.containsKey(chkKey)) {
+//				if (!CoCodeManager.OSS_INFO_UPPER.containsKey(chkKey)) {
 //					// licnese 정보 취득
 //					ProjectIdentification licenseParam = new ProjectIdentification();
 //					licenseParam.setComponentId(bean.getComponentId());
@@ -912,7 +912,7 @@ public class OssController extends CoTopComponent{
 //
 //					String licenseName = CommonFunction.makeLicenseExpressionIdentify(licenseList);
 //
-//					if(CommonFunction.isIgnoreLicense(licenseName)){
+//					if (CommonFunction.isIgnoreLicense(licenseName)){
 //						continue;
 //					}
 //
@@ -926,12 +926,12 @@ public class OssController extends CoTopComponent{
 //					ossBean.setCopyright(bean.getCopyrightText());
 //
 //					// OSS Name이 등록되어 있는 경우, NickName을 치환한다.
-//					if(CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().toUpperCase())) {
+//					if (CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().toUpperCase())) {
 //						ossBean.setOssName(CoCodeManager.OSS_INFO_UPPER_NAMES.get(ossBean.getOssName().toUpperCase()));
 //
 //						// 등록되어 있는 oss name인 경우 마지막으로 생성한 oss를 기준으로 사용자 입력정보를 무시하고 DB에 등록된 정보를 설정한다.
 //						OssMaster lastCreatedOssBean = ossService.getLastModifiedOssInfoByName(ossBean);
-//						if(lastCreatedOssBean != null && !isEmpty(lastCreatedOssBean.getOssId())) {
+//						if (lastCreatedOssBean != null && !isEmpty(lastCreatedOssBean.getOssId())) {
 //							OssMaster masterBean = CoCodeManager.OSS_INFO_BY_ID.get(lastCreatedOssBean.getOssId());
 //							ossBean.setLicenseName(CommonFunction.makeLicenseExpression(masterBean.getOssLicenses()));
 //							String downloadLocation = StringUtil.isEmpty(lastCreatedOssBean.getDownloadLocationGroup()) ? lastCreatedOssBean.getDownloadLocation() : lastCreatedOssBean.getDownloadLocationGroup();
@@ -941,7 +941,7 @@ public class OssController extends CoTopComponent{
 //							ossBean.setSummaryDescription(masterBean.getSummaryDescription()); // OSS bulk registration > Summary Description란 추가
 //
 //							// nickname 정보를 설정한다.
-//							if(masterBean.getOssNicknames() != null) {
+//							if (masterBean.getOssNicknames() != null) {
 //								ossBean.setOssNickname(CommonFunction.arrayToString(masterBean.getOssNicknames(), ","));
 //							}
 //						}
@@ -954,7 +954,7 @@ public class OssController extends CoTopComponent{
 //					ossBean.setGridId("jqg_" + gridIdSeq++);
 //
 //					// default 정렬
-//					if(CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().toUpperCase())) {
+//					if (CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().toUpperCase())) {
 //						resultMapVer.put(chkKey, ossBean);
 //					} else {
 //						resultMap.put(chkKey, ossBean);
@@ -965,7 +965,7 @@ public class OssController extends CoTopComponent{
 //					// nick name 을 정식명칭으로 변경한 case도 중복체크에 포함한다.
 //					String chkKey2 = (bean.getOssName().trim() + "_" + avoidNull(bean.getOssVersion()).trim()).toUpperCase();
 //
-//					if(!chkKey.equals(chkKey2)) {
+//					if (!chkKey.equals(chkKey2)) {
 //						dupCheckList.add(chkKey2);
 //					}
 //				}
@@ -974,19 +974,19 @@ public class OssController extends CoTopComponent{
 //
 //		List<OssMaster> list = null;
 //
-//		if(!resultMap.isEmpty()) {
+//		if (!resultMap.isEmpty()) {
 //			list = new ArrayList<>(resultMap.values()) ;
 //		}
 //
-//		if(!resultMapVer.isEmpty()) {
-//			if(list == null) {
+//		if (!resultMapVer.isEmpty()) {
+//			if (list == null) {
 //				list = new ArrayList<>(resultMapVer.values()) ;
 //			} else {
 //				list.addAll(new ArrayList<>(resultMapVer.values()));
 //			}
 //		}
 //
-//		if(list == null) {
+//		if (list == null) {
 //			list = new ArrayList<>();
 //		}
 //
@@ -1197,7 +1197,7 @@ public class OssController extends CoTopComponent{
 			, HttpServletResponse res
 			, Model model){
 		// 이미등록되어 있는 OSS의 경우 Skip한다.
-		if(CoCodeManager.OSS_INFO_UPPER.containsKey( (ossMaster.getOssName() + "_" + avoidNull(ossMaster.getOssVersion())).toUpperCase() )) {
+		if (CoCodeManager.OSS_INFO_UPPER.containsKey( (ossMaster.getOssName() + "_" + avoidNull(ossMaster.getOssVersion())).toUpperCase() )) {
 			return makeJsonResponseHeader(true, "Skip");
 		}
 		
@@ -1213,13 +1213,13 @@ public class OssController extends CoTopComponent{
 		resMap.put("validMapResult", validMapResult);
 		resMap.put("diffMapResult", diffMapResult);
 
-		if(!vr.isValid()) {
+		if (!vr.isValid()) {
 			return makeJsonResponseHeader(resMap);
 		}
 		
 		// 기존에 동일한 이름으로 등록되어 있는 OSS Name인 지 확인
 		boolean isNewVersion = CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossMaster.getOssName().toUpperCase());
-		if(isNewVersion) {
+		if (isNewVersion) {
 			ossMaster.setExistOssNickNames(ossService.getOssNickNameListByOssName(ossMaster.getOssName()));
 		}
 		
@@ -1228,12 +1228,12 @@ public class OssController extends CoTopComponent{
 		List<OssLicense> ossLicenseList = new ArrayList<>();
 		int licenseIdx = 0;
 		
-		for(String s : ossMaster.getLicenseName().toUpperCase().split(" OR ")) {
+		for (String s : ossMaster.getLicenseName().toUpperCase().split(" OR ")) {
 			// 순서가 중요
 			String orGroupStr = s.replaceAll("\\(", " ").replaceAll("\\)", " ");
 			boolean groupFirst = true;
 			
-			for(String s2 : orGroupStr.split(" AND ")) {
+			for (String s2 : orGroupStr.split(" AND ")) {
 				LicenseMaster license = CoCodeManager.LICENSE_INFO_UPPER.get(s2.trim().toUpperCase());
 				OssLicense licenseBean = new OssLicense();
 				licenseBean.setOssLicenseIdx(String.valueOf(licenseIdx++));
@@ -1247,37 +1247,37 @@ public class OssController extends CoTopComponent{
 		
 		ossMaster.setOssLicenses(ossLicenseList);
 		
-		if(ossLicenseList.size() > 1) {
+		if (ossLicenseList.size() > 1) {
 			ossMaster.setLicenseDiv(CoConstDef.LICENSE_DIV_MULTI);
 		}
 		
 		// nick Name을 Array형으로 변경해줌
-		if(!isEmpty(ossMaster.getOssNickname())) {
+		if (!isEmpty(ossMaster.getOssNickname())) {
 			// trim 처리는 registOssMaster 내에서 처리한다.
 			ossMaster.setOssNicknames(ossMaster.getOssNickname().split(","));
 		}
 		
-		if(!isEmpty(ossMaster.getDownloadLocation())){
+		if (!isEmpty(ossMaster.getDownloadLocation())){
 			List<String> duplicateDownloadLocation = new ArrayList<>();
 			String result = "";
 			boolean isFirst = true;
 			
-			for(String url : ossMaster.getDownloadLocation().split(",")) {
-				if(duplicateDownloadLocation.contains(url)) {
+			for (String url : ossMaster.getDownloadLocation().split(",")) {
+				if (duplicateDownloadLocation.contains(url)) {
 					continue;
 				}
 				
-				if(!isEmpty(result)) {
+				if (!isEmpty(result)) {
 					result += ",";
 				}
 				
-				if(url.endsWith("/")) {
+				if (url.endsWith("/")) {
 					result += url.substring(0, url.length()-1);
 				}else {
 					result += url;
 				}
 				
-				if(isFirst) {
+				if (isFirst) {
 					ossMaster.setDownloadLocation(result);
 					isFirst = false;
 				}
@@ -1288,8 +1288,8 @@ public class OssController extends CoTopComponent{
 			ossMaster.setDownloadLocations(result.split(","));
 		}
 		
-		if(!isEmpty(ossMaster.getHomepage())) {
-			if(ossMaster.getHomepage().endsWith("/")) {
+		if (!isEmpty(ossMaster.getHomepage())) {
+			if (ossMaster.getHomepage().endsWith("/")) {
 				String homepage = ossMaster.getHomepage();
 				ossMaster.setHomepage(homepage.substring(0, homepage.length()-1));
 			}
@@ -1340,7 +1340,7 @@ public class OssController extends CoTopComponent{
 	public String ossDetailView(HttpServletRequest req, HttpServletResponse res, @ModelAttribute OssMaster bean, Model model){
 		List<OssMaster> ossList = ossService.getOssListByName(bean);
 		
-		if(ossList != null && !ossList.isEmpty()) {
+		if (ossList != null && !ossList.isEmpty()) {
 			OssMaster _bean = ossList.get(0);
 			_bean.setOssName(StringUtil.replaceHtmlEscape(_bean.getOssName()));
 			
@@ -1415,14 +1415,14 @@ public class OssController extends CoTopComponent{
 				resMap.put("validMap", validMap);
 			}
 			
-			if(!vr.isDiff()){
+			if (!vr.isDiff()){
 				Map<String, String> diffMap = vr.getDiffMessageMap();
 				result.addAll(autoFillOssInfoService.checkOssLicenseData(mainData, null, diffMap));
 				resMap.put("diffMap", diffMap);
 			}
 		}
 		
-		if(result.size() > 0) {
+		if (result.size() > 0) {
 			Map<String, Object> data = autoFillOssInfoService.checkOssLicense(result);
 			resMap.put("list", data.get("checkedData"));
 			resMap.put("error", data.get("error"));
@@ -1496,7 +1496,7 @@ public class OssController extends CoTopComponent{
 				resMap.put("validMap", validMap);
 			}
 			
-			if(!vr.isDiff()){
+			if (!vr.isDiff()){
 				Map<String, String> diffMap = vr.getDiffMessageMap();
 				result.addAll(ossService.checkOssNameData(mainData, null, diffMap));
 				resMap.put("diffMap", diffMap);
@@ -1505,12 +1505,12 @@ public class OssController extends CoTopComponent{
 			result.addAll(ossService.checkOssNameData(mainData, null, null));
 		}
 		
-		if(result.size() > 0) {
+		if (result.size() > 0) {
 			result = ossService.checkOssName(result);
 			List<ProjectIdentification> valid = new ArrayList<ProjectIdentification>();
 			List<ProjectIdentification> invalid = new ArrayList<ProjectIdentification>();
-			for(ProjectIdentification prj : result){
-				if(prj.getCheckOssList().equals("I")){
+			for (ProjectIdentification prj : result){
+				if (prj.getCheckOssList().equals("I")){
 					invalid.add(prj);
 				} else{
 					valid.add(prj);
@@ -1546,7 +1546,7 @@ public class OssController extends CoTopComponent{
 
 		Map<String, Object> map = ossService.saveOssURLNickname(paramBean);
 		boolean updatedFlag = (boolean) map.get("isValid");
-		if(updatedFlag) {
+		if (updatedFlag) {
 			CoCodeManager.getInstance().refreshOssInfo();
 			String action = CoConstDef.ACTION_CODE_UPDATE;
 			OssMaster afterBean = ossService.getOssInfo(null, paramBean.getCheckName(), true);
@@ -1583,7 +1583,7 @@ public class OssController extends CoTopComponent{
 		Map<String, Object> map = ossService.saveOssNickname(paramBean);
 		boolean updatedFlag = (boolean) map.get("isValid");
 		
-		if(updatedFlag) {
+		if (updatedFlag) {
 			CoCodeManager.getInstance().refreshOssInfo();
 			String action = CoConstDef.ACTION_CODE_UPDATE;
 			OssMaster afterBean = ossService.getOssInfo(null, paramBean.getCheckName(), true);
@@ -1652,7 +1652,7 @@ public class OssController extends CoTopComponent{
 		try {
 			downloadId = ExcelDownLoadUtil.getExcelDownloadId("autoAnalysis", ossBean.getPrjId(), RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 			
-			if(!isEmpty(downloadId)) {
+			if (!isEmpty(downloadId)) {
 				result = ossService.startAnalysis(ossBean.getPrjId(), downloadId);
 				return makeJsonResponseHeader(result);
 			}
@@ -1679,13 +1679,13 @@ public class OssController extends CoTopComponent{
 		int rows = Integer.parseInt(req.getParameter("rows"));
 		String sidx = req.getParameter("sidx");
 		
-		if(sidx != null) {
+		if (sidx != null) {
 			sidx  = sidx.split("[,]")[1].trim();
 		}
 		
 		ossMaster.setSidx(sidx);
 		
-		if(page == 0) {
+		if (page == 0) {
 			page = ossService.getAnalysisListPage(rows, ossMaster.getPrjId());
 		}
 		
@@ -1701,7 +1701,7 @@ public class OssController extends CoTopComponent{
 		
 		map = ExcelUtil.getCsvData(map, ossMaster);
 		
-		if(map == null || map.isEmpty()) {
+		if (map == null || map.isEmpty()) {
 			return makeJsonResponseHeader(result);
 		}
 		
@@ -1709,9 +1709,9 @@ public class OssController extends CoTopComponent{
 		map = ossService.getOssAnalysisList(ossMaster);
 		result = ExcelUtil.readAnalysisList(allData, (List<OssAnalysis>) map.get("rows"));
 		
-		if(!result.isEmpty()) {
+		if (!result.isEmpty()) {
 			// isValid - false(throws 발생) || true(data 조합)
-			if((boolean) result.get("isValid")) {
+			if ((boolean) result.get("isValid")) {
 				CommonFunction.setAnalysisResultList(result);
 				result.put("page", (int) map.get("page"));
 				result.put("total", (int) map.get("total"));
@@ -1739,7 +1739,7 @@ public class OssController extends CoTopComponent{
 		analysisResultData = (List<OssAnalysis>) fromJson(dataString, typeAnalysis);
 		String sessionKey = CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_ANALYSIS_RESULT_DATA, groupId);
 		
-		if(getSessionObject(sessionKey) != null) {
+		if (getSessionObject(sessionKey) != null) {
 			deleteSession(sessionKey);
 		}
 		
@@ -1765,7 +1765,7 @@ public class OssController extends CoTopComponent{
 		String sessionKey = CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_ANALYSIS_RESULT_DATA, analysisBean.getGroupId());
 		List<OssAnalysis> detailData = (List<OssAnalysis>) getSessionObject(sessionKey);
 		
-		if(detailData != null) {
+		if (detailData != null) {
 			result.put("isValid", true);
 			result.put("detailData", detailData);
 			result.put("cloneLicenseData", new OssMaster());
@@ -1805,24 +1805,24 @@ public class OssController extends CoTopComponent{
 			, HttpServletResponse res
 			, Model model){
 		// 이미등록되어 있는 OSS의 경우 Skip한다.
-		if(CoCodeManager.OSS_INFO_UPPER.containsKey( (analysisBean.getOssName() + "_" + avoidNull(analysisBean.getOssVersion())).toUpperCase() )) {
+		if (CoCodeManager.OSS_INFO_UPPER.containsKey( (analysisBean.getOssName() + "_" + avoidNull(analysisBean.getOssVersion())).toUpperCase() )) {
 			return makeJsonResponseHeader(false, "Skip");
 		}
 		
 		// analysis Data -> OssMaster 변환
 		OssMaster resultData = new OssMaster();
 		
-		if(!isEmpty(analysisBean.getOssName())) {
+		if (!isEmpty(analysisBean.getOssName())) {
 			resultData.setOssName(analysisBean.getOssName());
 		}
 		
-		if(!isEmpty(analysisBean.getOssVersion())) {
+		if (!isEmpty(analysisBean.getOssVersion())) {
 			resultData.setOssVersion(analysisBean.getOssVersion());
 		}
 		
 		// 기존에 동일한 이름으로 등록되어 있는 OSS Name인 지 확인
 		boolean isNewVersion = CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(analysisBean.getOssName().toUpperCase());
-		if(isNewVersion) {
+		if (isNewVersion) {
 			resultData.setExistOssNickNames(ossService.getOssNickNameListByOssName(resultData.getOssName()));
 		}
 		
@@ -1832,16 +1832,16 @@ public class OssController extends CoTopComponent{
 		List<OssLicense> ossLicenseList = new ArrayList<>();
 		int licenseIdx = 0;
 		
-		if(!isEmpty(analysisBean.getLicenseName())) {
-//			for(String s : analysisBean.getLicenseName().toUpperCase().split(" OR ")) {
+		if (!isEmpty(analysisBean.getLicenseName())) {
+//			for (String s : analysisBean.getLicenseName().toUpperCase().split(" OR ")) {
 				// 순서가 중요
 				String orGroupStr = analysisBean.getLicenseName().replaceAll("\\(", " ").replaceAll("\\)", " ");
 //				boolean groupFirst = true;
-				for(String s2 : orGroupStr.split(",")) {
+				for (String s2 : orGroupStr.split(",")) {
 					LicenseMaster license = CoCodeManager.LICENSE_INFO_UPPER.get(s2.trim().toUpperCase());
 					OssLicense licenseBean = new OssLicense();
 					
-					if(license != null) {
+					if (license != null) {
 						licenseBean.setOssLicenseIdx(String.valueOf(licenseIdx++));
 						licenseBean.setLicenseId(license.getLicenseId());
 						licenseBean.setLicenseName(license.getLicenseNameTemp());
@@ -1864,26 +1864,26 @@ public class OssController extends CoTopComponent{
 			resultData.setLicenseName("");
 		}
 		
-		if(ossLicenseList.size() > 1) {
+		if (ossLicenseList.size() > 1) {
 			resultData.setLicenseDiv(CoConstDef.LICENSE_DIV_MULTI);
 		}
 		
 		// nick Name을 Array형으로 변경해줌
-		if(!isEmpty(analysisBean.getOssNickname())) {
+		if (!isEmpty(analysisBean.getOssNickname())) {
 			// trim 처리는 registOssMaster 내에서 처리한다.
 			resultData.setOssNickname(analysisBean.getOssNickname());
 			resultData.setOssNicknames(analysisBean.getOssNickname().split(","));
 		}
 		
-		if(!isEmpty(analysisBean.getDownloadLocation())){
+		if (!isEmpty(analysisBean.getDownloadLocation())){
 			String result = "";
 			
-			for(String url : analysisBean.getDownloadLocation().split(",")) {
-				if(!isEmpty(result)) {
+			for (String url : analysisBean.getDownloadLocation().split(",")) {
+				if (!isEmpty(result)) {
 					result += ",";
 				}
 				
-				if(url.endsWith("/")) {
+				if (url.endsWith("/")) {
 					result += url.substring(0, url.length()-1);
 				} else {
 					result += url;
@@ -1896,8 +1896,8 @@ public class OssController extends CoTopComponent{
 			resultData.setDownloadLocation("");
 		}
 		
-		if(!isEmpty(analysisBean.getHomepage())) {
-			if(analysisBean.getHomepage().endsWith("/")) {
+		if (!isEmpty(analysisBean.getHomepage())) {
+			if (analysisBean.getHomepage().endsWith("/")) {
 				String homepage = analysisBean.getHomepage();
 				resultData.setHomepage(homepage.substring(0, homepage.length()-1));
 			} else {
@@ -1927,7 +1927,7 @@ public class OssController extends CoTopComponent{
 			resMap.put("validMapResult", validMapResult);
 			resMap.put("diffMapResult", diffMapResult);
 			
-			if(!vr.isValid()) {
+			if (!vr.isValid()) {
 				return makeJsonResponseHeader(false, "Fail", resMap);
 			}
 		} catch (Exception e) {
@@ -2017,7 +2017,7 @@ public class OssController extends CoTopComponent{
 		// sync check
 		List<String> syncCheckList = ossService.getOssListSyncCheck(selectOssList, standardOssList);
 		
-		if(selectOssList != null && !selectOssList.isEmpty()) {
+		if (selectOssList != null && !selectOssList.isEmpty()) {
 			OssMaster _bean = selectOssList.get(0);
 			_bean.setOssName(StringUtil.replaceHtmlEscape(_bean.getOssName()));
 			
@@ -2161,8 +2161,8 @@ public class OssController extends CoTopComponent{
 								break;
 						}
 				}
-				if(!ossMasterCheclFlag && !declaredLicenseCheckFlag && !detectedLicenseCheckFlag && !downloadLocationCheckFlag){
-					if(!isEmpty(comment)) {
+				if (!ossMasterCheclFlag && !declaredLicenseCheckFlag && !detectedLicenseCheckFlag && !downloadLocationCheckFlag){
+					if (!isEmpty(comment)) {
 						onlyCommentRegistFlag = true;
 					}
 				}
@@ -2170,7 +2170,7 @@ public class OssController extends CoTopComponent{
 				if ((ossMasterCheclFlag || declaredLicenseCheckFlag || detectedLicenseCheckFlag || downloadLocationCheckFlag) || onlyCommentRegistFlag) {
 					ossService.syncOssMaster(syncBean, declaredLicenseCheckFlag, detectedLicenseCheckFlag, downloadLocationCheckFlag);
 					
-					if(!onlyCommentRegistFlag) {
+					if (!onlyCommentRegistFlag) {
 						History h = new History();
 						h = ossService.work(syncBean);
 						h.sethAction(action);

--- a/src/main/java/oss/fosslight/controller/PartnerController.java
+++ b/src/main/java/oss/fosslight/controller/PartnerController.java
@@ -115,29 +115,29 @@ public class PartnerController extends CoTopComponent{
 		PartnerMaster searchBean = null;
 		Object _param =  getSessionObject(CoConstDef.SESSION_KEY_PREFIX_DEFAULT_SEARCHVALUE + "OSSLISTMORE", true);
 		
-		if(_param != null) {
+		if (_param != null) {
 			String defaultSearchOssId = (String) _param;
 			searchBean = new PartnerMaster();
 			
-			if(!isEmpty(defaultSearchOssId)) {
+			if (!isEmpty(defaultSearchOssId)) {
 				deleteSession(SESSION_KEY_SEARCH);
 				
 				OssMaster ossBean = CoCodeManager.OSS_INFO_BY_ID.get(defaultSearchOssId);
 				
-				if(ossBean != null) {
+				if (ossBean != null) {
 					searchBean.setOssName(ossBean.getOssName());
 					searchBean.setOssVersion(ossBean.getOssVersion());
 				}
 			}
 		} else {
-			if(!CoConstDef.FLAG_YES.equals(req.getParameter("gnbF"))) {
+			if (!CoConstDef.FLAG_YES.equals(req.getParameter("gnbF"))) {
 				deleteSession(SESSION_KEY_SEARCH);
 				
 				searchBean = searchService.getPartnerSearchFilter(loginUserName());
-				if(searchBean == null) {
+				if (searchBean == null) {
 					searchBean = new PartnerMaster();
 				}
-			} else if(getSessionObject(SESSION_KEY_SEARCH) != null) {
+			} else if (getSessionObject(SESSION_KEY_SEARCH) != null) {
 				searchBean = (PartnerMaster) getSessionObject(SESSION_KEY_SEARCH);
 			}	
 		}
@@ -177,7 +177,7 @@ public class PartnerController extends CoTopComponent{
 		String binaryFileId = partnerMaster.getBinaryFileId();
 		T2File binaryFile = new T2File();
 		
-		if(!isEmpty(binaryFileId)){
+		if (!isEmpty(binaryFileId)){
 			binaryFile.setFileSeq(binaryFileId);
 			binaryFile = fileMapper.getFileInfo(binaryFile);
 			
@@ -193,7 +193,7 @@ public class PartnerController extends CoTopComponent{
 		
 		List<Project> prjList = projectMapper.selectPartnerRefPrjList(partnerMaster);
 		
-		if(prjList.size() > 0) {
+		if (prjList.size() > 0) {
 			model.addAttribute("prjList", toJson(prjList));
 		}
 		
@@ -218,7 +218,7 @@ public class PartnerController extends CoTopComponent{
 		try {
 			partnerMaster = partnerService.getPartnerMasterOne(partnerMaster);
 			
-			if(CoConstDef.FLAG_YES.equals(partnerMaster.getUseYn())) {
+			if (CoConstDef.FLAG_YES.equals(partnerMaster.getUseYn())) {
 				T2File confirmationFile = new T2File();
 				confirmationFile.setFileSeq(partnerMaster.getConfirmationFileId());
 				confirmationFile = fileMapper.getFileInfo(confirmationFile);
@@ -270,19 +270,19 @@ public class PartnerController extends CoTopComponent{
 		partnerMaster.setSortField(sidx);
 		partnerMaster.setSortOrder(sord);
 		
-		if(partnerMaster.getStatus() != null) {
+		if (partnerMaster.getStatus() != null) {
 			String statuses = partnerMaster.getStatus();
-			if(!isEmpty(statuses)) {
+			if (!isEmpty(statuses)) {
 				String[] arrStatuses = statuses.split(",");
 				partnerMaster.setArrStatuses(arrStatuses);
 			}
 		}
 		
-		if("search".equals(req.getParameter("act"))){
+		if ("search".equals(req.getParameter("act"))){
 			// 검색 조건 저장
 			// save search condition
 			putSessionObject(SESSION_KEY_SEARCH, partnerMaster);
-		}else if(getSessionObject(SESSION_KEY_SEARCH) != null){
+		}else if (getSessionObject(SESSION_KEY_SEARCH) != null){
 			partnerMaster = (PartnerMaster) getSessionObject(SESSION_KEY_SEARCH);
 		}
 		
@@ -367,7 +367,7 @@ public class PartnerController extends CoTopComponent{
 			, Model model) throws Exception{
 		PartnerMaster orgPartnerMaster = null;
 		
-		if(!isEmpty(vo.getReviewer())) {
+		if (!isEmpty(vo.getReviewer())) {
 			orgPartnerMaster = partnerService.getPartnerMasterOne(vo);
 		}
 		
@@ -382,8 +382,8 @@ public class PartnerController extends CoTopComponent{
 		}
 		
 		try {
-			if(orgPartnerMaster != null) {
-				if(orgPartnerMaster != null && !vo.getReviewer().equals(orgPartnerMaster.getReviewer())) {
+			if (orgPartnerMaster != null) {
+				if (orgPartnerMaster != null && !vo.getReviewer().equals(orgPartnerMaster.getReviewer())) {
 					CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PARTER_REVIEWER_CHANGED);
 					mailBean.setParamPartnerId(vo.getPartnerId());
 					mailBean.setToIds(new String[]{vo.getReviewer()});
@@ -419,9 +419,9 @@ public class PartnerController extends CoTopComponent{
 		Map<String, Object> ruleMap = T2CoValidationConfig.getInstance().getRuleAllMap();
 		String msg = "";
 	        
-		if(result.size() > 0){
+		if (result.size() > 0){
 
-			if(!isEmpty(partnerMaster.getPartnerName()) && partnerMaster.getPartnerName().equals(result.get(0).getPartnerName())){
+			if (!isEmpty(partnerMaster.getPartnerName()) && partnerMaster.getPartnerName().equals(result.get(0).getPartnerName())){
 				msg = (String) ruleMap.get("PARTNER_NAME.DUPLICATED.MSG");
 				dupMap.put("partnerName", msg);
 			}
@@ -458,7 +458,7 @@ public class PartnerController extends CoTopComponent{
 		T2CoValidationResult vr = pv.validateObject(partnerMaster); 
 		
 		// return validator result
-		if(!vr.isValid()) {
+		if (!vr.isValid()) {
 			return makeJsonResponseHeader(false,  CommonFunction.makeValidMsgTohtml(vr.getValidMessageMap()), vr.getValidMessageMap());
 		}
 		
@@ -471,7 +471,7 @@ public class PartnerController extends CoTopComponent{
 		try{
 			History h = new History();
 			
-			if(!isNew) {
+			if (!isNew) {
 				h = partnerService.work(partnerMaster);
 				partnerService.registPartnerMaster(partnerMaster, ossComponents, ossComponentsLicense);
 				h.sethAction(CoConstDef.ACTION_CODE_UPDATE);
@@ -487,15 +487,15 @@ public class PartnerController extends CoTopComponent{
 			log.error(e.getMessage());
 		}
 		
-		if("10".equals(resCd) && !isEmpty(partnerMaster.getPartnerId())) {
+		if ("10".equals(resCd) && !isEmpty(partnerMaster.getPartnerId())) {
 			String prjId = partnerMaster.getPartnerId();
 			
 			// send invate mail
-			if(isNew) {
+			if (isNew) {
 				List<String> partnerInvateWatcherList = partnerService.getInvateWatcherList(prjId);
 				
-				if(partnerInvateWatcherList != null && !partnerInvateWatcherList.isEmpty()) {
-					for(String _email : partnerInvateWatcherList) {
+				if (partnerInvateWatcherList != null && !partnerInvateWatcherList.isEmpty()) {
+					for (String _email : partnerInvateWatcherList) {
 						try {
 							CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PARTER_WATCHER_INVATED);
 							mailBean.setParamPartnerId(prjId);
@@ -549,10 +549,10 @@ public class PartnerController extends CoTopComponent{
 			}
 			
 			try {
-				if(getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_UPLOAD_REPORT_CHANGEDLICENSE, partnerMaster.getOssFileId())) != null) {
+				if (getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_UPLOAD_REPORT_CHANGEDLICENSE, partnerMaster.getOssFileId())) != null) {
 					String chagedOssVersion = (String) getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_UPLOAD_REPORT_CHANGEDLICENSE, partnerMaster.getOssFileId()), true);
 					
-					if(!isEmpty(chagedOssVersion)) {
+					if (!isEmpty(chagedOssVersion)) {
 						CommentsHistory commentHisBean = new CommentsHistory();
 						commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_PARTNER);
 						commentHisBean.setReferenceId(prjId);
@@ -565,7 +565,7 @@ public class PartnerController extends CoTopComponent{
 			}
 		}
 		
-		if(!isEmpty(partnerMaster.getPartnerId())) {
+		if (!isEmpty(partnerMaster.getPartnerId())) {
 			resMap.put("partnerId", partnerMaster.getPartnerId());
 		}
 		
@@ -615,11 +615,11 @@ public class PartnerController extends CoTopComponent{
 			log.error(e.getMessage());
 		}
 		
-		if("10".equals(resCd)) {
+		if ("10".equals(resCd)) {
 			try {
 				CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PARTER_DELETED);
 				mailBean.setParamPartnerId(partnerMaster.getPartnerId());
-				if(!isEmpty(partnerMaster.getUserComment())) {
+				if (!isEmpty(partnerMaster.getUserComment())) {
 					mailBean.setComment(partnerMaster.getUserComment());
 				}
 				CoMailManager.getInstance().sendMail(mailBean);
@@ -665,7 +665,7 @@ public class PartnerController extends CoTopComponent{
 		try {
 			// addWatcher로 email을 등록할 경우 ldap search로 존재하는 사용자의 email인지 check가 필요함.
 			String ldapFlag = CoCodeManager.getCodeExpString(CoConstDef.CD_SYSTEM_SETTING, CoConstDef.CD_LDAP_USED_FLAG);
-			if(CoConstDef.FLAG_YES.equals(ldapFlag) && !isEmpty(project.getParEmail())) {
+			if (CoConstDef.FLAG_YES.equals(ldapFlag) && !isEmpty(project.getParEmail())) {
 				Map<String, String> userInfo = new HashMap<>();
 				userInfo.put("USER_ID", CoCodeManager.getCodeExpString(CoConstDef.CD_LDAP_SEARCH_INFO, CoConstDef.CD_DTL_LDAP_SEARCH_ID));
 				userInfo.put("USER_PW", CoCodeManager.getCodeExpString(CoConstDef.CD_LDAP_SEARCH_INFO, CoConstDef.CD_DTL_LDAP_SEARCH_PW));
@@ -675,7 +675,7 @@ public class PartnerController extends CoTopComponent{
 				
 				boolean isAuthenticated = userService.checkAdAccounts(userInfo, "USER_ID", "USER_PW", filter);
 				
-				if(!isAuthenticated) {
+				if (!isAuthenticated) {
 					throw new Exception("add Watcher Failure");
 				}
 				
@@ -686,7 +686,7 @@ public class PartnerController extends CoTopComponent{
 				resultMap.put("email", email);
 			}
 						
-			if(!isEmpty(project.getParUserId()) || !isEmpty(project.getParEmail())) {
+			if (!isEmpty(project.getParUserId()) || !isEmpty(project.getParEmail())) {
 				partnerService.addWatcher(project);
 				resultMap.put("isValid", "true");
 			} else {
@@ -703,7 +703,7 @@ public class PartnerController extends CoTopComponent{
 	public @ResponseBody ResponseEntity<Object> removeWatcher(@RequestBody PartnerMaster project,
 			HttpServletRequest req, HttpServletResponse res, Model model) {
 		try {
-			if(!isEmpty(project.getParUserId()) || !isEmpty(project.getParEmail())) {
+			if (!isEmpty(project.getParUserId()) || !isEmpty(project.getParEmail())) {
 				partnerService.removeWatcher(project);
 			} else {
 				return makeJsonResponseHeader(false, null);
@@ -729,26 +729,26 @@ public class PartnerController extends CoTopComponent{
 			HttpServletRequest req, HttpServletResponse res, Model model) {
 			HashMap<String, Object> resMap = new HashMap<>();
 		try {			
-			if(!isEmpty(project.getListKind()) && !isEmpty(project.getListId()) ) {
+			if (!isEmpty(project.getListKind()) && !isEmpty(project.getListId()) ) {
 				
 				List<PartnerMaster> result = partnerService.copyWatcher(project);
 				
-				if(result != null) {
+				if (result != null) {
 
-					for(PartnerMaster pm : result) {
-						if(!StringUtils.isEmpty(pm.getDivision())) {
+					for (PartnerMaster pm : result) {
+						if (!StringUtils.isEmpty(pm.getDivision())) {
 							pm.setParDivision(pm.getDivision());
 							pm.setParDivisionName(CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, pm.getDivision()));
 						}
 					}
 					
-					if(!isEmpty(project.getPartnerId())) {
+					if (!isEmpty(project.getPartnerId())) {
 						boolean existPartnerWatcher = partnerService.existsWatcher(project);
 						
-						for(PartnerMaster pm : result) {
+						for (PartnerMaster pm : result) {
 							pm.setPartnerId(project.getPartnerId());
 							
-							if(existPartnerWatcher) {
+							if (existPartnerWatcher) {
 								partnerService.addWatcher(pm);
 							}
 						}
@@ -810,7 +810,7 @@ public class PartnerController extends CoTopComponent{
 		String statusCode = partnerMaster.getStatus();
 		String status = CoCodeManager.getCodeExpString(CoConstDef.CD_IDENTIFICATION_STATUS, statusCode);
 		
-		if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(partnerMaster.getStatus())) {
+		if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(partnerMaster.getStatus())) {
 			ProjectIdentification _param = new ProjectIdentification();
 			_param.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_PARTNER);
 			_param.setReferenceId(partnerMaster.getPartnerId());
@@ -827,7 +827,7 @@ public class PartnerController extends CoTopComponent{
 			
 			T2CoValidationResult vr = pv.validate(new HashMap<>());
 			// return validator result
-			if(!vr.isValid()) {
+			if (!vr.isValid()) {
 				return makeJsonResponseHeader(vr.getValidMessageMap());
 			}
 			
@@ -839,7 +839,7 @@ public class PartnerController extends CoTopComponent{
 
 				String _tempComment = avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_DEFAULT_CONTENTS, CoConstDef.CD_MAIL_TYPE_PARTER_CONF));
 
-				if(!isEmpty(userComment)) {
+				if (!isEmpty(userComment)) {
 					mailbean.setComment(avoidNull(userComment) + "<br />" + _tempComment);
 				} else{
 					mailbean.setComment(_tempComment);
@@ -850,7 +850,7 @@ public class PartnerController extends CoTopComponent{
 				log.error(e.getMessage(), e);
 			}
 		} else {
-			if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(partnerMaster.getStatus())) {
+			if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(partnerMaster.getStatus())) {
 				ProjectIdentification _param = new ProjectIdentification();
 				_param.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_PARTNER);
 				_param.setReferenceId(partnerMaster.getPartnerId());
@@ -868,7 +868,7 @@ public class PartnerController extends CoTopComponent{
 				T2CoValidationResult vr = pv.validate(new HashMap<>());
 				
 				// return validator result
-				if(!vr.isValid()) {
+				if (!vr.isValid()) {
 					if (!vr.isDiff()) {
 						return makeJsonResponseHeader(false, "", "", vr.getValidMessageMap(), vr.getDiffMessageMap());
 					} else {
@@ -884,25 +884,25 @@ public class PartnerController extends CoTopComponent{
 			partnerService.changeStatus(partnerMaster);
 			
 			try {
-				if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(partnerMaster.getStatus())) {
+				if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(partnerMaster.getStatus())) {
 					mailbean = new CoMail(CoConstDef.CD_MAIL_TYPE_PARTER_REQ_REVIEW);
-				} else if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_PROGRESS.equals(partnerMaster.getStatus())) {
-					if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(orgInfo.getStatus())) {
+				} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_PROGRESS.equals(partnerMaster.getStatus())) {
+					if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(orgInfo.getStatus())) {
 						// confirm -> reject
 						mailbean = new CoMail(CoConstDef.CD_MAIL_TYPE_PARTER_CANCELED_CONF);
-					} else if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(orgInfo.getStatus())) {
+					} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(orgInfo.getStatus())) {
 						// review -> reject
 						mailbean = new CoMail(CoConstDef.CD_MAIL_TYPE_PARTER_REJECT);
-					} else if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(orgInfo.getStatus())) {
+					} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST.equals(orgInfo.getStatus())) {
 						// self reject
 						mailbean = new CoMail(CoConstDef.CD_MAIL_TYPE_PARTER_SELF_REJECT);
 					}
 				}
 				
-				if(mailbean != null) {
+				if (mailbean != null) {
 					mailbean.setParamPartnerId(partnerMaster.getPartnerId());
 					
-					if(!isEmpty(userComment)) {
+					if (!isEmpty(userComment)) {
 						mailbean.setComment(userComment);
 					}
 					
@@ -924,7 +924,7 @@ public class PartnerController extends CoTopComponent{
 			} catch (Exception e) {
 				log.error(e.getMessage(), e);
 			}
-		} else if(!isEmpty(status)) {
+		} else if (!isEmpty(status)) {
 			try {
 				CommentsHistory commHisBean = new CommentsHistory();
 				commHisBean.setReferenceDiv(commentDiv);
@@ -965,18 +965,18 @@ public class PartnerController extends CoTopComponent{
 			file.setCreator(loginUserName());
 			list = fileService.uploadFile(req, file);
 
-			if(fileExtension.equals("csv")) {
+			if (fileExtension.equals("csv")) {
 				resultList = CommonFunction.checkCsvFileLimit(list);
 			} else {
 				resultList = CommonFunction.checkXlsxFileLimit(list);
 			}
 			
-			if(resultList.size() > 0) {
+			if (resultList.size() > 0) {
 				return toJson(resultList);
 			}
 		}
 
-		if(fileExtension.equals("csv")) {
+		if (fileExtension.equals("csv")) {
 			resultList.add(list);
 			resultList.add("SRC");
 			resultList.add("CSV_FILE");
@@ -988,16 +988,16 @@ public class PartnerController extends CoTopComponent{
 			Boolean isSpdxSpreadsheet = false;
 			
 			try {
-				if(CoConstDef.FLAG_YES.equals(excel)){
-					if(list != null && !list.isEmpty() && CoCodeManager.getCodeExpString(CoConstDef.CD_FILE_ACCEPT, "22").contains(list.get(0).getFileExt())) {
+				if (CoConstDef.FLAG_YES.equals(excel)){
+					if (list != null && !list.isEmpty() && CoCodeManager.getCodeExpString(CoConstDef.CD_FILE_ACCEPT, "22").contains(list.get(0).getFileExt())) {
 
 						sheetNameList = ExcelUtil.getSheetNames(list, RESOURCE_PUBLIC_UPLOAD_EXCEL_PATH_PREFIX);
 					}
 				}
 			
-				for(Object sheet : sheetNameList) {
+				for (Object sheet : sheetNameList) {
 					String sheetName = sheet.toString();
-					if(sheetName.contains("Package Info") || sheetName.contains("Per File Info")) {
+					if (sheetName.contains("Package Info") || sheetName.contains("Per File Info")) {
 						isSpdxSpreadsheet = true;
 					}
 				}
@@ -1005,7 +1005,7 @@ public class PartnerController extends CoTopComponent{
 				log.error(e.getMessage(), e);
 			}
 
-			if(isSpdxSpreadsheet){
+			if (isSpdxSpreadsheet){
 				resultList.add(list);
 				resultList.add(sheetNameList);
 				resultList.add("SPDX_SPREADSHEET_FILE");
@@ -1124,7 +1124,7 @@ public class PartnerController extends CoTopComponent{
 			log.error(e.getMessage());
 		}
 		
-		if(!vResult.isValid()){
+		if (!vResult.isValid()){
 			return makeJsonResponseHeader(vResult.getValidMessageMap());
 		}
 		
@@ -1243,23 +1243,23 @@ public class PartnerController extends CoTopComponent{
 			, Model model){
 		List<String> permissionCheckList = null;
 		
-		if(!CommonFunction.isAdmin()) {
+		if (!CommonFunction.isAdmin()) {
 			CommonFunction.setPartnerService(partnerService);
 			permissionCheckList = CommonFunction.checkUserPermissions(loginUserName(), partnerMaster.getPartnerIds(), "partner");
 		}
 		
-		if(permissionCheckList == null || permissionCheckList.isEmpty()){
+		if (permissionCheckList == null || permissionCheckList.isEmpty()){
 			Map<String, List<PartnerMaster>> updatePartnerDivision = partnerService.updatePartnerDivision(partnerMaster);	
 			
-			if(updatePartnerDivision.containsKey("before") && updatePartnerDivision.containsKey("after")) {
+			if (updatePartnerDivision.containsKey("before") && updatePartnerDivision.containsKey("after")) {
 				List<PartnerMaster> beforePartnerList = (List<PartnerMaster>) updatePartnerDivision.get("before");
 				List<PartnerMaster> afterPartnerList = (List<PartnerMaster>) updatePartnerDivision.get("after");
 				
-				if((beforePartnerList != null && !beforePartnerList.isEmpty()) 
+				if ((beforePartnerList != null && !beforePartnerList.isEmpty()) 
 						&& (afterPartnerList != null && !afterPartnerList.isEmpty())
 						&& beforePartnerList.size() == afterPartnerList.size()) {
 					
-					for(int i=0; i<beforePartnerList.size(); i++) {
+					for (int i=0; i<beforePartnerList.size(); i++) {
 						try {
 							CommentsHistory commentsHistory = new CommentsHistory();
 							commentsHistory.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_PARTNER);

--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -137,24 +137,24 @@ public class ProjectController extends CoTopComponent {
 		Object _param =  getSessionObject(CoConstDef.SESSION_KEY_PREFIX_DEFAULT_SEARCHVALUE + "OSSLISTMORE", true);
 		Object _param2 =  getSessionObject(CoConstDef.SESSION_KEY_PREFIX_DEFAULT_SEARCHVALUE + "PARTNERLISTMORE", true);
 		
-		if(_param != null) {
+		if (_param != null) {
 			String defaultSearchOssId = (String) _param;
 			searchBean = new Project();
 			
-			if(!isEmpty(defaultSearchOssId)) {
+			if (!isEmpty(defaultSearchOssId)) {
 				deleteSession(SESSION_KEY_SEARCH);
 				OssMaster ossBean = CoCodeManager.OSS_INFO_BY_ID.get(defaultSearchOssId);
 				
-				if(ossBean != null) {
+				if (ossBean != null) {
 					searchBean.setOssName(ossBean.getOssName());
 					searchBean.setOssVersion(ossBean.getOssVersion());
 				}
 			}
-		} else if(_param2 != null) {
+		} else if (_param2 != null) {
 			String defaultSearchRefPartnerId = (String) _param2;
 			searchBean = new Project();
 			
-			if(!isEmpty(defaultSearchRefPartnerId)) {
+			if (!isEmpty(defaultSearchRefPartnerId)) {
 				deleteSession(SESSION_KEY_SEARCH);
 				
 				searchBean.setRefPartnerId(defaultSearchRefPartnerId);
@@ -164,7 +164,7 @@ public class ProjectController extends CoTopComponent {
 				deleteSession(SESSION_KEY_SEARCH);
 				
 				searchBean = searchService.getProjectSearchFilter(loginUserName());
-				if(searchBean == null) {
+				if (searchBean == null) {
 					searchBean = new Project();
 				}
 			} else if (getSessionObject(SESSION_KEY_SEARCH) != null) {
@@ -246,7 +246,7 @@ public class ProjectController extends CoTopComponent {
 		String reviewerFlag = req.getParameter("reviewerFlag");
 		String userIdList = "";
 		
-		if(CoConstDef.FLAG_YES.equals(reviewerFlag)) {
+		if (CoConstDef.FLAG_YES.equals(reviewerFlag)) {
 			userIdList = projectService.getReviewerList(CoConstDef.FLAG_YES);
 		} else {
 			userIdList = projectService.getAdminUserList();
@@ -277,9 +277,9 @@ public class ProjectController extends CoTopComponent {
 		project.setSortField(sidx);
 		project.setSortOrder(sord);
 
-		if(project.getStatuses() != null) {
+		if (project.getStatuses() != null) {
 			String statuses = project.getStatuses();
-			if(!isEmpty(statuses)){
+			if (!isEmpty(statuses)){
 				String[] arrStatuses = statuses.split(",");
 				project.setArrStatuses(arrStatuses);
 			}
@@ -299,16 +299,16 @@ public class ProjectController extends CoTopComponent {
 		@SuppressWarnings("unchecked")
 		List<Project> list = (List<Project>) map.get("rows");
 		
-		for(Project prj : list) {
+		for (Project prj : list) {
 			List<String> permissionCheckList = CommonFunction.checkUserPermissions("", new String[] {prj.getPrjId()}, "project");
-			if(permissionCheckList != null) {
-				if(prj.getPublicYn().equals(CoConstDef.FLAG_NO)
+			if (permissionCheckList != null) {
+				if (prj.getPublicYn().equals(CoConstDef.FLAG_NO)
 						&& !CommonFunction.isAdmin() 
 						&& !permissionCheckList.contains(loginUserName())) {
 					prj.setPermission(0);
 					prj.setStatusPermission(0);
 				} else {
-					if(!CommonFunction.isAdmin() && !permissionCheckList.contains(loginUserName())) {
+					if (!CommonFunction.isAdmin() && !permissionCheckList.contains(loginUserName())) {
 						prj.setStatusPermission(0);
 					} else {
 						prj.setStatusPermission(1);
@@ -338,10 +338,10 @@ public class ProjectController extends CoTopComponent {
 		
 		Object _param =  getSessionObject(CoConstDef.SESSION_KEY_PREFIX_DEFAULT_SEARCHVALUE + "PARTNER", true);
 		
-		if(_param != null) {
+		if (_param != null) {
 			String partnerKey = (String) _param;
 			
-			if(!isEmpty(partnerKey)) {
+			if (!isEmpty(partnerKey)) {
 				deleteSession(SESSION_KEY_SEARCH);
 				
 				String[] partnerArr = partnerKey.split("\\|\\|");
@@ -396,11 +396,11 @@ public class ProjectController extends CoTopComponent {
 		List<String> permissionCheckList = null;
 		boolean permissionFlag = false;
 		
-		if(!CommonFunction.isAdmin()) {
+		if (!CommonFunction.isAdmin()) {
 			CommonFunction.setProjectService(projectService);
 			project.setPrjIds(new String[] {prjId});
 			permissionCheckList = CommonFunction.checkUserPermissions("", project.getPrjIds(), "project");
-			if(permissionCheckList.contains(loginUserName())) {
+			if (permissionCheckList.contains(loginUserName())) {
 				permissionFlag = true;
 			}
 		}
@@ -412,7 +412,7 @@ public class ProjectController extends CoTopComponent {
 			
 			return PROJECT.VIEW_JSP;
 		} else {
-			if(!permissionFlag) {
+			if (!permissionFlag) {
 				List<T2Users> userList = userService.selectAllUsers();
 				
 				if (userList != null) {
@@ -433,7 +433,7 @@ public class ProjectController extends CoTopComponent {
 		try {
 			project = projectService.getProjectDetail(project);
 			
-			if(CoConstDef.FLAG_YES.equals(project.getUseYn())) {
+			if (CoConstDef.FLAG_YES.equals(project.getUseYn())) {
 				CommentsHistory comHisBean = new CommentsHistory();
 				comHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PROJECT_USER);
 				comHisBean.setReferenceId(prjId);
@@ -551,12 +551,12 @@ public class ProjectController extends CoTopComponent {
 		boolean isBatResult = !isEmpty(identification.getRefBatId());
 		boolean isSortOnBom = false;
 		
-		if(CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(code)) {
-			if(!isEmpty(identification.getSidxOrg())) {
+		if (CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(code)) {
+			if (!isEmpty(identification.getSidxOrg())) {
 				String[] _sortIdxs = identification.getSidxOrg().split(",");
 				
-				if(_sortIdxs.length == 2) {
-					if(!isEmpty(_sortIdxs[1].trim())) {
+				if (_sortIdxs.length == 2) {
+					if (!isEmpty(_sortIdxs[1].trim())) {
 						isSortOnBom = true;
 					}
 					
@@ -567,7 +567,7 @@ public class ProjectController extends CoTopComponent {
 			
 			String filterCondition = CommonFunction.getFilterToString(identification.getFilters());
 			
-			if(!isEmpty(filterCondition)) {
+			if (!isEmpty(filterCondition)) {
 				identification.setFilterCondition(filterCondition);
 			}
 		}
@@ -591,19 +591,19 @@ public class ProjectController extends CoTopComponent {
 			
 			T2CoValidationResult vr = pv.validate(new HashMap<>());
 			
-			if(!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+			if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
 				map.replace("mainData", CommonFunction
 						.identificationSortByValidInfo((List<ProjectIdentification>) map.get("mainData"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false));
 				
-				if(!vr.isValid()) {
+				if (!vr.isValid()) {
 					map.put("validData", vr.getValidMessageMap());
 				}
 				
-				if(!vr.isDiff()) {
+				if (!vr.isDiff()) {
 					map.put("diffData", vr.getDiffMessageMap());
 				}
 				
-				if(vr.hasInfo()) {
+				if (vr.hasInfo()) {
 					map.put("infoData", vr.getInfoMessageMap());
 				}
 			}
@@ -689,7 +689,7 @@ public class ProjectController extends CoTopComponent {
 					Project prjInfo = projectService.getProjectBasicInfo(identification.getReferenceId());
 					
 					if (prjInfo != null) {
-						if(!isEmpty(prjInfo.getSrcAndroidNoticeXmlId())) {
+						if (!isEmpty(prjInfo.getSrcAndroidNoticeXmlId())) {
 							noticeBinaryList = CommonFunction.getNoticeBinaryList(
 									fileService.selectFileInfoById(prjInfo.getSrcAndroidNoticeXmlId()));
 						}
@@ -723,16 +723,16 @@ public class ProjectController extends CoTopComponent {
 			
 			T2CoValidationResult vr = pv.validate(new HashMap<>());
 			
-			if(!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+			if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
 				map.replace("mainData", CommonFunction
 						.identificationSortByValidInfo((List<ProjectIdentification>) map.get("mainData"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false, true));
-				if(!vr.isValid()) {
+				if (!vr.isValid()) {
 					map.put("validData", vr.getValidMessageMap());
 				}
-				if(!vr.isDiff()) {
+				if (!vr.isDiff()) {
 					map.put("diffData", vr.getDiffMessageMap());
 				}
-				if(vr.hasInfo()) {
+				if (vr.hasInfo()) {
 					map.put("infoData", vr.getInfoMessageMap());
 				}
 			}
@@ -745,21 +745,21 @@ public class ProjectController extends CoTopComponent {
 			
 			T2CoValidationResult vr = pv.validate(new HashMap<>());
 			
-			if(!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
-				if(!CoConstDef.CD_DTL_COMPONENT_BAT.equals(code)){
+			if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+				if (!CoConstDef.CD_DTL_COMPONENT_BAT.equals(code)){
 					map.replace("mainData", CommonFunction
 							.identificationSortByValidInfo((List<ProjectIdentification>) map.get("mainData"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false));
 				}
 				
-				if(!vr.isValid()) {
+				if (!vr.isValid()) {
 					map.put("validData", vr.getValidMessageMap());
 				}
 				
-				if(!vr.isDiff()) {
+				if (!vr.isDiff()) {
 					map.put("diffData", vr.getDiffMessageMap());
 				}
 				
-				if(vr.hasInfo()) {
+				if (vr.hasInfo()) {
 					map.put("infoData", vr.getInfoMessageMap());
 				}
 			}
@@ -772,21 +772,21 @@ public class ProjectController extends CoTopComponent {
 
 			T2CoValidationResult vr = pv.validate(new HashMap<>());
 			
-			if(!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
-				if(!isSortOnBom) {
+			if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+				if (!isSortOnBom) {
 					map.replace("rows", CommonFunction
 							.identificationSortByValidInfo((List<ProjectIdentification>) map.get("rows"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false, true));
 				}
 				
-				if(!vr.isValid()) {
+				if (!vr.isValid()) {
 					map.put("validData", vr.getValidMessageMap());
 				}
 				
-				if(!vr.isDiff()) {
+				if (!vr.isDiff()) {
 					map.put("diffData", vr.getDiffMessageMap());
 				}
 				
-				if(vr.hasInfo()) {
+				if (vr.hasInfo()) {
 					map.put("infoData", vr.getInfoMessageMap());
 				}
 			} else {
@@ -796,7 +796,7 @@ public class ProjectController extends CoTopComponent {
 		} else if (CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(code)) {
 			PartnerMaster partnerInfo = new PartnerMaster();
 			
-			if(identification.getPartnerId() == null){
+			if (identification.getPartnerId() == null){
 				partnerInfo.setPartnerId(identification.getReferenceId());
 			}else{
 				partnerInfo.setPartnerId(identification.getPartnerId());
@@ -820,16 +820,16 @@ public class ProjectController extends CoTopComponent {
 
 				T2CoValidationResult vr = pv.validate(new HashMap<>());
 				
-				if(!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+				if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
 					map.replace("mainData", CommonFunction.identificationSortByValidInfo(
 							(List<ProjectIdentification>) map.get("mainData"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false, true));
-					if(!vr.isValid()) {
+					if (!vr.isValid()) {
 						map.put("validData", vr.getValidMessageMap());
 					}
-					if(!vr.isDiff()) {
+					if (!vr.isDiff()) {
 						map.put("diffData", vr.getDiffMessageMap());
 					}
-					if(vr.hasInfo()) {
+					if (vr.hasInfo()) {
 						map.put("infoData", vr.getInfoMessageMap());
 					}
 				}
@@ -843,16 +843,16 @@ public class ProjectController extends CoTopComponent {
 			
 			T2CoValidationResult vr = pv.validate(new HashMap<>());
 
-			if(!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+			if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
 				map.replace("mainData", CommonFunction.identificationSortByValidInfo((List<ProjectIdentification>) map.get("mainData")
 						, vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false));
-				if(!vr.isValid()) {
+				if (!vr.isValid()) {
 					map.put("validData", vr.getValidMessageMap());
 				}
-				if(!vr.isDiff()) {
+				if (!vr.isDiff()) {
 					map.put("diffData", vr.getDiffMessageMap());
 				}
-				if(vr.hasInfo()) {
+				if (vr.hasInfo()) {
 					map.put("infoData", vr.getInfoMessageMap());
 				}
 			}
@@ -875,13 +875,13 @@ public class ProjectController extends CoTopComponent {
 			HttpServletResponse res, Model model) {
 		Map<String, List<Project>> map = projectService.getModelList(project.getPrjId());
 		
-		if(map != null && !map.isEmpty() && CoConstDef.FLAG_YES.equals(project.getCopy())) {
+		if (map != null && !map.isEmpty() && CoConstDef.FLAG_YES.equals(project.getCopy())) {
 			List<Project> list = map.get("currentModelList");
 			
-			if(list != null) {
+			if (list != null) {
 				List<Project> list2 = new ArrayList<>();
 				
-				for(Project modelBean : list) {
+				for (Project modelBean : list) {
 					modelBean.setReleaseDate(null);
 					modelBean.setModifier(null);
 					modelBean.setModifiedDate(null);
@@ -1012,7 +1012,7 @@ public class ProjectController extends CoTopComponent {
 			project.setModifiedDate(project.getCreatedDate());
 			projectService.updateReject(project);
 			
-			for(String prjId : project.getPrjIds()) {
+			for (String prjId : project.getPrjIds()) {
 				project.setPrjId(prjId);
 				History h = projectService.work(project);
 				h.sethAction(CoConstDef.ACTION_CODE_UPDATE);
@@ -1081,13 +1081,13 @@ public class ProjectController extends CoTopComponent {
 		List<Project> list = (List<Project>) fromJson(jsonString, collectionType);
 		project.setModelList(list);
 		
-		if(project.getWatchers() == null) {
+		if (project.getWatchers() == null) {
 			String[] watcherArr = req.getParameterValues("watchers");
 			
-			if(watcherArr == null) {
+			if (watcherArr == null) {
 				String watcherArrTemp = req.getParameter("watchers");
 				
-				if(watcherArrTemp != null) {
+				if (watcherArrTemp != null) {
 					String[] tempWatcherArr = {watcherArrTemp};
 					watcherArr = tempWatcherArr;
 				}
@@ -1157,7 +1157,7 @@ public class ProjectController extends CoTopComponent {
 				beforeBean.setModelList(projectService.getModelListExcel(project));
 				beforeBean.setWatcherList(projectService.getWatcherList(project));
 				projectService.registProject(project);
-				if(copy.equals("true") && (project.getNoticeType() != null && project.getNoticeType().equals(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED))) {
+				if (copy.equals("true") && (project.getNoticeType() != null && project.getNoticeType().equals(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED))) {
 					projectService.copySrcAndroidNoticeFile(project);
 				}
 				afterBean = projectService.getProjectBasicInfo(project.getPrjId());
@@ -1177,28 +1177,28 @@ public class ProjectController extends CoTopComponent {
 		lastResult.put("prjId", project.getPrjId());
 		String flag = "false";
 		
-		if(!isNew && afterBean.getModelList() != null && afterBean.getModelList().size() > 0) {
-			if(beforeBean.getModelList() == null || beforeBean.getModelList().size() == 0) {
+		if (!isNew && afterBean.getModelList() != null && afterBean.getModelList().size() > 0) {
+			if (beforeBean.getModelList() == null || beforeBean.getModelList().size() == 0) {
 				flag = "true";
 			} else {
-				for(int i=0; i < afterBean.getModelList().size(); i++){
+				for (int i=0; i < afterBean.getModelList().size(); i++){
 					int cnt = 0;
 					boolean ck_flag = false;
 					String after = afterBean.getModelList().get(i).getCategory()+"|"+afterBean.getModelList().get(i).getModelName()+"|"+afterBean.getModelList().get(i).getReleaseDate();
 					
-					for(int j=0; j < beforeBean.getModelList().size(); j++){
+					for (int j=0; j < beforeBean.getModelList().size(); j++){
 						String before = beforeBean.getModelList().get(j).getCategory()+"|"+beforeBean.getModelList().get(j).getModelName()+"|"+beforeBean.getModelList().get(j).getReleaseDate();
 						
-						if(avoidNull(after).equals(before)){
+						if (avoidNull(after).equals(before)){
 							cnt++;
 						}
 						
-						if(!avoidNull(after).equals(before) && cnt == 0){
+						if (!avoidNull(after).equals(before) && cnt == 0){
 							ck_flag = true;
 						}
 					}
 					
-					if(cnt == 0 && ck_flag == true){
+					if (cnt == 0 && ck_flag == true){
 						flag = "true";
 					}
 				}
@@ -1207,7 +1207,7 @@ public class ProjectController extends CoTopComponent {
 		
 		lastResult.put("isAdd", flag);
 		String userComment = project.getUserComment();
-		if(!isEmpty(userComment) && !isEmpty(project.getPrjId())) {
+		if (!isEmpty(userComment) && !isEmpty(project.getPrjId())) {
 			CommentsHistory commentsHistory = new CommentsHistory();
 			commentsHistory.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PROJECT_HIS);
 			commentsHistory.setReferenceId(project.getPrjId());
@@ -1221,7 +1221,7 @@ public class ProjectController extends CoTopComponent {
 				String mailType = "true".equals(copy)?CoConstDef.CD_MAIL_TYPE_PROJECT_COPIED:CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED;
 				String diffDivisionComment = "";
 				
-				if(CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED.equals(mailType) && !beforeBean.getDivision().equals(afterBean.getDivision())){
+				if (CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED.equals(mailType) && !beforeBean.getDivision().equals(afterBean.getDivision())){
 					diffDivisionComment = CommonFunction.getDiffItemComment(beforeBean, afterBean);
 				}
 				
@@ -1238,11 +1238,11 @@ public class ProjectController extends CoTopComponent {
 				
 				CoMailManager.getInstance().sendMail(mailBean);
 				
-				if(CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED.equals(mailType)){
+				if (CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED.equals(mailType)){
 					String diffItemComment = CommonFunction.getDiffItemComment(beforeBean, afterBean, true);
 					
 					try {
-						if(!isEmpty(diffItemComment) || !isEmpty(diffDivisionComment)) {
+						if (!isEmpty(diffItemComment) || !isEmpty(diffDivisionComment)) {
 							diffItemComment += diffDivisionComment;
 							CommentsHistory commHisBean = new CommentsHistory();
 							commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PROJECT_HIS);
@@ -1273,10 +1273,10 @@ public class ProjectController extends CoTopComponent {
 			}
 		}
 		
-		if((isNew || "true".equals(copy)) && !isEmpty(project.getPrjId()) && project.getWatchers() != null && project.getWatchers().length > 0) {
+		if ((isNew || "true".equals(copy)) && !isEmpty(project.getPrjId()) && project.getWatchers() != null && project.getWatchers().length > 0) {
 			List<String> mailList = new ArrayList<>(); 
 			
-			if(!isNew && !"true".equals(copy)) {
+			if (!isNew && !"true".equals(copy)) {
 				String[] arr;
 				List<String> emailList = new ArrayList<>();
 				List<String> emailList2 = new ArrayList<>();
@@ -1284,21 +1284,21 @@ public class ProjectController extends CoTopComponent {
 				for (String watcher : project.getWatchers()) {
 					arr = watcher.split("\\/");
 					
-					if("Email".equals(arr[1])){
-						if(!emailList.contains(arr[0])) {
+					if ("Email".equals(arr[1])){
+						if (!emailList.contains(arr[0])) {
 							emailList.add(arr[0]);
 						}
 					}
 				}
 			
-				if(beforeBean.getWatcherList() != null && !beforeBean.getWatcherList().isEmpty()) {
-					for(Project _prj : beforeBean.getWatcherList()) {
+				if (beforeBean.getWatcherList() != null && !beforeBean.getWatcherList().isEmpty()) {
+					for (Project _prj : beforeBean.getWatcherList()) {
 						emailList2.add(_prj.getPrjEmail());
 					}
 				}
 				
-				for(String s : emailList) {
-					if(!emailList2.contains(s)) {
+				for (String s : emailList) {
+					if (!emailList2.contains(s)) {
 						// 신규 추가 이면
 						mailList.add(s);
 					}
@@ -1306,11 +1306,11 @@ public class ProjectController extends CoTopComponent {
 			} else {
 				List<Project> _prjList = projectService.getWatcherList(project);
 				
-				if(_prjList != null) {
-					for(Project _prj : _prjList) {
-						if(!StringUtil.isEmptyTrimmed(_prj.getPrjEmail())) {
+				if (_prjList != null) {
+					for (Project _prj : _prjList) {
+						if (!StringUtil.isEmptyTrimmed(_prj.getPrjEmail())) {
 							String _mailAddr = _prj.getPrjEmail().trim();
-							if(!mailList.contains(_mailAddr)) {
+							if (!mailList.contains(_mailAddr)) {
 								mailList.add(_mailAddr);
 							}
 						}
@@ -1318,8 +1318,8 @@ public class ProjectController extends CoTopComponent {
 				}
 			}
 			
-			if(!mailList.isEmpty()) {
-				for(String addr : mailList) {
+			if (!mailList.isEmpty()) {
+				for (String addr : mailList) {
 					try {
 						CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_INVATED);
 						mailBean.setParamPrjId(project.getPrjId());
@@ -1336,7 +1336,7 @@ public class ProjectController extends CoTopComponent {
 		
 		try {
 			// 1. 신규 생성 & partner id가 존재함. -> 이미 완료된 시점
-			if(isNew && !isEmpty(project.getRefPartnerId())) {
+			if (isNew && !isEmpty(project.getRefPartnerId())) {
 				// 2. RefPartnerId 기준으로 OSS Component & OSS Component License Data -> Identification > 3rd Party에 copy함.
 				// 3. PROJECT_PARTNER_MAP 생성
 				// -> Identification > 3rd party save처리와 동일한 상태
@@ -1362,7 +1362,7 @@ public class ProjectController extends CoTopComponent {
 					log.error(e.getMessage(), e);
 				}
 				
-				if(!result.containsKey("validData")) {
+				if (!result.containsKey("validData")) {
 					// review Start에서는 status말고 변경되는 정보가 없어서 우선은 pass함.					
 					prjBean.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM);
 					prjBean.setIgnoreBinaryDbFlag(CoConstDef.FLAG_NO);
@@ -1379,14 +1379,14 @@ public class ProjectController extends CoTopComponent {
 			log.error(e.getMessage(), e);
 		}
 		
-		if(copy.equals("true") && !confirmStatusCopy.equals("false")) {
+		if (copy.equals("true") && !confirmStatusCopy.equals("false")) {
 			Map<String, Object> copyConfirmStatusResultMap = updateCopyConfirmStatus(req, project, confirmStatusCopy, userComment);
-			if(copyConfirmStatusResultMap.get("result").equals("true")) {
+			if (copyConfirmStatusResultMap.get("result").equals("true")) {
 				lastResult.put("confirmCopyStatusSuccess", "true");
 			}else {
 				String falseStep = "";
 				
-				if(copyConfirmStatusResultMap.get("step").equals("verificationProgress")) {
+				if (copyConfirmStatusResultMap.get("step").equals("verificationProgress")) {
 					falseStep = "verification";
 					project.setIdentificationStatus(null);
 					project.setVerificationStatus(CoConstDef.CD_DTL_PROJECT_STATUS_PROGRESS);
@@ -1397,14 +1397,14 @@ public class ProjectController extends CoTopComponent {
 				} 
 				
 				Project prj = projectService.getProjectBasicInfo(project.getPrjId());
-				if(falseStep.equals("verification") && !isEmpty(prj.getVerificationStatus())) {
+				if (falseStep.equals("verification") && !isEmpty(prj.getVerificationStatus())) {
 					project.setVerificationStatus(prj.getVerificationStatus());
 				}
 				
 				projectService.updateCopyConfirmStatusProjectStatus(project);
 				
 				lastResult.put("confirmCopyStatusSuccess", "false");
-				if(!confirmStatusCopy.equals("IdentificationProg")) {
+				if (!confirmStatusCopy.equals("IdentificationProg")) {
 					lastResult.put("confirmCopyStatusFail", falseStep);
 				}
 			}
@@ -1421,21 +1421,21 @@ public class ProjectController extends CoTopComponent {
 		boolean identificationStatusRequest = false;
 		boolean identificationStatusConfirm = false;
 		
-		if(!project.getNoticeType().equals(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED)) {
+		if (!project.getNoticeType().equals(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED)) {
 			ProjectIdentification identification = new ProjectIdentification();
 			identification.setReferenceId(project.getCopyPrjId());
 			identification.setMerge(CoConstDef.FLAG_NO);
 			Map<String, Object> result = getOssComponentDataInfo(identification, CoConstDef.CD_DTL_COMPONENT_ID_BOM);
 			projectService.insertCopyConfirmStatusBomList(project, identification);
 			
-			if(result.containsKey("validData") && (confirmStatusCopy.equals("IdentificationConf") || confirmStatusCopy.equals("verificationConf"))) {
+			if (result.containsKey("validData") && (confirmStatusCopy.equals("IdentificationConf") || confirmStatusCopy.equals("verificationConf"))) {
 				log.error("copyConfirmStatus error >>> bom validation");
 				returnMap.put("result", "false");
 				returnMap.put("step", "IdentificationProgress");
 				return returnMap;
 			}
 			
-			if(!result.containsKey("validData") && !confirmStatusCopy.equals("IdentificationProg")) {
+			if (!result.containsKey("validData") && !confirmStatusCopy.equals("IdentificationProg")) {
 				project.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST);
 				
 				try {
@@ -1479,14 +1479,14 @@ public class ProjectController extends CoTopComponent {
 				return returnMap;
 			}
 			
-			if(isEmpty(projectService.getProjectBasicInfo(project.getPrjId()).getSrcAndroidNoticeFileId())) {
+			if (isEmpty(projectService.getProjectBasicInfo(project.getPrjId()).getSrcAndroidNoticeFileId())) {
 				log.error("copyConfirmStatus error > androidNoticeFile empty");
 				returnMap.put("result", "false");
 				returnMap.put("step", "identificationProgress");
 				return returnMap;
 			}
 			
-			if(!confirmStatusCopy.equals("IdentificationProg")) {
+			if (!confirmStatusCopy.equals("IdentificationProg")) {
 				project.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REQUEST);
 				
 				try {
@@ -1504,7 +1504,7 @@ public class ProjectController extends CoTopComponent {
 			}
 		}
 		
-		if(identificationStatusRequest) {
+		if (identificationStatusRequest) {
 			project.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM);
 			project.setIgnoreBinaryDbFlag(CoConstDef.FLAG_NO);
 			
@@ -1526,7 +1526,7 @@ public class ProjectController extends CoTopComponent {
 			Project prjInfo = projectService.getProjectBasicInfo(project.getPrjId());
 			Project copyPrjInfo = projectService.getProjectBasicInfo(project.getCopyPrjId());
 			
-			if(!project.getNetworkServerType().equals(copyPrjInfo.getNetworkServerType())) {
+			if (!project.getNetworkServerType().equals(copyPrjInfo.getNetworkServerType())) {
 				returnMap.put("result", "false");
 				returnMap.put("step", "verificationProgress");
 				return returnMap;
@@ -1535,7 +1535,7 @@ public class ProjectController extends CoTopComponent {
 			String filePath = CommonFunction.emptyCheckProperty("packaging.path", "/upload/packaging");
 			List<String> fileSeqsList = projectService.getPackageFileList(project, filePath);
 			
-			if(fileSeqsList.size() > 0) {
+			if (fileSeqsList.size() > 0) {
 				ProjectIdentification identification = new ProjectIdentification();
 				identification.setReferenceId(project.getPrjId());
 				identification.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_PACKAGING);
@@ -1550,7 +1550,7 @@ public class ProjectController extends CoTopComponent {
 				List<String> componentIdList = new ArrayList<>();
 				
 				List<ProjectIdentification> ocList = projectService.selectIdentificationGridList(identification);
-				for(ProjectIdentification pi : ocList) {
+				for (ProjectIdentification pi : ocList) {
 					filePathList.add(pi.getFilePath());
 					componentIdList.add(pi.getComponentId());
 				}
@@ -1564,7 +1564,7 @@ public class ProjectController extends CoTopComponent {
 					boolean isChangedPackageFile = verificationService.getChangedPackageFile(project.getPrjId(), fileSeqsList);
 					int seq = 1;
 					
-					for(String fileSeq : fileSeqsList){
+					for (String fileSeq : fileSeqsList){
 						map.put("fileSeq", fileSeq);
 						map.put("packagingFileIdx", seq++);
 						map.put("isChangedPackageFile", isChangedPackageFile);
@@ -1573,7 +1573,7 @@ public class ProjectController extends CoTopComponent {
 					
 					resMap = verifyResult.get(0);
 					
-					if(fileSeqsList.size() > 1){
+					if (fileSeqsList.size() > 1){
 						resMap.put("verifyValid", verifyResult.get(verifyResult.size()-1).get("verifyValid"));
 						resMap.put("fileCounts", verifyResult.get(verifyResult.size()-1).get("fileCounts"));
 					}
@@ -1628,7 +1628,7 @@ public class ProjectController extends CoTopComponent {
 			prjInfo.setVerificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM);
 			prjInfo.setDestributionStatus(null);
 
-/*			if("T".equals(avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE, project.getDistributionType())).trim().toUpperCase())
+/*			if ("T".equals(avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE, project.getDistributionType())).trim().toUpperCase())
 					|| (CoConstDef.FLAG_NO.equals(avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE, project.getDistributionType())).trim().toUpperCase()) 
 							&& verificationService.checkNetworkServer(ossNotice.getPrjId())
 					)
@@ -1905,7 +1905,7 @@ public class ProjectController extends CoTopComponent {
 				 * // basic validator는 무시, validate를 호출하여 custom validator를
 				 * 수행한다. T2CoValidationResult vr = pv.validate(new HashMap<>());
 				 * 
-				 * // return validator result if(!vr.isValid()) { return
+				 * // return validator result if (!vr.isValid()) { return
 				 * makeJsonResponseHeader(vr.getValidMessageMap()); }
 				 */
 				try {
@@ -1944,15 +1944,15 @@ public class ProjectController extends CoTopComponent {
 				
 				// binary.txt 파일이 변경된 경우 최초 한번만 수행
 				Project beforeProjectIfno = projectService.getProjectBasicInfo(prjId);
-				if(!isEmpty(binaryFileId) && beforeProjectIfno != null && !binaryFileId.equals(beforeProjectIfno.getBinBinaryFileId())) {
+				if (!isEmpty(binaryFileId) && beforeProjectIfno != null && !binaryFileId.equals(beforeProjectIfno.getBinBinaryFileId())) {
 					List<String> binaryTxtList = CommonFunction.getBinaryListBinBinaryTxt(fileService.selectFileInfoById(binaryFileId));
 					
-					if(binaryTxtList != null && !binaryTxtList.isEmpty()) {
+					if (binaryTxtList != null && !binaryTxtList.isEmpty()) {
 						// 현재 osslist의 binary 목록을 격납
 						Map<String, ProjectIdentification> componentBinaryList = new HashMap<>();
 						
-						for(ProjectIdentification bean : ossComponents) {
-							if(!isEmpty(bean.getBinaryName())) {
+						for (ProjectIdentification bean : ossComponents) {
+							if (!isEmpty(bean.getBinaryName())) {
 								componentBinaryList.put(bean.getBinaryName(), bean);
 							}
 						}
@@ -1960,8 +1960,8 @@ public class ProjectController extends CoTopComponent {
 						List<ProjectIdentification> addComponentList = Lists.newArrayList();
 						
 						// 존재여부 확인
-						for(String binaryNameTxt : binaryTxtList) {
-							if(!componentBinaryList.containsKey(binaryNameTxt)) {
+						for (String binaryNameTxt : binaryTxtList) {
+							if (!componentBinaryList.containsKey(binaryNameTxt)) {
 								// add 해야할 list
 								ProjectIdentification bean = new ProjectIdentification();
 								// 화면에서 추가한 것 처럼 jqg로 시작하는 component id를 임시로 설정한다.
@@ -1972,13 +1972,13 @@ public class ProjectController extends CoTopComponent {
 								changeAdded += "<br> - " + binaryNameTxt;
 							} else { // exclude처리된 경우
 								ProjectIdentification bean = componentBinaryList.get(binaryNameTxt);
-								if(bean != null && CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+								if (bean != null && CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 									changeExclude += "<br>" + binaryNameTxt;
 								}
 							}
 						}
 						
-						if(addComponentList != null && !addComponentList.isEmpty()) {
+						if (addComponentList != null && !addComponentList.isEmpty()) {
 							ossComponents.addAll(addComponentList);
 						}
 					}
@@ -1989,13 +1989,13 @@ public class ProjectController extends CoTopComponent {
 				if (!isEmpty(changeExclude) || !isEmpty(changeAdded)) {
 					String changedByResultTxt = "";
 					
-					if(!isEmpty(changeAdded)) {
+					if (!isEmpty(changeAdded)) {
 						changedByResultTxt += "<b>The following binaries were added to OSS List automatically because they exist in the fosslight_binary.txt.</b><br>";
 						changedByResultTxt += changeAdded;
 					}
 					
-					if(!isEmpty(changeExclude)) {
-						if(!isEmpty(changedByResultTxt)) {
+					if (!isEmpty(changeExclude)) {
+						if (!isEmpty(changedByResultTxt)) {
 							changedByResultTxt += "<br><br>";
 						}
 						changedByResultTxt += "<b>The following binaries are written to the OSS report as excluded, but they are in the fosslight_binary.txt. Make sure it is not included in the final firmware.</b><br>";
@@ -2055,10 +2055,10 @@ public class ProjectController extends CoTopComponent {
 				}
 				
 				try {
-					if(getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, csvFileId)) != null) {
+					if (getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, csvFileId)) != null) {
 						String chagedOssVersion = (String) getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, csvFileId), true);
 						
-						if(!isEmpty(chagedOssVersion)) {
+						if (!isEmpty(chagedOssVersion)) {
 							CommentsHistory commentHisBean = new CommentsHistory();
 							commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
 							commentHisBean.setReferenceId(prjId);
@@ -2168,7 +2168,7 @@ public class ProjectController extends CoTopComponent {
 			 * // basic validator는 무시, validate를 호출하여 custom validator를 수행한다.
 			 * T2CoValidationResult vr = pv.validate(new HashMap<>());
 			 * 
-			 * // return validator result if(!vr.isValid()) { return
+			 * // return validator result if (!vr.isValid()) { return
 			 * makeJsonResponseHeader(vr.getValidMessageMap()); }
 			 */
 			// save 시 가장 기본적인 유효성 체크만 진행 (길이, 형식 체크)
@@ -2223,10 +2223,10 @@ public class ProjectController extends CoTopComponent {
 						}
 						
 						try {
-							if(getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, _file.getFileSeq())) != null) {
+							if (getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, _file.getFileSeq())) != null) {
 								String chagedOssVersion = (String) getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, _file.getFileSeq()), true);
 								
-								if(!isEmpty(chagedOssVersion)) {
+								if (!isEmpty(chagedOssVersion)) {
 									CommentsHistory commentHisBean = new CommentsHistory();
 									commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
 									commentHisBean.setReferenceId(prjId);
@@ -2317,7 +2317,7 @@ public class ProjectController extends CoTopComponent {
 		ossComponent = (List<ProjectIdentification>) fromJson(mainDataString, collectionType2);
 		
 		List<List<ProjectIdentification>> ossComponentLicense = null;
-		if(code.equals(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER)) {
+		if (code.equals(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER)) {
 			ossComponentLicense = CommonFunction.setOssComponentLicense(ossComponent, true);
 		} else {
 			ossComponentLicense = CommonFunction.setOssComponentLicense(ossComponent);
@@ -2415,11 +2415,11 @@ public class ProjectController extends CoTopComponent {
 		try {
 			String fileId = null;
 			
-			if(!isEmpty(androidNoticeXmlId)) {
+			if (!isEmpty(androidNoticeXmlId)) {
 				fileId = androidNoticeXmlId;
 			}
 			
-			if(isEmpty(androidNoticeXmlId) 
+			if (isEmpty(androidNoticeXmlId) 
 					&& !isEmpty(androidNoticeFileId)) {
 				fileId = androidNoticeFileId;
 			}
@@ -2529,9 +2529,9 @@ public class ProjectController extends CoTopComponent {
 			}
 			
 			try {
-				if(getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, androidCsvFileId)) != null) {
+				if (getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, androidCsvFileId)) != null) {
 					String chagedOssVersion = (String) getSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, androidCsvFileId), true);
-					if(!isEmpty(chagedOssVersion)) {
+					if (!isEmpty(chagedOssVersion)) {
 						CommentsHistory commentHisBean = new CommentsHistory();
 						commentHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
 						commentHisBean.setReferenceId(prjId);
@@ -2628,11 +2628,11 @@ public class ProjectController extends CoTopComponent {
 		String resCd = "";
 		String resMsg = "";
 
-		if(project.getPrjId() == null || "".equals(project.getPrjId())) {
+		if (project.getPrjId() == null || "".equals(project.getPrjId())) {
 			return makeJsonResponseHeader(false, "prjId is empty", null);
 		}
 		
-		if(project.getDelOsdd()!=null && (project.getDelOsdd().equals(CoConstDef.FLAG_YES) || project.getDelOsdd().equals(CoConstDef.FLAG_NO))) {
+		if (project.getDelOsdd()!=null && (project.getDelOsdd().equals(CoConstDef.FLAG_YES) || project.getDelOsdd().equals(CoConstDef.FLAG_NO))) {
 			project.setCompleteYn(CoConstDef.FLAG_NO);
 			project.setStatusRequestYn(CoConstDef.FLAG_NO);
 			project.setCommId(null);
@@ -2640,16 +2640,16 @@ public class ProjectController extends CoTopComponent {
 			project.setIgnoreUserCommentReg(CoConstDef.FLAG_YES);
 			
 			resMsg = getMessage("msg.distribute.reset");
-			if("10".equals(resCd)){
+			if ("10".equals(resCd)){
 				
 			}	
-			else if("20".equals(resCd)){
+			else if ("20".equals(resCd)){
 				resMsg="server error.";
 			} else{
 				resMsg = resCd;
 			}
 			
-			if(!resCd.equals("10")) {
+			if (!resCd.equals("10")) {
 				return makeJsonResponseHeader(false, resMsg, null);
 			}
 		}
@@ -2659,15 +2659,15 @@ public class ProjectController extends CoTopComponent {
 		try {
 			 resultMap = projectService.updateProjectStatus(project);
 			 
-			 if(resultMap.containsKey("androidMessage")) {
+			 if (resultMap.containsKey("androidMessage")) {
 				 return makeJsonResponseHeader(false, getMessage("msg.project.android.valid"));
 			 }
 			 
-			 if(resultMap.containsKey("diffMap")) {
+			 if (resultMap.containsKey("diffMap")) {
 				 return makeJsonResponseHeader(false, null, (Map<String, Object>) resultMap.get("validMap"), (Map<String, Object>) resultMap.get("diffMap"));
 			 }
 			 
-			 if(resultMap.containsKey("validMap")) {
+			 if (resultMap.containsKey("validMap")) {
 				 return makeJsonResponseHeader(false, null, (Map<String, Object>) resultMap.get("validMap"));
 			 }
 		} catch (Exception e) {
@@ -2705,11 +2705,11 @@ public class ProjectController extends CoTopComponent {
 		model.addAttribute("project", projectMaster);
 		// android model이면서 bom화면을 표시하려고하는 경우, android bin tab index로 치환한다.
 		
-		if(!"3".equals(initDiv) && CoConstDef.FLAG_YES.equals(projectMaster.getAndroidFlag())) {
+		if (!"3".equals(initDiv) && CoConstDef.FLAG_YES.equals(projectMaster.getAndroidFlag())) {
 			initDiv = "3";
 		}
 		
-		if(!partnerFlag && "0".equals(initDiv)) {
+		if (!partnerFlag && "0".equals(initDiv)) {
 			initDiv = "1";
 		}
 		
@@ -2973,7 +2973,7 @@ public class ProjectController extends CoTopComponent {
 			return makeJsonResponseHeader(false, errMsg);
 		}
 
-		if(!isEmpty(status) && CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(status.toUpperCase())){
+		if (!isEmpty(status) && CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(status.toUpperCase())){
 			ProjectIdentification identification = new ProjectIdentification();
 			identification.setReferenceId(prjId);
 			identification.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_BOM);
@@ -3088,7 +3088,7 @@ public class ProjectController extends CoTopComponent {
 		try {
 			// addWatcher로 email을 등록할 경우 ldap search로 존재하는 사용자의 email인지 check가 필요함.
 			String ldapFlag = CoCodeManager.getCodeExpString(CoConstDef.CD_SYSTEM_SETTING, CoConstDef.CD_LDAP_USED_FLAG);
-			if(CoConstDef.FLAG_YES.equals(ldapFlag) && !isEmpty(project.getPrjEmail())) {
+			if (CoConstDef.FLAG_YES.equals(ldapFlag) && !isEmpty(project.getPrjEmail())) {
 				Map<String, String> userInfo = new HashMap<>();
 				userInfo.put("USER_ID", CoCodeManager.getCodeExpString(CoConstDef.CD_LDAP_SEARCH_INFO, CoConstDef.CD_DTL_LDAP_SEARCH_ID));
 				userInfo.put("USER_PW", CoCodeManager.getCodeExpString(CoConstDef.CD_LDAP_SEARCH_INFO, CoConstDef.CD_DTL_LDAP_SEARCH_PW));
@@ -3098,7 +3098,7 @@ public class ProjectController extends CoTopComponent {
 				
 				boolean isAuthenticated = userService.checkAdAccounts(userInfo, "USER_ID", "USER_PW", filter);
 				
-				if(!isAuthenticated) {
+				if (!isAuthenticated) {
 					throw new Exception("add Watcher Failure");
 				}
 				
@@ -3109,7 +3109,7 @@ public class ProjectController extends CoTopComponent {
 				resultMap.put("email", email);
 			}
 			
-			if(!isEmpty(project.getPrjUserId()) || !isEmpty(project.getPrjEmail())) {
+			if (!isEmpty(project.getPrjUserId()) || !isEmpty(project.getPrjEmail())) {
 				projectService.addWatcher(project);
 				resultMap.put("isValid", "true");
 			} else {
@@ -3135,7 +3135,7 @@ public class ProjectController extends CoTopComponent {
 	public @ResponseBody ResponseEntity<Object> removeWatcher(@RequestBody Project project,
 			HttpServletRequest req, HttpServletResponse res, Model model) {
 		try {
-			if(!isEmpty(project.getPrjUserId()) || !isEmpty(project.getPrjEmail())) {
+			if (!isEmpty(project.getPrjUserId()) || !isEmpty(project.getPrjEmail())) {
 				projectService.removeWatcher(project);
 			} else {
 				return makeJsonResponseHeader(false, null);
@@ -3162,23 +3162,23 @@ public class ProjectController extends CoTopComponent {
 		HashMap<String, Object> resMap = new HashMap<>();
 		
 		try {			
-			if(!isEmpty(project.getListKind()) && !isEmpty(project.getListId()) ) {
+			if (!isEmpty(project.getListKind()) && !isEmpty(project.getListId()) ) {
 				List<Project> result = projectService.copyWatcher(project);
 				
-				if(result != null) {
-					for(Project bean : result) {
-						if(!isEmpty(bean.getPrjDivision())) {
+				if (result != null) {
+					for (Project bean : result) {
+						if (!isEmpty(bean.getPrjDivision())) {
 							bean.setPrjDivisionName(CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, bean.getPrjDivision()));
 						}
 					}
 					
-					if(!isEmpty(project.getPrjId())) {
+					if (!isEmpty(project.getPrjId())) {
 						boolean existProjectWatcher = projectService.existsWatcher(project);
 						
-						for(Project pm : result) {
+						for (Project pm : result) {
 							pm.setPrjId(project.getPrjId());
 							
-							if(existProjectWatcher) {
+							if (existProjectWatcher) {
 								projectService.addWatcher(pm);
 							}
 						}					
@@ -3343,20 +3343,20 @@ public class ProjectController extends CoTopComponent {
 				}
 			}
 
-			if(fileExtension.equals("csv")) {
+			if (fileExtension.equals("csv")) {
 				resultList = CommonFunction.checkCsvFileLimit(list);
 			} else {
 				resultList = CommonFunction.checkXlsxFileLimit(list);
 			}
 			
-			if(resultList.size() > 0) {
+			if (resultList.size() > 0) {
 				return toJson(resultList);
 			}
 		} catch (Exception e) {
 			log.error(e.getMessage());
 		}
 
-		if(fileExtension.equals("csv")) {
+		if (fileExtension.equals("csv")) {
 			resultList.add(list);
 			resultList.add("SRC");
 			resultList.add("CSV_FILE");
@@ -3372,14 +3372,14 @@ public class ProjectController extends CoTopComponent {
 			}
 
 			Boolean isSpdxSpreadsheet = false;
-			for(Object sheet : sheetNameList) {
+			for (Object sheet : sheetNameList) {
 				String sheetName = sheet.toString();
-				if(sheetName.contains("Package Info") || sheetName.contains("Per File Info")) {
+				if (sheetName.contains("Package Info") || sheetName.contains("Per File Info")) {
 					isSpdxSpreadsheet = true;
 				}
 			}
 
-			if(isSpdxSpreadsheet){
+			if (isSpdxSpreadsheet){
 				resultList.add(list);
 				resultList.add(sheetNameList);
 				resultList.add("SPDX_SPREADSHEET_FILE");
@@ -3430,13 +3430,13 @@ public class ProjectController extends CoTopComponent {
 				}
 			}
 
-			if(fileExtension.equals("csv")) {
+			if (fileExtension.equals("csv")) {
 				resultList = CommonFunction.checkCsvFileLimit(list);
 			} else {
 				resultList = CommonFunction.checkXlsxFileLimit(list);
 			}
 			
-			if(resultList.size() > 0) {
+			if (resultList.size() > 0) {
 				return toJson(resultList);
 			}
 		} catch (Exception e) {
@@ -3466,14 +3466,14 @@ public class ProjectController extends CoTopComponent {
 			}
 			
 			Boolean isSpdxSpreadsheet = false;
-			for(Object sheet : sheetNameList) {
+			for (Object sheet : sheetNameList) {
 				String sheetName = sheet.toString();
-				if(sheetName.contains("Package Info") || sheetName.contains("Per File Info")) {
+				if (sheetName.contains("Package Info") || sheetName.contains("Per File Info")) {
 					isSpdxSpreadsheet = true;
 				}
 			}
 			
-			if(isSpdxSpreadsheet){
+			if (isSpdxSpreadsheet){
 				resultList.add(list);
 				resultList.add(sheetNameList);
 				resultList.add("SPDX_SPREADSHEET_FILE");
@@ -3535,11 +3535,11 @@ public class ProjectController extends CoTopComponent {
 				if (!ExcelUtil.readReport(readType, true, sheetList.toArray(new String[sheetList.size()]), fileSeq,
 						reportData, errMsgList)) {
 					// error 처리
-					for(String s : errMsgList) {
-						if(isEmpty(s)) {
+					for (String s : errMsgList) {
+						if (isEmpty(s)) {
 							continue;
 						}
-						if(!isEmpty(errMsg)) {
+						if (!isEmpty(errMsg)) {
 							errMsg += "<br/>";
 						}
 						errMsg += s;
@@ -3551,11 +3551,11 @@ public class ProjectController extends CoTopComponent {
 				return makeJsonResponseHeader(false, e.getMessage());
 			}
 			
-			for(String s : errMsgList) {
-				if(isEmpty(s)) {
+			for (String s : errMsgList) {
+				if (isEmpty(s)) {
 					continue;
 				}
-				if(!isEmpty(errMsg)) {
+				if (!isEmpty(errMsg)) {
 					errMsg += "<br/>";
 				}
 				errMsg += s;
@@ -3582,17 +3582,17 @@ public class ProjectController extends CoTopComponent {
 						CoConstDef.SESSION_KEY_UPLOAD_REPORT_CHANGEDLICENSE, fileSeq));
 			}
 
-			if(resultMap.containsKey("versionChangedList")) {
+			if (resultMap.containsKey("versionChangedList")) {
 				List<String> versionChangedList = (List<String>) resultMap.get("versionChangedList");
-				if(!versionChangedList.isEmpty()) {
+				if (!versionChangedList.isEmpty()) {
 					String versionChangedStr = "<b>The following open source version below has been changed to a registered version</b><br><br>";
-					for(String s : versionChangedList) {
+					for (String s : versionChangedList) {
 						versionChangedStr += "<br>" + s;
 					}
 					
 					putSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, fileSeq), versionChangedStr);
 
-					if(!isEmpty(systemChangeHisStr)) {
+					if (!isEmpty(systemChangeHisStr)) {
 						systemChangeHisStr += "<br><br>" + versionChangedStr;
 					}
 				}
@@ -3612,7 +3612,7 @@ public class ProjectController extends CoTopComponent {
 			pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) resultMap.get("subData"));
 
 			T2CoValidationResult vr = pv.validate(new HashMap<>());
-			if(!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+			if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
 				resultMap.replace("mainData", CommonFunction.identificationSortByValidInfo(
 						(List<ProjectIdentification>) resultMap.get("mainData"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false));
 				return makeJsonResponseHeader(true, errMsg, resultMap, vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap());
@@ -3684,7 +3684,7 @@ public class ProjectController extends CoTopComponent {
 		project.setPrjName(project.getPrjName());
 		project.setPrjVersion(avoidNull(project.getPrjVersion()) + "_Copied");
 		
-		if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(identificationStatus)) {
+		if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(identificationStatus)) {
 			T2Users user = new T2Users();
 			user.setUserId(loginUserName());
 			
@@ -3695,7 +3695,7 @@ public class ProjectController extends CoTopComponent {
 
 			comment = "Copy with confirm status from [PRJ-" + prjId + "] " + project.getPrjName();
 			
-			if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(verificationStatus)) {
+			if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(verificationStatus)) {
 				project.setVerificationStatusConfFlag(CoConstDef.FLAG_YES);
 			}
 		}else {
@@ -3716,7 +3716,7 @@ public class ProjectController extends CoTopComponent {
 		project.setCompleteYn(CoConstDef.FLAG_NO);
 		
 		T2Users user = userService.getLoginUserInfo();
-		if(user != null && user.getDivision() != null) {
+		if (user != null && user.getDivision() != null) {
 			project.setDivision(user.getDivision());
 		}
 		
@@ -3789,7 +3789,7 @@ public class ProjectController extends CoTopComponent {
 				}
 			}
 			
-			if(count != 1) {
+			if (count != 1) {
 				resultList = null;
 			} else {
 				// 파일 등록
@@ -3816,7 +3816,7 @@ public class ProjectController extends CoTopComponent {
 				
 				resultList = CommonFunction.checkXlsxFileLimit(list);
 				
-				if(resultList.size() > 0) {
+				if (resultList.size() > 0) {
 					return toJson(resultList);
 				}
 			}
@@ -3881,11 +3881,11 @@ public class ProjectController extends CoTopComponent {
 				if (!ExcelUtil.readAndroidBuildImage("", true, sheetList.toArray(new String[sheetList.size()]), fileSeq,
 						resultFileSeq, reportData, errMsgList, checkHeaderSheetName)) {
 					// error 처리
-					for(String s : errMsgList) {
-						if(isEmpty(s)) {
+					for (String s : errMsgList) {
+						if (isEmpty(s)) {
 							continue;
 						}
-						if(!isEmpty(errMsg)) {
+						if (!isEmpty(errMsg)) {
 							errMsg += "<br/>";
 						}
 						errMsg += s;
@@ -3897,11 +3897,11 @@ public class ProjectController extends CoTopComponent {
 				return makeJsonResponseHeader(false, e.getMessage());
 			}
 			
-			for(String s : errMsgList) {
-				if(isEmpty(s)) {
+			for (String s : errMsgList) {
+				if (isEmpty(s)) {
 					continue;
 				}
-				if(!isEmpty(errMsg)) {
+				if (!isEmpty(errMsg)) {
 					errMsg += "<br/>";
 				}
 				errMsg += s;
@@ -3936,7 +3936,7 @@ public class ProjectController extends CoTopComponent {
 				String noticeFileName = noticeFile.getLogiNm();
                 String fullName = noticeFile.getLogiPath() + "/" + noticeFileName;
                 
-                if("xml".equalsIgnoreCase(FilenameUtils.getExtension(noticeFileName))) {
+                if ("xml".equalsIgnoreCase(FilenameUtils.getExtension(noticeFileName))) {
                     noticeBinaryList = CommonFunction.getAndroidNoticeBinaryXmlList(fullName);
                 } else {
                     noticeBinaryList = CommonFunction.getAndroidNoticeBinaryList(FileUtils.readFileToString(
@@ -3946,7 +3946,7 @@ public class ProjectController extends CoTopComponent {
                 Map<String, Object> convertObj = CommonFunction.convertToProjectIdentificationList(reportData, fileSeq);
 				noticeCheckResultMap = projectService.applySrcAndroidModel((List<ProjectIdentification>)convertObj.get("resultList"), noticeBinaryList);
 				
-				if(convertObj.containsKey("versionChangeList")) {
+				if (convertObj.containsKey("versionChangeList")) {
 					versionChangedList = (List<String>) convertObj.get("versionChangeList");
 				}
 			} catch (IOException e) {
@@ -3961,28 +3961,28 @@ public class ProjectController extends CoTopComponent {
 
 			String systemChangeHisStr = "";
 			
-			if(!isEmpty(resultTextChangeHisStr)) {
+			if (!isEmpty(resultTextChangeHisStr)) {
 				systemChangeHisStr = resultTextChangeHisStr;
 			}
 			
-			if(!isEmpty(licenseNameChangeHisStr)) {
-				if(!isEmpty(systemChangeHisStr)) {
+			if (!isEmpty(licenseNameChangeHisStr)) {
+				if (!isEmpty(systemChangeHisStr)) {
 					systemChangeHisStr += "<br><br>";
 				}
 				
 				systemChangeHisStr += licenseNameChangeHisStr;
 			}
 			
-			if(versionChangedList != null) {
+			if (versionChangedList != null) {
 				String versionChangedStr = "<b>The following open source version below has been changed to a registered version</b><br><br>";
 				
-				for(String s : versionChangedList) {
+				for (String s : versionChangedList) {
 					versionChangedStr += "<br>" + s;
 				}
 				
 				putSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, fileSeq), versionChangedStr);
 				
-				if(!isEmpty(systemChangeHisStr)) {
+				if (!isEmpty(systemChangeHisStr)) {
 					systemChangeHisStr += "<br><br>";
 				}
 				systemChangeHisStr += versionChangedStr;
@@ -4006,7 +4006,7 @@ public class ProjectController extends CoTopComponent {
 				
 				T2CoValidationResult vr = pv.validate(new HashMap<>());
 
-				if(!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+				if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
 					resultMap.replace("mainData", CommonFunction.identificationSortByValidInfo(
 							(List<ProjectIdentification>) resultMap.get("mainData"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false));
 					return makeJsonResponseHeader(true, errMsg, resultMap, vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap());
@@ -4048,12 +4048,12 @@ public class ProjectController extends CoTopComponent {
 		Project project = new Project();
 		project.setPrjId(commentsHistory.getReferenceId());
 		Project projectDetail = projectService.getProjectDetail(project);
-		if(projectDetail.getCompleteYn().equals(CoConstDef.FLAG_NO)) {
+		if (projectDetail.getCompleteYn().equals(CoConstDef.FLAG_NO)) {
 			//향후 메세지 처리 확인 할것
 			return makeJsonResponseHeader(false, "The status is not Complete. Check the status value.", null);
 		}else {
 			String commentsMode = commentsHistory.getCommentsMode();
-			if(commentsMode.equals("reject")) {
+			if (commentsMode.equals("reject")) {
 				project.setCompleteYn(CoConstDef.FLAG_NO);
 				project.setStatusRequestYn(CoConstDef.FLAG_NO);
 				project.setCommId(null);
@@ -4061,15 +4061,15 @@ public class ProjectController extends CoTopComponent {
 				project.setIgnoreUserCommentReg(CoConstDef.FLAG_YES);
 				
 				resMsg = getMessage("msg.distribute.reset");
-				if("10".equals(resCd)){
+				if ("10".equals(resCd)){
 				}	
-				else if("20".equals(resCd)){
+				else if ("20".equals(resCd)){
 					resMsg="server error.";
 				}
 				else{
 					resMsg = resCd;
 				}
-				if(!resCd.equals("10")) {
+				if (!resCd.equals("10")) {
 					return makeJsonResponseHeader(false, resMsg, null);
 				}
 				
@@ -4099,7 +4099,7 @@ public class ProjectController extends CoTopComponent {
 		project.setPrjId(commentsHistory.getReferenceId());
 		Project projectDetail = projectService.getProjectDetail(project);
 		
-		if(projectDetail.getCompleteYn().equals(CoConstDef.FLAG_NO)) {
+		if (projectDetail.getCompleteYn().equals(CoConstDef.FLAG_NO)) {
 			//향후 메세지 처리 확인 할것
 			return makeJsonResponseHeader(false, "The status is not Complete. Check the status value.", null);
 		}else {
@@ -4172,8 +4172,8 @@ public class ProjectController extends CoTopComponent {
 			
 			String validMsg = projectService.checkValidData(result);
 			
-			if(isEmpty(validMsg)) {
-				if(CoConstDef.FLAG_YES.equals(zipFlag)) {
+			if (isEmpty(validMsg)) {
+				if (CoConstDef.FLAG_YES.equals(zipFlag)) {
 					fileId = projectService.makeZipFileId(result, projectDetail);
 				} else {
 					try {
@@ -4187,7 +4187,7 @@ public class ProjectController extends CoTopComponent {
 				return makeJsonResponseHeader(false, validMsg);
 			}
 			
-			if(isEmpty(fileId)){
+			if (isEmpty(fileId)){
 				return makeJsonResponseHeader(false, "overflow");
 			}
 		} catch (Exception e) {
@@ -4251,7 +4251,7 @@ public class ProjectController extends CoTopComponent {
 				log.error(e.getMessage(), e);
 			}
 			
-			if((List<ProjectIdentification>) beforeBom.get("rows") == null || (List<ProjectIdentification>) afterBom.get("rows") == null) {// before, after값 중 하나라도 null이 있으면 비교 불가함. 
+			if ((List<ProjectIdentification>) beforeBom.get("rows") == null || (List<ProjectIdentification>) afterBom.get("rows") == null) {// before, after값 중 하나라도 null이 있으면 비교 불가함. 
 				throw new Exception();
 			}
 		
@@ -4309,23 +4309,23 @@ public class ProjectController extends CoTopComponent {
 			HttpServletResponse res, Model model) {
 		List<String> permissionCheckList = null;
 		
-		if(!CommonFunction.isAdmin()) {
+		if (!CommonFunction.isAdmin()) {
 			CommonFunction.setProjectService(projectService);
 			permissionCheckList = CommonFunction.checkUserPermissions(loginUserName(), project.getPrjIds(), "project");
 		}
 		
-		if(permissionCheckList == null || permissionCheckList.isEmpty()){
+		if (permissionCheckList == null || permissionCheckList.isEmpty()){
 			Map<String, List<Project>> updatePrjDivision = projectService.updateProjectDivision(project);
 			
-			if(updatePrjDivision.containsKey("before") && updatePrjDivision.containsKey("after")) {
+			if (updatePrjDivision.containsKey("before") && updatePrjDivision.containsKey("after")) {
 				List<Project> beforePrjList = (List<Project>) updatePrjDivision.get("before");
 				List<Project> afterPrjList = (List<Project>) updatePrjDivision.get("after");
 				
-				if((beforePrjList != null && !beforePrjList.isEmpty()) 
+				if ((beforePrjList != null && !beforePrjList.isEmpty()) 
 						&& (afterPrjList != null && !afterPrjList.isEmpty())
 						&& beforePrjList.size() == afterPrjList.size()) {
 					
-					for(int i=0; i<beforePrjList.size(); i++) {
+					for (int i=0; i<beforePrjList.size(); i++) {
 						try {
 							String mailType = CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED;
 							CoMail mailBean = new CoMail(mailType);
@@ -4361,7 +4361,7 @@ public class ProjectController extends CoTopComponent {
 	}
 	
 	public void updateProjectNotification(Project project, Map<String, Object> resultMap) {
-		if(resultMap != null){
+		if (resultMap != null){
 			String mailType = (String) resultMap.get("mailType");
 			String userComment = (String) resultMap.get("userComment");
 			String commentDiv = (String) resultMap.get("commentDiv");
@@ -4378,7 +4378,7 @@ public class ProjectController extends CoTopComponent {
 				log.error(e.getMessage(), e);
 			}
 			
-			if(!isEmpty(mailType)) {
+			if (!isEmpty(mailType)) {
 				try {
 					CoMail mailBean = new CoMail(mailType);
 					mailBean.setParamPrjId(project.getPrjId());

--- a/src/main/java/oss/fosslight/controller/SPDXDownloadController.java
+++ b/src/main/java/oss/fosslight/controller/SPDXDownloadController.java
@@ -65,22 +65,22 @@ public class SPDXDownloadController extends CoTopComponent {
 			
 			Project prjBean = projectService.getProjectBasicInfo(prjId);
 			
-			if("spdxRdf".equals(spdxType)) {
-				if(!isEmpty(prjBean.getSpdxRdfFileId())) {
+			if ("spdxRdf".equals(spdxType)) {
+				if (!isEmpty(prjBean.getSpdxRdfFileId())) {
 					downloadId = prjBean.getSpdxRdfFileId();
 				} else {
 					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 					T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 					String sheetFullPath = sheetFile.getLogiPath();
 					
-					if(!sheetFullPath.endsWith("/")) {
+					if (!sheetFullPath.endsWith("/")) {
 						sheetFullPath += "/";
 					}
 					
 					sheetFullPath += sheetFile.getLogiNm();
 					String rdfFullPath = sheetFile.getLogiPath();
 					
-					if(!rdfFullPath.endsWith("/")) {
+					if (!rdfFullPath.endsWith("/")) {
 						rdfFullPath += "/";
 					}
 					
@@ -94,7 +94,7 @@ public class SPDXDownloadController extends CoTopComponent {
 					try {
 						File spdxRdfFile = new File(rdfFullPath);
 						
-						if(spdxRdfFile.exists() && spdxRdfFile.length() <= 0) {
+						if (spdxRdfFile.exists() && spdxRdfFile.length() <= 0) {
 							CommentsHistory commHisBean = new CommentsHistory();
 							commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS);
 							commHisBean.setReferenceId(prjId);
@@ -107,15 +107,15 @@ public class SPDXDownloadController extends CoTopComponent {
 						log.error(e.getMessage(), e);
 					}
 				}
-			} else if("spdxTag".equals(spdxType)) {
-				if(!isEmpty(prjBean.getSpdxTagFileId())) {
+			} else if ("spdxTag".equals(spdxType)) {
+				if (!isEmpty(prjBean.getSpdxTagFileId())) {
 					downloadId = prjBean.getSpdxTagFileId();
 				} else {
 					String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 					T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 					String sheetFullPath = sheetFile.getLogiPath();
 					
-					if(!sheetFullPath.endsWith("/")) {
+					if (!sheetFullPath.endsWith("/")) {
 						sheetFullPath += "/";
 					}
 					
@@ -123,7 +123,7 @@ public class SPDXDownloadController extends CoTopComponent {
 					
 					String tagFullPath = sheetFile.getLogiPath();
 					
-					if(!tagFullPath.endsWith("/")) {
+					if (!tagFullPath.endsWith("/")) {
 						tagFullPath += "/";
 					}
 					
@@ -137,7 +137,7 @@ public class SPDXDownloadController extends CoTopComponent {
 					try {
 						File spdxTafFile = new File(tagFullPath);
 						
-						if(spdxTafFile.exists() && spdxTafFile.length() <= 0) {
+						if (spdxTafFile.exists() && spdxTafFile.length() <= 0) {
 							CommentsHistory commHisBean = new CommentsHistory();
 							commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS);
 							commHisBean.setReferenceId(prjId);
@@ -149,7 +149,7 @@ public class SPDXDownloadController extends CoTopComponent {
 						log.error(e.getMessage(), e);
 					}
 				}
-			} else if("spdxJson".equals(spdxType)) {
+			} else if ("spdxJson".equals(spdxType)) {
 				if (!isEmpty(prjBean.getSpdxJsonFileId())) {
 					downloadId = prjBean.getSpdxJsonFileId();
 				} else {
@@ -190,7 +190,7 @@ public class SPDXDownloadController extends CoTopComponent {
 						log.error(e.getMessage(), e);
 					}
 				}
-			} else if("spdxYaml".equals(spdxType)) {
+			} else if ("spdxYaml".equals(spdxType)) {
 				if (!isEmpty(prjBean.getSpdxYamlFileId())) {
 					downloadId = prjBean.getSpdxYamlFileId();
 				} else {
@@ -231,8 +231,8 @@ public class SPDXDownloadController extends CoTopComponent {
 						log.error(e.getMessage(), e);
 					}
 				}
-			} else if("spdx".equals(spdxType)){
-				if(!isEmpty(prjBean.getSpdxSheetFileId())) {
+			} else if ("spdx".equals(spdxType)){
+				if (!isEmpty(prjBean.getSpdxSheetFileId())) {
 					downloadId = prjBean.getSpdxSheetFileId();
 				} else {
 					downloadId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
@@ -259,7 +259,7 @@ public class SPDXDownloadController extends CoTopComponent {
 		T2File fileInfo = fileService.selectFileInfo(req.getParameter("id"));
 		String filePath = fileInfo.getLogiPath();
 		
-		if(!filePath.endsWith("/")) {
+		if (!filePath.endsWith("/")) {
 			filePath += "/";
 		}
 		
@@ -278,19 +278,19 @@ public class SPDXDownloadController extends CoTopComponent {
 			String dataStr = (String)map.get("dataStr");
 			String prjId = (String)map.get("prjId");
 			
-			if("spdxRdf".equals(spdxType)) {
+			if ("spdxRdf".equals(spdxType)) {
 				String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx_self", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 				T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 				String sheetFullPath = sheetFile.getLogiPath();
 				
-				if(!sheetFullPath.endsWith("/")) {
+				if (!sheetFullPath.endsWith("/")) {
 					sheetFullPath += "/";
 				}
 				
 				sheetFullPath += sheetFile.getLogiNm();
 				String rdfFullPath = sheetFile.getLogiPath();
 				
-				if(!rdfFullPath.endsWith("/")) {
+				if (!rdfFullPath.endsWith("/")) {
 					rdfFullPath += "/";
 				}
 				
@@ -304,7 +304,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				try {
 					File spdxRdfFile = new File(rdfFullPath);
 					
-					if(spdxRdfFile.exists() && spdxRdfFile.length() <= 0) {
+					if (spdxRdfFile.exists() && spdxRdfFile.length() <= 0) {
 						CommentsHistory commHisBean = new CommentsHistory();
 						commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS);
 						commHisBean.setReferenceId(prjId);
@@ -316,12 +316,12 @@ public class SPDXDownloadController extends CoTopComponent {
 				} catch (Exception e) {
 					log.error(e.getMessage(), e);
 				}
-			} else if("spdxTag".equals(spdxType)) {
+			} else if ("spdxTag".equals(spdxType)) {
 				String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx_self", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 				T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 				String sheetFullPath = sheetFile.getLogiPath();
 				
-				if(!sheetFullPath.endsWith("/")) {
+				if (!sheetFullPath.endsWith("/")) {
 					sheetFullPath += "/";
 				}
 				
@@ -329,7 +329,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				
 				String tagFullPath = sheetFile.getLogiPath();
 				
-				if(!tagFullPath.endsWith("/")) {
+				if (!tagFullPath.endsWith("/")) {
 					tagFullPath += "/";
 				}
 				
@@ -343,7 +343,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				try {
 					File spdxTafFile = new File(tagFullPath);
 					
-					if(spdxTafFile.exists() && spdxTafFile.length() <= 0) {
+					if (spdxTafFile.exists() && spdxTafFile.length() <= 0) {
 						CommentsHistory commHisBean = new CommentsHistory();
 						commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS);
 						commHisBean.setReferenceId(prjId);
@@ -354,7 +354,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				} catch (Exception e) {
 					log.error(e.getMessage(), e);
 				}
-			} else if("spdxJson".equals(spdxType)) {
+			} else if ("spdxJson".equals(spdxType)) {
 				String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx_self", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 				T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 				String sheetFullPath = sheetFile.getLogiPath();
@@ -391,7 +391,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				} catch (Exception e) {
 					log.error(e.getMessage(), e);
 				}
-			} else if("spdxYaml".equals(spdxType)) {
+			} else if ("spdxYaml".equals(spdxType)) {
 				String sheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx_self", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 				T2File sheetFile = fileService.selectFileInfo(sheetFileId);
 				String sheetFullPath = sheetFile.getLogiPath();
@@ -428,7 +428,7 @@ public class SPDXDownloadController extends CoTopComponent {
 				} catch (Exception e) {
 					log.error(e.getMessage(), e);
 				}
-			} else if("spdx".equals(spdxType)){
+			} else if ("spdx".equals(spdxType)){
 				downloadId = ExcelDownLoadUtil.getExcelDownloadId("spdx_self", dataStr, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 			} else {
 				log.error("not match type...");

--- a/src/main/java/oss/fosslight/controller/ScannerController.java
+++ b/src/main/java/oss/fosslight/controller/ScannerController.java
@@ -40,12 +40,12 @@ public class ScannerController {
 			log.info("fl scanner start pid : " + prjId + ", url:" + wgetUrl);
 			String scannServiceUrl = CoCodeManager.getCodeExpString(CoConstDef.CD_EXTERNAL_ANALYSIS_SETTING, CoConstDef.CD_DTL_FL_SCANNER_URL);
 			String adminToken = CoCodeManager.getCodeExpString(CoConstDef.CD_EXTERNAL_ANALYSIS_SETTING, CoConstDef.CD_DTL_ADMIN_TOKEN);
-			if(StringUtil.isEmpty(scannServiceUrl) || StringUtil.isEmpty(adminToken)) {
+			if (StringUtil.isEmpty(scannServiceUrl) || StringUtil.isEmpty(adminToken)) {
 				return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE, "FL Scanner Url or Admin token is not configured");
 			}
 			
 			T2Users user = userService.getLoginUserInfo();
-			if(user == null || StringUtil.isEmpty(user.getEmail())) {
+			if (user == null || StringUtil.isEmpty(user.getEmail())) {
 				return responseService.getFailResult(CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE, "Login User Email is not configured");
 			}
 			

--- a/src/main/java/oss/fosslight/controller/SearchController.java
+++ b/src/main/java/oss/fosslight/controller/SearchController.java
@@ -164,7 +164,7 @@ public class SearchController extends CoTopComponent {
     public String getSidx(HttpServletRequest req){
 
         String sidx = req.getParameter("sidx");
-        if(sidx != null) {
+        if (sidx != null) {
             sidx = sidx.split("[,]")[1].trim();
         }
         return sidx;
@@ -173,7 +173,7 @@ public class SearchController extends CoTopComponent {
 
     public String getHttpPrefix(String homepage){
         List<String> httpPrefixs = Arrays.asList("https://", "http://", "www.");
-        if(!httpPrefixs.contains(homepage)){
+        if (!httpPrefixs.contains(homepage)){
             homepage = homepage.replaceFirst("^((http|https)://)?(www.)*", "");
         }
         return homepage;

--- a/src/main/java/oss/fosslight/controller/SelfCheckController.java
+++ b/src/main/java/oss/fosslight/controller/SelfCheckController.java
@@ -104,14 +104,14 @@ public class SelfCheckController extends CoTopComponent {
 		
 		Project searchBean = null;
 		
-		if(!CoConstDef.FLAG_YES.equals(req.getParameter("gnbF"))) {
+		if (!CoConstDef.FLAG_YES.equals(req.getParameter("gnbF"))) {
 			deleteSession(SESSION_KEY_SEARCH);
 			
 			searchBean = searchService.getSelfCheckSearchFilter(loginUserName());
-			if(searchBean == null) {
+			if (searchBean == null) {
 				searchBean = new Project();
 			}
-		} else if(getSessionObject(SESSION_KEY_SEARCH) != null) {
+		} else if (getSessionObject(SESSION_KEY_SEARCH) != null) {
 			searchBean = (Project) getSessionObject(SESSION_KEY_SEARCH);
 		}
 		
@@ -154,10 +154,10 @@ public class SelfCheckController extends CoTopComponent {
 		model.addAttribute("partnerFlag", CommonFunction.propertyFlagCheck("menu.partner.use.flag", CoConstDef.FLAG_YES));
 		
 		// Admin인 경우 Creator 를 변경할 수 있도록 사용자 정보를 반환한다.
-		if(CommonFunction.isAdmin()) {
+		if (CommonFunction.isAdmin()) {
 			List<T2Users> userList = userService.selectAllUsers();
 			
-			if(userList != null) {
+			if (userList != null) {
 				model.addAttribute("userWithDivisionList", userList);
 			}
 		}
@@ -177,7 +177,7 @@ public class SelfCheckController extends CoTopComponent {
 		try {
 			project = selfCheckService.getProjectDetail(project);
 			
-			if(CoConstDef.FLAG_YES.equals(project.getUseYn())) {
+			if (CoConstDef.FLAG_YES.equals(project.getUseYn())) {
 				model.addAttribute("project", project);
 				model.addAttribute("detail", toJson(project));
 				model.addAttribute("distributionFlag", CommonFunction.propertyFlagCheck("distribution.use.flag", CoConstDef.FLAG_YES));
@@ -186,10 +186,10 @@ public class SelfCheckController extends CoTopComponent {
 				model.addAttribute("partnerFlag", CommonFunction.propertyFlagCheck("menu.partner.use.flag", CoConstDef.FLAG_YES));
 				
 				// Admin인 경우 Creator 를 변경할 수 있도록 사용자 정보를 반환한다.
-				if(CommonFunction.isAdmin()) {
+				if (CommonFunction.isAdmin()) {
 					List<T2Users> userList = userService.selectAllUsers();
 					
-					if(userList != null) {
+					if (userList != null) {
 						model.addAttribute("userWithDivisionList", userList);
 					}
 				}
@@ -220,10 +220,10 @@ public class SelfCheckController extends CoTopComponent {
 		project.setSortField(sidx);
 		project.setSortOrder(sord);
 		
-		if("search".equals(req.getParameter("act"))){
+		if ("search".equals(req.getParameter("act"))){
 			// 검색 조건 저장
 			putSessionObject(SESSION_KEY_SEARCH, project);
-		}else if(getSessionObject(SESSION_KEY_SEARCH) != null){
+		}else if (getSessionObject(SESSION_KEY_SEARCH) != null){
 			project = (Project) getSessionObject(SESSION_KEY_SEARCH);
 		}
 
@@ -291,7 +291,7 @@ public class SelfCheckController extends CoTopComponent {
 						.identificationSortByValidInfo(mainDataList, null, null, null, true, true));
 			}
 			
-			if(!vr.isDiff()){
+			if (!vr.isDiff()){
 				Map<String, String> diffMap = vr.getDiffMessageMap();
 				map.put("diffData", diffMap);
 			}
@@ -304,7 +304,7 @@ public class SelfCheckController extends CoTopComponent {
 	public String ossDetailView(HttpServletRequest req, HttpServletResponse res, @ModelAttribute Project bean, Model model){
 		Project project = selfCheckService.getProjectDetail(bean);
 		
-		if(project != null) {
+		if (project != null) {
 			model.addAttribute("project", project);
 		} else {
 			model.addAttribute("project", new Project());
@@ -319,15 +319,15 @@ public class SelfCheckController extends CoTopComponent {
 		
 		List<LicenseMaster> resultList = new ArrayList<LicenseMaster>();
 		
-		if(!isEmpty(bean.getLicenseName())) {
-			for(String s : bean.getLicenseName().split(",")) {
-				if(isEmpty(s)) {
+		if (!isEmpty(bean.getLicenseName())) {
+			for (String s : bean.getLicenseName().split(",")) {
+				if (isEmpty(s)) {
 					continue;
 				}
 				
 				s = s.toUpperCase().trim();
 				
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(s)) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(s)) {
 					resultList.add(CoCodeManager.LICENSE_INFO_UPPER.get(s));
 				}
 			}
@@ -398,7 +398,7 @@ public class SelfCheckController extends CoTopComponent {
 			 * // basic validator는 무시, validate를 호출하여 custom validator를 수행한다.
 			 * T2CoValidationResult vr = pv.validate(new HashMap<>());
 			 * 
-			 * // return validator result if(!vr.isValid()) { return
+			 * // return validator result if (!vr.isValid()) { return
 			 * makeJsonResponseHeader(vr.getValidMessageMap()); }
 			 */
 			
@@ -411,7 +411,7 @@ public class SelfCheckController extends CoTopComponent {
 			
 			T2CoValidationResult vr = pv.validate(new HashMap<>());
 			
-			if(!vr.isValid()) {
+			if (!vr.isValid()) {
 				return makeJsonResponseHeader(vr.getValidMessageMap());
 			}
 
@@ -454,16 +454,16 @@ public class SelfCheckController extends CoTopComponent {
 		String copy = req.getParameter("copy");
 		String creatorIdByName = null;
 		
-		if(CommonFunction.isAdmin() && !isNew && !"true".equals(copy)) {
-			if(!isEmpty(project.getCreatorNm())) {
+		if (CommonFunction.isAdmin() && !isNew && !"true".equals(copy)) {
+			if (!isEmpty(project.getCreatorNm())) {
 				List<T2Users> userList = userService.getUserListByName(project.getCreatorNm());
 				
-				if(userList != null) {
-					for(T2Users _bean : userList) {
-						if(_bean.getUserId().equals(project.getCreator())) {
+				if (userList != null) {
+					for (T2Users _bean : userList) {
+						if (_bean.getUserId().equals(project.getCreator())) {
 							creatorIdByName = _bean.getUserId();
 							
-							if(!creatorIdByName.equals(project.getCreator())) {
+							if (!creatorIdByName.equals(project.getCreator())) {
 								project.setCreator(_bean.getUserId());
 							}
 							
@@ -515,7 +515,7 @@ public class SelfCheckController extends CoTopComponent {
 	public @ResponseBody String getLicenseUserGuideHtml(@PathVariable String licenseName, HttpServletRequest req, HttpServletResponse res, Model model){
 		LicenseMaster license = CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(licenseName).toUpperCase());
 		
-		if(license != null) {
+		if (license != null) {
 			return CommonFunction.makeHtmlLinkTagWithText(license.getDescription());
 		}
 		
@@ -527,7 +527,7 @@ public class SelfCheckController extends CoTopComponent {
 	public @ResponseBody ResponseEntity<Object> addWatcher(@RequestBody Project project,
 			HttpServletRequest req, HttpServletResponse res, Model model) {
 		try {
-			if(!isEmpty(project.getPrjUserId()) || !isEmpty(project.getPrjEmail())) {
+			if (!isEmpty(project.getPrjUserId()) || !isEmpty(project.getPrjEmail())) {
 				selfCheckService.addWatcher(project);
 			} else {
 				return makeJsonResponseHeader(false, null);
@@ -543,7 +543,7 @@ public class SelfCheckController extends CoTopComponent {
 	public @ResponseBody ResponseEntity<Object> removeWatcher(@RequestBody Project project,
 			HttpServletRequest req, HttpServletResponse res, Model model) {
 		try {
-			if(!isEmpty(project.getPrjUserId()) || !isEmpty(project.getPrjEmail())) {
+			if (!isEmpty(project.getPrjUserId()) || !isEmpty(project.getPrjEmail())) {
 				selfCheckService.removeWatcher(project);
 			} else {
 				return makeJsonResponseHeader(false, null);
@@ -569,24 +569,24 @@ public class SelfCheckController extends CoTopComponent {
 			HttpServletRequest req, HttpServletResponse res, Model model) {
 			HashMap<String, Object> resMap = new HashMap<>();
 		try {			
-			if(!isEmpty(project.getListKind()) && !isEmpty(project.getListId()) ) {
+			if (!isEmpty(project.getListKind()) && !isEmpty(project.getListId()) ) {
 				
 				List<Project> result = selfCheckService.copyWatcher(project);
 				
-				if(result != null) {
-					for(Project bean : result) {
-						if(!StringUtils.isEmpty(bean.getPrjDivision())) {
+				if (result != null) {
+					for (Project bean : result) {
+						if (!StringUtils.isEmpty(bean.getPrjDivision())) {
 							bean.setPrjDivisionName(CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, bean.getPrjDivision()));
 						}
 					}
 					
-					if(!isEmpty(project.getPrjId())) {
+					if (!isEmpty(project.getPrjId())) {
 						boolean existSelfCheckWatcher = selfCheckService.existsWatcher(project);
 						
-						for(Project pm : result) {
+						for (Project pm : result) {
 							pm.setPrjId(project.getPrjId());
 							
-							if(existSelfCheckWatcher) {
+							if (existSelfCheckWatcher) {
 								selfCheckService.addWatcher(pm);
 							}
 						}					
@@ -611,15 +611,15 @@ public class SelfCheckController extends CoTopComponent {
 		Map<String, List<LicenseMaster>> resultMap = new HashMap<>();
 		List<LicenseMaster> resultList = new ArrayList<LicenseMaster>();
 		
-		if(!isEmpty(bean.getLicenseName())) {
-			for(String s : bean.getLicenseName().split(",")) {
-				if(isEmpty(s)) {
+		if (!isEmpty(bean.getLicenseName())) {
+			for (String s : bean.getLicenseName().split(",")) {
+				if (isEmpty(s)) {
 					continue;
 				}
 				
 				s = s.toUpperCase().trim();
 				
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(s)) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(s)) {
 					resultList.add(CoCodeManager.LICENSE_INFO_UPPER.get(s));
 				}
 			}

--- a/src/main/java/oss/fosslight/controller/SessionController.java
+++ b/src/main/java/oss/fosslight/controller/SessionController.java
@@ -28,7 +28,7 @@ public class SessionController extends CoTopComponent{
 	
 	@GetMapping(value = SESSION.LOGIN, produces = "text/html; charset=utf-8")
 	public String user(HttpServletRequest req, HttpServletResponse res) throws IOException {
-		if(isLogin()) {
+		if (isLogin()) {
 			res.sendRedirect(req.getContextPath() + "/index");
 		}
 		
@@ -44,7 +44,7 @@ public class SessionController extends CoTopComponent{
 				long d2_timestamp = d2.getTime() / 1000;
 				long today_timestamp = System.currentTimeMillis() / 1000;
 	
-				if(d1_timestamp < today_timestamp && d2_timestamp > today_timestamp){
+				if (d1_timestamp < today_timestamp && d2_timestamp > today_timestamp){
 					res.sendRedirect(req.getContextPath() + AppConstBean.ERROR_PAGES_DEFAULT);
 				}
 				

--- a/src/main/java/oss/fosslight/controller/StatisticsController.java
+++ b/src/main/java/oss/fosslight/controller/StatisticsController.java
@@ -69,7 +69,7 @@ public class StatisticsController extends CoTopComponent{
 		Statistics stat = new Statistics();
 		stat.setStartDate(startDate);
 		stat.setEndDate(endDate);
-		if(divisionNo.contains(",")) {
+		if (divisionNo.contains(",")) {
 			String[] divisionNums = divisionNo.split(",");
 			stat.setDivisionNums(divisionNums);
 		}else {
@@ -99,7 +99,7 @@ public class StatisticsController extends CoTopComponent{
 		stat.setChartType(chartType);
 		stat.setIsRawData(isRawData);
 		
-		if("OSS".equals(chartType)) {
+		if ("OSS".equals(chartType)) {
 			return makeJsonResponseHeader(statisticsService.getUpdatedOssChartData(stat));
 		} else { // LICENSE
 			return makeJsonResponseHeader(statisticsService.getUpdatedLicenseChartData(stat));
@@ -115,7 +115,7 @@ public class StatisticsController extends CoTopComponent{
 		String type = req.getParameter("categoryType");
 		String isRawData = req.getParameter("isRawData");
 		
-		if("STT".equals(type)) {
+		if ("STT".equals(type)) {
 			type = "3rd" + type;
 		}
 		
@@ -159,27 +159,27 @@ public class StatisticsController extends CoTopComponent{
 		
 		model.addAttribute("chartName", req.getParameter("chartName"));
 		
-		if(!StringUtil.isEmpty(startDate)) {
+		if (!StringUtil.isEmpty(startDate)) {
 			model.addAttribute("startDate", startDate);
 		}
 		
-		if(!StringUtil.isEmpty(endDate)) {
+		if (!StringUtil.isEmpty(endDate)) {
 			model.addAttribute("endDate", endDate);
 		}
 		
-		if(!StringUtil.isEmpty(categoryType)) {
+		if (!StringUtil.isEmpty(categoryType)) {
 			model.addAttribute("categoryType", categoryType);
 		}
 		
-		if(!StringUtil.isEmpty(divisionNo)) {
+		if (!StringUtil.isEmpty(divisionNo)) {
 			model.addAttribute("divisionNo", divisionNo);
 		}
 		
-		if(!StringUtil.isEmpty(pieSize)) {
+		if (!StringUtil.isEmpty(pieSize)) {
 			model.addAttribute("pieSize", pieSize);
 		}
 		
-		if(!StringUtil.isEmpty(chartType)) {
+		if (!StringUtil.isEmpty(chartType)) {
 			model.addAttribute("chartType", chartType);
 		}
 		

--- a/src/main/java/oss/fosslight/controller/UserController.java
+++ b/src/main/java/oss/fosslight/controller/UserController.java
@@ -80,7 +80,7 @@ public class UserController extends CoTopComponent {
 		// validation check
 		T2CoValidationResult vResult = validate(req);
 		
-		if(!vResult.isValid()) {
+		if (!vResult.isValid()) {
 			return makeJsonResponseHeader(vResult.getValidMessageMap());
 		}
 		
@@ -94,12 +94,12 @@ public class UserController extends CoTopComponent {
 		
 		String ldapFlag = CoCodeManager.getCodeExpString(CoConstDef.CD_SYSTEM_SETTING, CoConstDef.CD_LDAP_USED_FLAG);
 		
-		if(!CoConstDef.FLAG_YES.equals(ldapFlag)) {
+		if (!CoConstDef.FLAG_YES.equals(ldapFlag)) {
 			vo.setPassword(encodePassword((String) validResultMap.get("USER_PW")));
 		}
 		
 		// 선택된 division이 없을경우 N/A로 선택됨.
-		if(isEmpty(vo.getDivision())){
+		if (isEmpty(vo.getDivision())){
 			vo.setDivision(CoConstDef.CD_USER_DIVISION_EMPTY);
 		}
 		
@@ -147,7 +147,7 @@ public class UserController extends CoTopComponent {
 		String email = req.getParameter("email");
 		List<T2Users> list = userService.checkEmail(email);
 		
-		if(list.size() > 0){
+		if (list.size() > 0){
 			resMap.put("isValid", "true");
 			resMap.put("userId", list.get(0).getUserId());
 			resMap.put("division", list.get(0).getDivision());
@@ -205,7 +205,7 @@ public class UserController extends CoTopComponent {
 			
 			int updateCnt = userService.updateUsers(userInfo);
 			
-			if(updateCnt == 1) {
+			if (updateCnt == 1) {
 				resMap.put("resCd", "10");
 			} else {
 				resMap.put("resCd", "20");
@@ -230,12 +230,12 @@ public class UserController extends CoTopComponent {
 		try {
 			params.put("USER_NAME", params.get("userName").trim());
 			params.put("DIVISION", params.get("division").trim());
-			if(params.get("password") != null) {
+			if (params.get("password") != null) {
 				params.put("PASSWORD", params.get("password").trim());
 			}
 			T2CoAdminValidator validator = new T2CoAdminValidator();
 			T2CoValidationResult vr = validator.validate(params);
-			if(!vr.isValid()) {
+			if (!vr.isValid()) {
 				return makeJsonResponseHeader(false,  CommonFunction.makeValidMsgTohtml(vr.getValidMessageMap()), vr.getValidMessageMap());
 			}
 			userInfo.setUserId(loginUserName());
@@ -244,7 +244,7 @@ public class UserController extends CoTopComponent {
 			userInfo.setDivision(params.get("DIVISION"));
 			
 			String passwd = params.get("PASSWORD");
-			if(!StringUtil.isEmpty(passwd)) {
+			if (!StringUtil.isEmpty(passwd)) {
 				userInfo.setPassword(encodePassword(passwd)); // password encoding	
 			}
 			
@@ -275,7 +275,7 @@ public class UserController extends CoTopComponent {
 		
 		isSuccess = userService.procToken(userData);
 		
-		if(isSuccess) {
+		if (isSuccess) {
 			// email 발송
 			try {
 				String emailType = null;
@@ -292,7 +292,7 @@ public class UserController extends CoTopComponent {
 						break;
 				}
 				
-				if(!isEmpty(emailType)) {
+				if (!isEmpty(emailType)) {
 					CoMail mailBean = new CoMail(emailType);
 					mailBean.setParamUserId(userData.getUserId());
 					mailBean.setToIds(new String[] { userData.getUserId() });

--- a/src/main/java/oss/fosslight/controller/VerificationController.java
+++ b/src/main/java/oss/fosslight/controller/VerificationController.java
@@ -80,7 +80,7 @@ public class VerificationController extends CoTopComponent {
 		
 		Project projectMaster = projectService.getProjectDetail(project);
 		
-		if(!StringUtil.isEmpty(projectMaster.getCreator())){
+		if (!StringUtil.isEmpty(projectMaster.getCreator())){
 			projectMaster.setPrjDivision(projectService.getDivision(projectMaster));	
 		}
 		
@@ -94,7 +94,7 @@ public class VerificationController extends CoTopComponent {
 		
 		OssNotice _noticeInfo = projectService.setCheckNotice(projectMaster);
 		
-		if(_noticeInfo != null) {
+		if (_noticeInfo != null) {
 			// Notice Type: Accompanied with source code인 경우 Default Company Name, Email 세팅
 			model.addAttribute("ossNotice", _noticeInfo);
 		}
@@ -106,14 +106,14 @@ public class VerificationController extends CoTopComponent {
 		List<String> duplLicenseCheckList = new ArrayList<>(); // 중목제거용
 		
 		// 사용중인 라이선스에 user guide가 설정되어 있는 경우 체크
-		if(list != null && !list.isEmpty()) {
-			for(OssComponents bean : list) {
+		if (list != null && !list.isEmpty()) {
+			for (OssComponents bean : list) {
 				// multi license의 경우 콤마 구분으로 반환됨
-				if(!isEmpty(bean.getLicenseName())) {
+				if (!isEmpty(bean.getLicenseName())) {
 					LicenseMaster licenseBean;
-					for(String license : bean.getLicenseName().split(",", -1)) {
+					for (String license : bean.getLicenseName().split(",", -1)) {
 						licenseBean = CoCodeManager.LICENSE_INFO_UPPER.get(license.toUpperCase());
-						if(licenseBean != null && !isEmptyWithLineSeparator(licenseBean.getDescription()) 
+						if (licenseBean != null && !isEmptyWithLineSeparator(licenseBean.getDescription()) 
 								&& !duplLicenseCheckList.contains(licenseBean.getLicenseId())
 								&& CoConstDef.FLAG_YES.equals(avoidNull(licenseBean.getObligationDisclosingSrcYn()))) {
 							userGuideLicenseList.add(licenseBean);
@@ -148,7 +148,7 @@ public class VerificationController extends CoTopComponent {
 		
 		Project projectMaster = projectService.getProjectDetail(project);
 		
-		if(!StringUtil.isEmpty(projectMaster.getCreator())){
+		if (!StringUtil.isEmpty(projectMaster.getCreator())){
 			projectMaster.setPrjDivision(projectService.getDivision(projectMaster));	
 		}
 		
@@ -162,7 +162,7 @@ public class VerificationController extends CoTopComponent {
 		
 		OssNotice _noticeInfo = projectService.setCheckNotice(projectMaster);
 		
-		if(_noticeInfo != null && CoConstDef.FLAG_NO.equals(projectMaster.getUseCustomNoticeYn())) {
+		if (_noticeInfo != null && CoConstDef.FLAG_NO.equals(projectMaster.getUseCustomNoticeYn())) {
 			// Notice Type: Accompanied with source code인 경우 Default Company Name, Email 세팅
 			model.addAttribute("ossNotice", _noticeInfo);
 		}
@@ -174,14 +174,14 @@ public class VerificationController extends CoTopComponent {
 		List<String> duplLicenseCheckList = new ArrayList<>();
 		
 		// 사용중인 라이선스에 user guide가 설정되어 있는 경우 체크
-		if(list != null && !list.isEmpty()) {
-			for(OssComponents bean : list) {
+		if (list != null && !list.isEmpty()) {
+			for (OssComponents bean : list) {
 				// multi license의 경우 콤마 구분으로 반환됨
-				if(!isEmpty(bean.getLicenseName())) {
+				if (!isEmpty(bean.getLicenseName())) {
 					LicenseMaster licenseBean;
-					for(String license : bean.getLicenseName().split(",", -1)) {
+					for (String license : bean.getLicenseName().split(",", -1)) {
 						licenseBean = CoCodeManager.LICENSE_INFO_UPPER.get(license.toUpperCase());
-						if(licenseBean != null && !isEmptyWithLineSeparator(licenseBean.getDescription()) 
+						if (licenseBean != null && !isEmptyWithLineSeparator(licenseBean.getDescription()) 
 								&& !duplLicenseCheckList.contains(licenseBean.getLicenseId())) {
 							userGuideLicenseList.add(licenseBean);
 							duplLicenseCheckList.add(licenseBean.getLicenseId());
@@ -250,7 +250,7 @@ public class VerificationController extends CoTopComponent {
 		//엑셀 분석
 		List<ProjectIdentification> verificationList = ExcelUtil.getVerificationList(req, CommonFunction.emptyCheckProperty("upload.path", "/upload"));
 		
-		if(verificationList == null) {
+		if (verificationList == null) {
 			return makeJsonResponseHeader(false, "");
 		}
 		
@@ -280,7 +280,7 @@ public class VerificationController extends CoTopComponent {
 			boolean isChangedPackageFile = verificationService.getChangedPackageFile(prjId, fileSeqs);
 			int seq = 1;
 			
-			for(String fileSeq : fileSeqs){
+			for (String fileSeq : fileSeqs){
 				map.put("fileSeq", fileSeq);
 				map.put("packagingFileIdx", seq++);
 				map.put("isChangedPackageFile", isChangedPackageFile);
@@ -289,7 +289,7 @@ public class VerificationController extends CoTopComponent {
 			
 			resMap = result.get(0);
 			
-			if(fileSeqs.size() > 1){
+			if (fileSeqs.size() > 1){
 				resMap.put("verifyValid", result.get(result.size()-1).get("verifyValid"));
 				resMap.put("fileCounts", result.get(result.size()-1).get("fileCounts"));
 			}
@@ -352,14 +352,14 @@ public class VerificationController extends CoTopComponent {
 			String noticeFileId = prjMasterInfo.getNoticeFileId();
 			log.debug("PARAM: "+ "noticeFileId="+noticeFileId);
 			
-			if("conf".equals(confirm)){
+			if ("conf".equals(confirm)){
 				boolean ignoreMailSend = false;
 				
 				String userComment = ossNotice.getUserComment();
 
 				//파일 만들기
-				if(isEmpty(noticeFileId) || !CoConstDef.FLAG_YES.equals(useCustomNoticeYn)) {
-					if(!verificationService.getNoticeHtmlFile(ossNotice)) {
+				if (isEmpty(noticeFileId) || !CoConstDef.FLAG_YES.equals(useCustomNoticeYn)) {
+					if (!verificationService.getNoticeHtmlFile(ossNotice)) {
 						return makeJsonResponseHeader(false, getMessage("msg.common.valid2"));
 					}
 				}
@@ -370,7 +370,7 @@ public class VerificationController extends CoTopComponent {
 				
 				{
 					Project projectMaster = projectService.getProjectBasicInfo(ossNotice.getPrjId());
-					if(!isEmpty(projectMaster.getPackageFileId())) {
+					if (!isEmpty(projectMaster.getPackageFileId())) {
 						List<OssComponents> list = verificationService.getVerifyOssList(projectMaster);
 						needResetPackageFile = list.isEmpty();
 					}
@@ -397,7 +397,7 @@ public class VerificationController extends CoTopComponent {
 				{
 					prjInfo = projectService.getProjectBasicInfo(ossNotice.getPrjId());
 					
-					if("T".equals(avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE, prjInfo.getDistributionType())).trim().toUpperCase())
+					if ("T".equals(avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE, prjInfo.getDistributionType())).trim().toUpperCase())
 							|| (CoConstDef.FLAG_NO.equals(avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE, prjInfo.getDistributionType())).trim().toUpperCase()) 
 									&& verificationService.checkNetworkServer(ossNotice.getPrjId())
 							)
@@ -405,12 +405,12 @@ public class VerificationController extends CoTopComponent {
 							) {
 						project.setDestributionStatus(CoConstDef.CD_DTL_DISTRIBUTE_STATUS_NA);
 						ignoreMailSend = true;
-					} else if(!CoConstDef.CD_DTL_DISTRIBUTE_NA.equals(prjInfo.getDistributeTarget())
+					} else if (!CoConstDef.CD_DTL_DISTRIBUTE_NA.equals(prjInfo.getDistributeTarget())
 							&& CoConstDef.CD_DTL_DISTRIBUTE_STATUS_NA.equals(prjInfo.getDestributionStatus())) {
 						project.setResetDistributionStatus(CoConstDef.FLAG_YES);
 					}
 					
-					if(!isEmpty(prjInfo.getDestributionStatus()) 
+					if (!isEmpty(prjInfo.getDestributionStatus()) 
 							&& CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(confirm.toUpperCase())) {
 						project.setChangedNoticeYn(CoConstDef.FLAG_YES);
 					}
@@ -418,7 +418,7 @@ public class VerificationController extends CoTopComponent {
 				project.setModifier(project.getLoginUserName());
 				
 				// 기존에 등록한 package file의 삭제
-				if(needResetPackageFile) {
+				if (needResetPackageFile) {
 					project.setNeedPackageFileReset(CoConstDef.FLAG_YES);
 				}
 				
@@ -477,13 +477,13 @@ public class VerificationController extends CoTopComponent {
 				verificationService.changePackageFileNameDistributeFormat(ossNotice.getPrjId());
 			} else { // preview 인 경우
 				// 저장된 고지문구가 없을 경우
-				if(isEmpty(noticeFileId) || !CoConstDef.FLAG_YES.equals(useCustomNoticeYn)) {
+				if (isEmpty(noticeFileId) || !CoConstDef.FLAG_YES.equals(useCustomNoticeYn)) {
 					resultHtml = verificationService.getNoticeHtml(ossNotice);
 				} else { // 저장된 고지문구가 있을 경우
 					T2File fileInfo = fileService.selectFileInfo(noticeFileId);
 					resultHtml = CommonFunction.getStringFromFile(fileInfo.getLogiPath() + "/" + fileInfo.getLogiNm());
 					// 파일을 못찾을 경우 예외처리
-					if(isEmpty(resultHtml)) {
+					if (isEmpty(resultHtml)) {
 						resultHtml = verificationService.getNoticeHtml(ossNotice);
 					}
 				}
@@ -560,7 +560,7 @@ public class VerificationController extends CoTopComponent {
 		file.setCreator(loginUserName());
 		map.put("filePath", "");
 		
-		if(StringUtil.isEmpty(fileId)){
+		if (StringUtil.isEmpty(fileId)){
 			list = fileService.uploadWgetFile(request, file, map, false);
 		}
 		
@@ -613,7 +613,7 @@ public class VerificationController extends CoTopComponent {
 		vResult = pv.validateRequest(reqMap, req, keyPreMap);
 		
 		
-		if(!vResult.isValid()){
+		if (!vResult.isValid()){
 			return makeJsonResponseHeader(vResult.getValidMessageMap());
 		}
 		
@@ -649,7 +649,7 @@ public class VerificationController extends CoTopComponent {
 		log.debug("PARAM: "+ "prjId="+ossNotice.getPrjId());
 		log.debug("PARAM: "+ "useCustomNoticeYn="+useCustomNoticeYn);
 		
-		if(!verificationService.getNoticeHtmlFile(ossNotice, noticeHtml) || !CoConstDef.FLAG_YES.equals(useCustomNoticeYn)) {
+		if (!verificationService.getNoticeHtmlFile(ossNotice, noticeHtml) || !CoConstDef.FLAG_YES.equals(useCustomNoticeYn)) {
 			return makeJsonResponseHeader(false, "Notice Registration Failed");
 		}
 		
@@ -671,7 +671,7 @@ public class VerificationController extends CoTopComponent {
 			log.debug("PARAM: "+ "noticeFileId="+noticeFileId);
 			log.debug("PARAM: "+ "useCustomNoticeYn="+useCustomNoticeYn);
 			
-			if(isEmpty(noticeFileId)) {
+			if (isEmpty(noticeFileId)) {
 				downloadId = verificationService.getNoticeHtmlFileForPreview(ossNotice);
 			} else {
 				downloadId = noticeFileId;
@@ -712,7 +712,7 @@ public class VerificationController extends CoTopComponent {
 			log.debug("PARAM: "+ "noticeFileId="+noticeFileId);
 			log.debug("PARAM: "+ "useCustomNoticeYn="+useCustomNoticeYn);
 			
-			if(!isEmpty(prjMasterInfo.getNoticeTextFileId())) {
+			if (!isEmpty(prjMasterInfo.getNoticeTextFileId())) {
 				downloadId = prjMasterInfo.getNoticeTextFileId();
 			} else {
 				downloadId = verificationService.getNoticeTextFileForPreview(ossNotice);
@@ -741,7 +741,7 @@ public class VerificationController extends CoTopComponent {
 			log.debug("PARAM: "+ "noticeFileId="+noticeFileId);
 			log.debug("PARAM: "+ "useCustomNoticeYn="+useCustomNoticeYn);
 			
-			if(!isEmpty(prjMasterInfo.getSimpleHtmlFileId())) {
+			if (!isEmpty(prjMasterInfo.getSimpleHtmlFileId())) {
 				downloadId = prjMasterInfo.getSimpleHtmlFileId();
 			} else {
 				downloadId = verificationService.getNoticeTextFileForPreview(ossNotice);
@@ -769,7 +769,7 @@ public class VerificationController extends CoTopComponent {
 			log.debug("PARAM: "+ "noticeFileId="+noticeFileId);
 			log.debug("PARAM: "+ "useCustomNoticeYn="+useCustomNoticeYn);
 			
-			if(!isEmpty(prjMasterInfo.getSimpleTextFileId())) {
+			if (!isEmpty(prjMasterInfo.getSimpleTextFileId())) {
 				downloadId = prjMasterInfo.getSimpleTextFileId();
 			} else {
 				downloadId = verificationService.getNoticeTextFileForPreview(ossNotice);
@@ -820,7 +820,7 @@ public class VerificationController extends CoTopComponent {
 		
 		boolean result = verificationService.setReusePackagingFile(map);
 		
-		if(result) {
+		if (result) {
 			resultMap.put("file", file);
 			
 			return makeJsonResponseHeader(resultMap);
@@ -919,7 +919,7 @@ public class VerificationController extends CoTopComponent {
 			log.error(e.getMessage());
 		}
 		
-		if(!vResult.isValid()){
+		if (!vResult.isValid()){
 			return makeJsonResponseHeader(vResult.getValidMessageMap());
 		}
 		

--- a/src/main/java/oss/fosslight/controller/VulnerabilityController.java
+++ b/src/main/java/oss/fosslight/controller/VulnerabilityController.java
@@ -39,11 +39,11 @@ public class VulnerabilityController extends CoTopComponent {
 	public String list(HttpServletRequest req, HttpServletResponse res, Model model){
 		Object _param =  getSessionObject(CoConstDef.SESSION_KEY_PREFIX_DEFAULT_SEARCHVALUE + "VULNOSSNAME", true);
 		
-		if(_param != null) {
+		if (_param != null) {
 			String defaultSearchOssName = (String) _param;
 			
-			if(!isEmpty(defaultSearchOssName)) {
-				if(defaultSearchOssName.indexOf("|") > -1) {
+			if (!isEmpty(defaultSearchOssName)) {
+				if (defaultSearchOssName.indexOf("|") > -1) {
 					String[] params = defaultSearchOssName.split("\\|");
 					
 					model.addAttribute("defaultOssName", params[0]);
@@ -98,7 +98,7 @@ public class VulnerabilityController extends CoTopComponent {
 	
 	@GetMapping(value=VULNERABILITY.VULN_POPUP, produces = "text/html; charset=utf-8")
 	public String vulnpopup(HttpServletRequest req, HttpServletResponse res, @ModelAttribute OssMaster bean, Model model) throws IOException{
-		if(!isLogin()) {
+		if (!isLogin()) {
 			return SESSION.LOGIN_JSP;
 		}
 		
@@ -115,7 +115,7 @@ public class VulnerabilityController extends CoTopComponent {
 			Model model){
 		Map<String, Object> resultMap = new HashMap<>();
 		
-		if(!isEmpty(bean.getOssName())) {
+		if (!isEmpty(bean.getOssName())) {
 			int page = Integer.parseInt(req.getParameter("page"));
 			int rows = Integer.parseInt(req.getParameter("rows"));
 			String sidx = req.getParameter("sidx");
@@ -130,13 +130,13 @@ public class VulnerabilityController extends CoTopComponent {
 			
 			String filters = "";
 			
-			if(!isEmpty(bean.getFilters())) {
+			if (!isEmpty(bean.getFilters())) {
 				filters = bean.getFilters().replaceAll("\"op\":\"cn\"", "\"op\":\"eq\"");	// popup에서는 equals만 지원함.
 			}
 			
 			String filterCondition = CommonFunction.getFilterToString(filters, null, exceptionMap);
 			
-			if(!isEmpty(filterCondition)) {
+			if (!isEmpty(filterCondition)) {
 				bean.setFilterCondition(filterCondition);
 			}
 			

--- a/src/main/java/oss/fosslight/domain/BinaryAnalysisResult.java
+++ b/src/main/java/oss/fosslight/domain/BinaryAnalysisResult.java
@@ -416,7 +416,7 @@ public class BinaryAnalysisResult extends ComBean implements Serializable {
 	 * @param batKey the bat key
 	 */
 	public void addBatKey(String batKey) {
-		if(this.batKeyList == null) {
+		if (this.batKeyList == null) {
 			this.batKeyList = new ArrayList<>();
 		}
 		this.batKeyList.add(batKey);

--- a/src/main/java/oss/fosslight/domain/BinaryMaster.java
+++ b/src/main/java/oss/fosslight/domain/BinaryMaster.java
@@ -180,12 +180,12 @@ public class BinaryMaster extends ComBean implements Serializable{
 	}
 	
 	public void addBatWatcher(String division, String userId) {
-		if(!isEmpty(division)) {
+		if (!isEmpty(division)) {
 			BatWatcher bean = new BatWatcher();
 			bean.setDivision(division);
 			bean.setUserId(userId);
 			bean.setBatId(this.batId);
-			if(this.batWatcher == null) {
+			if (this.batWatcher == null) {
 				this.batWatcher = new ArrayList<BatWatcher>();
 			}
 			this.batWatcher.add(bean);

--- a/src/main/java/oss/fosslight/domain/CoCode.java
+++ b/src/main/java/oss/fosslight/domain/CoCode.java
@@ -157,7 +157,7 @@ public class CoCode {
     {
         Vector<String[]> vector = new Vector<String[]>();
         int i = 0;
-        for(int j = codeDtls.size(); i < j; i++)
+        for (int j = codeDtls.size(); i < j; i++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
             if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
@@ -175,10 +175,10 @@ public class CoCode {
     {
         Vector<CoCodeDtl> vector = new Vector<CoCodeDtl>();
         int i = 0;
-        for(int j = codeDtls.size(); i < j; i++)
+        for (int j = codeDtls.size(); i < j; i++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
-            if(!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
+            if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
               continue;
             }
             vector.add(codedtl);
@@ -197,7 +197,7 @@ public class CoCode {
     {
         Vector<String[]> vector = new Vector<String[]>();
         int i = 0;
-        for(int j = codeDtls.size(); i < j; i++)
+        for (int j = codeDtls.size(); i < j; i++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
             if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
@@ -214,7 +214,7 @@ public class CoCode {
     {
         Vector<CoCodeDtl> vector = new Vector<CoCodeDtl>();
         int i = 0;
-        for(int j = codeDtls.size(); i < j; i++)
+        for (int j = codeDtls.size(); i < j; i++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
             if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
@@ -236,7 +236,7 @@ public class CoCode {
     {
         Vector<String> vector = new Vector<String>();
         int i = 0;
-        for(int j = codeDtls.size(); i < j; i++)
+        for (int j = codeDtls.size(); i < j; i++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(i);
             if (!ignoreDel && CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
@@ -280,7 +280,7 @@ public class CoCode {
     {
         StringBuffer stringbuffer = (new StringBuffer("<select name='")).append(s).append("'>\n");
         int j = 0;
-        for(int k = codeDtls.size(); j < k; j++)
+        for (int k = codeDtls.size(); j < k; j++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
             stringbuffer.append("    <option value='").append(codedtl.cdDtlNo).append('\'');
@@ -304,7 +304,7 @@ public class CoCode {
     {
         StringBuffer stringbuffer = new StringBuffer();
         int j = 0;
-        for(int k = codeDtls.size(); j < k; j++)
+        for (int k = codeDtls.size(); j < k; j++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
             
@@ -314,7 +314,7 @@ public class CoCode {
             
             stringbuffer.append("    <option VALUE='").append(codedtl.cdDtlNo).append('\'');
             
-            if((i == 0 && codedtl.cdDtlNo.equals(s)) || (i == 1 && codedtl.cdDtlNm.equals(s))) {
+            if ((i == 0 && codedtl.cdDtlNo.equals(s)) || (i == 1 && codedtl.cdDtlNm.equals(s))) {
                 stringbuffer.append(" selected");
             }
             stringbuffer.append(">").append(codedtl.cdDtlNm).append("</option>\n");
@@ -334,8 +334,8 @@ public class CoCode {
         StringBuffer stringbuffer = new StringBuffer();
         
         int j = 0;
-        if(CoConstDef.CD_PROJECT_STATUS.equals(cd)) {
-	        for(int k = codeDtls.size(); j < k; j++)
+        if (CoConstDef.CD_PROJECT_STATUS.equals(cd)) {
+	        for (int k = codeDtls.size(); j < k; j++)
 	        {
 	            CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
 
@@ -346,17 +346,17 @@ public class CoCode {
 	            stringbuffer.append("    <input name='statuses' type='checkbox' value='").append(codedtl.cdDtlNo).append("' ").append((status.indexOf(codedtl.cdDtlNo)>-1)?"checked='checked'":""); 
 	            stringbuffer.append(" style='margin:2px 5px 0px 0px;' />&nbsp;").append(codedtl.cdDtlNm).append("&nbsp;&nbsp;&nbsp;&nbsp;");
 	        }
-        } else if(CoConstDef.CD_LICENSE_RESTRICTION.equals(cd)) {
+        } else if (CoConstDef.CD_LICENSE_RESTRICTION.equals(cd)) {
         	int newLineIdx = 0; 
-        	if("list".equals(callType)){
+        	if ("list".equals(callType)){
         		newLineIdx = 3;
-        	}else if("edit".equals(callType)){
+        	}else if ("edit".equals(callType)){
         		newLineIdx = 4;
         	}
         	
         	List<String> restrictionList = Arrays.asList(status.split(","));
         	
-        	for(int k = codeDtls.size(); j < k; j++)
+        	for (int k = codeDtls.size(); j < k; j++)
 	        {
 	            CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
 
@@ -367,8 +367,8 @@ public class CoCode {
 	            stringbuffer.append("    <input name='restrictions' type='checkbox' value='").append(codedtl.cdDtlNo).append("' ").append((restrictionList.contains(codedtl.cdDtlNo))?"checked='checked'":""); 
 	            stringbuffer.append(" style='margin:2px 5px 0px 0px;' />&nbsp;").append(codedtl.cdDtlNm).append("&nbsp;&nbsp;&nbsp;&nbsp;"+(j==newLineIdx?"<br>"+("list".equals(callType)?"<label></label>":""):""));
 	        }
-        } else if(CoConstDef.CD_NOTICE_INFO.equals(cd)) {
-        	for(int k = codeDtls.size(); j < k; j++)
+        } else if (CoConstDef.CD_NOTICE_INFO.equals(cd)) {
+        	for (int k = codeDtls.size(); j < k; j++)
 	        {
 	            CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
 
@@ -399,9 +399,9 @@ public class CoCode {
         int j = 0;
         NAExceptionFlag = StringUtils.isEmpty(NAExceptionFlag) ? true : NAExceptionFlag; // default 시 true로 setting
         
-        if(!StringUtils.isEmpty(name)) {
+        if (!StringUtils.isEmpty(name)) {
         	List<String> values = Arrays.asList(val.split(","));
-	        for(int k = codeDtls.size(); j < k; j++){
+	        for (int k = codeDtls.size(); j < k; j++){
 	            CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
 	           
 	            if (CoConstDef.FLAG_NO.equals(codedtl.useYn)) {
@@ -431,7 +431,7 @@ public class CoCode {
         StringBuffer stringbuffer = new StringBuffer();
         int j = 0;
         
-        if(StringUtils.isEmpty(distributionType)) {
+        if (StringUtils.isEmpty(distributionType)) {
         	distributionType = CoConstDef.CD_GENERAL_MODEL;
         }
         
@@ -439,7 +439,7 @@ public class CoCode {
           networkServerType = CoConstDef.FLAG_NO;
         }
         
-        for(int k = codeDtls.size(); j < k; j++) {
+        for (int k = codeDtls.size(); j < k; j++) {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
             
             if (CoConstDef.FLAG_NO.equals(codedtl.useYn)
@@ -474,7 +474,7 @@ public class CoCode {
 	public String createOptionCheckboxString(String s, String s1, int i) {
 		StringBuffer stringbuffer = new StringBuffer();
         int j = 0;
-        for(int k = codeDtls.size(); j < k; j++)
+        for (int k = codeDtls.size(); j < k; j++)
         {
             CoCodeDtl codedtl = (CoCodeDtl)codeDtls.get(j);
             

--- a/src/main/java/oss/fosslight/domain/CoMail.java
+++ b/src/main/java/oss/fosslight/domain/CoMail.java
@@ -438,9 +438,9 @@ public class CoMail extends ComBean {
 	 */
 	public void setToIds(String[] toIds) {
 		List<String> temp = new ArrayList<>();
-		if(toIds != null) {
-			for(String s : toIds) {
-				if(!isEmpty(s)) {
+		if (toIds != null) {
+			for (String s : toIds) {
+				if (!isEmpty(s)) {
 					temp.add(s.trim());
 				}
 			}
@@ -465,9 +465,9 @@ public class CoMail extends ComBean {
 	 */
 	public void setCcIds(String[] ccIds) {
 		List<String> temp = new ArrayList<>();
-		if(ccIds != null) {
-			for(String s : ccIds) {
-				if(!isEmpty(s)) {
+		if (ccIds != null) {
+			for (String s : ccIds) {
+				if (!isEmpty(s)) {
 					temp.add(s.trim());
 				}
 			}
@@ -491,9 +491,9 @@ public class CoMail extends ComBean {
 	 */
 	public void setBccIds(String[] bccIds) {
 		List<String> temp = new ArrayList<>();
-		if(bccIds != null) {
-			for(String s : bccIds) {
-				if(!isEmpty(s)) {
+		if (bccIds != null) {
+			for (String s : bccIds) {
+				if (!isEmpty(s)) {
 					temp.add(s.trim());
 				}
 			}

--- a/src/main/java/oss/fosslight/domain/CoMailManager.java
+++ b/src/main/java/oss/fosslight/domain/CoMailManager.java
@@ -84,7 +84,7 @@ public class CoMailManager extends CoTopComponent {
      * @return single instance of CoMailManager
      */
     public static CoMailManager getInstance() {
-    	if(instance == null) {
+    	if (instance == null) {
     		instance = new CoMailManager();
         	mailSender = (JavaMailSender) getWebappContext().getBean(JavaMailSender.class);
         	mailManagerMapper = (MailManagerMapper) getWebappContext().getBean(MailManagerMapper.class);
@@ -114,13 +114,13 @@ public class CoMailManager extends CoTopComponent {
     	
     	boolean EMAIL_USE_FLAG = CoConstDef.FLAG_YES.equals(CommonFunction.getProperty("mail.smtp.useflag"));
     	
-    	if(!EMAIL_USE_FLAG) {
+    	if (!EMAIL_USE_FLAG) {
     		return procResult;
     	}
     	
     	try {
     		// Check the required things
-    		if(bean == null || isEmpty(bean.getMsgType())) {
+    		if (bean == null || isEmpty(bean.getMsgType())) {
     			log.error("Mail Bean or Type is Empty");
     			return false;
     		}
@@ -133,7 +133,7 @@ public class CoMailManager extends CoTopComponent {
     		String msgType = bean.getMsgType();
     		
     		// To use the same title in case of recalculated
-    		if(CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_REMOVE_RECALCULATED.equals(msgType)) {
+    		if (CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_REMOVE_RECALCULATED.equals(msgType)) {
     			msgType = CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_RECALCULATED;
     		}
     		
@@ -141,7 +141,7 @@ public class CoMailManager extends CoTopComponent {
 
 			title = makeMailSubject(title, bean);
 			// Add a direct link to OSS information (ADMIN ONLY)
-			if(CoConstDef.CD_MAIL_TYPE_OSS_REGIST.equals(bean.getMsgType())
+			if (CoConstDef.CD_MAIL_TYPE_OSS_REGIST.equals(bean.getMsgType())
 					|| CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION.equals(bean.getMsgType())
 					|| CoConstDef.CD_MAIL_TYPE_OSS_UPDATE.equals(bean.getMsgType())
 					|| CoConstDef.CD_MAIL_TYPE_ADDNICKNAME_UPDATE.equals(bean.getMsgType())
@@ -179,7 +179,7 @@ public class CoMailManager extends CoTopComponent {
 				}
 			}
     		
-    		if(CoConstDef.CD_MAIL_TYPE_OSS_DELETE.equals(bean.getMsgType()) && bean.getParamOssInfo() != null) {
+    		if (CoConstDef.CD_MAIL_TYPE_OSS_DELETE.equals(bean.getMsgType()) && bean.getParamOssInfo() != null) {
     			OssMaster oss_basic_info = bean.getParamOssInfo();
     			String result = appendChangeStyleLinkFormatArray(oss_basic_info.getDownloadLocation());
 				oss_basic_info.setDownloadLocation(result);
@@ -187,7 +187,7 @@ public class CoMailManager extends CoTopComponent {
     			convertDataMap.put(CoCodeManager.getCodeString(CoConstDef.CD_MAIL_COMPONENT_NAME, CoConstDef.CD_MAIL_COMPONENT_OSSBASICINFO), oss_basic_info); // oss_basic_info
     		}
     		
-    		if(CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_REJECT.equals(bean.getMsgType()) && bean.getParamPrjInfo() != null) {
+    		if (CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_REJECT.equals(bean.getMsgType()) && bean.getParamPrjInfo() != null) {
 
 				// In case of distribution reject, distribution info must be received as a separate parameter (already deleted)
     			convertDataMap.put(CoCodeManager.getCodeString(CoConstDef.CD_MAIL_COMPONENT_NAME, CoConstDef.CD_MAIL_COMPONENT_PROJECT_DISTRIBUTIONINFO), bean.getParamPrjInfo()); // oss_basic_info
@@ -195,9 +195,9 @@ public class CoMailManager extends CoTopComponent {
     		
     		// TODO 92번 메일 ( vulnerability recalculated )의 경우 as-is to-be 가 존재하기 때문에 예외처리한다.
     		// 94번 메일 NVD Data > CVSS Score가 9.0이상인 대상중 현재 배치로인해 NVD Data가 삭제된 경우 mail 발송
-    		if(CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_RECALCULATED.equals(bean.getMsgType())
+    		if (CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_RECALCULATED.equals(bean.getMsgType())
     				|| CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_REMOVE_RECALCULATED.equals(bean.getMsgType())) {
-    			if(bean.getParamOssInfoMap() == null || bean.getParamOssInfoMap().isEmpty()) {
+    			if (bean.getParamOssInfoMap() == null || bean.getParamOssInfoMap().isEmpty()) {
     				return false;
     			}
     			
@@ -208,17 +208,17 @@ public class CoMailManager extends CoTopComponent {
     			// 변경된 oss id 과 해당 프로젝트에서 사용중인 oss 목록을 비교하기 위해서 210 번 쿼리를 사용한다.
     			List<OssMaster> _contents = (List<OssMaster>) setContentsInfo(bean, recalculatedMsgType);
     			List<OssMaster> _reMakeContents = new ArrayList<>();
-    			for(OssMaster _bean : _contents) {
+    			for (OssMaster _bean : _contents) {
 					String key = _bean.getOssName().toUpperCase()+"_"+_bean.getOssVersion();
 					
-    				if(bean.getParamOssInfoMap().containsKey(key)) {
+    				if (bean.getParamOssInfoMap().containsKey(key)) {
     					OssMaster reMakeBean = bean.getParamOssInfoMap().get(key);
     					OssMaster diffBean = CoCodeManager.OSS_INFO_UPPER.get(key);
-    					if(diffBean == null) {
+    					if (diffBean == null) {
     						return false;
     					}
     					
-						if("0".equals(reMakeBean.getCvssScoreTo())) { 
+						if ("0".equals(reMakeBean.getCvssScoreTo())) { 
 							reMakeBean.setCveIdTo("NONE");
 						}
 						
@@ -226,7 +226,7 @@ public class CoMailManager extends CoTopComponent {
     				}
     			}
     			
-    			if(_reMakeContents.isEmpty()) {
+    			if (_reMakeContents.isEmpty()) {
     				return false;
     			}
 
@@ -234,12 +234,12 @@ public class CoMailManager extends CoTopComponent {
     			
     		}
     		
-    		if(CoConstDef.CD_MAIL_TYPE_VULNERABILITY_NVDINFO_DIFF.equals(bean.getMsgType())) {
+    		if (CoConstDef.CD_MAIL_TYPE_VULNERABILITY_NVDINFO_DIFF.equals(bean.getMsgType())) {
     			convertDataMap.put("vulnerability_diff_vendor_info", bean.getParamList());
     		}
     		
     		// ldap Search시 사용자 정보가 변경된 경우
-    		if(CoConstDef.CD_MAIL_TYPE_CHANGED_USER_INFO.equals(bean.getMsgType()) && bean.getParamList() != null) {
+    		if (CoConstDef.CD_MAIL_TYPE_CHANGED_USER_INFO.equals(bean.getMsgType()) && bean.getParamList() != null) {
     			List<Map<String, Object>> userList = bean.getParamList();
     			List<T2Users> changedUserList = new ArrayList<>();
     			List<T2Users> retireeUserList = new ArrayList<>();
@@ -247,15 +247,15 @@ public class CoMailManager extends CoTopComponent {
     	        Calendar c1 = Calendar.getInstance();
     	        String strToday = sdf.format(c1.getTime());
     	        
-    			for(Map<String, Object> userInfo : userList) {
+    			for (Map<String, Object> userInfo : userList) {
     				T2Users t2user = new T2Users();
     				t2user.setUserId((String) userInfo.get("userId"));
     				t2user.setModifiedDate(strToday);
     				
     				// 정보 변경 사용자
-    				if(userInfo.containsKey("beforeUserName")) {
+    				if (userInfo.containsKey("beforeUserName")) {
     					String userName  = (String) userInfo.get("beforeUserName");
-    					if(!userInfo.containsKey("newcomer")) {
+    					if (!userInfo.containsKey("newcomer")) {
     						userName += " -> ";
     						userName += (String) userInfo.get("afterUserName");
     					} else {
@@ -280,11 +280,11 @@ public class CoMailManager extends CoTopComponent {
     				
     			}
     			
-    			if(changedUserList.size() > 0) {
+    			if (changedUserList.size() > 0) {
     				convertDataMap.put("changed_user_info", changedUserList);
     			}
     			
-    			if(retireeUserList.size() > 0) {
+    			if (retireeUserList.size() > 0) {
     				convertDataMap.put("retiree_user_info", retireeUserList);
     			}
     			
@@ -292,13 +292,13 @@ public class CoMailManager extends CoTopComponent {
     		
     		// Common
     		{
-        		if(isEmpty(bean.getCreationUserId())) {
+        		if (isEmpty(bean.getCreationUserId())) {
         			bean.setCreationUserId(bean.getLoginUserName());
         		}
         		
-        		if(!isEmpty(bean.getComment())) {
+        		if (!isEmpty(bean.getComment())) {
         			// FIXME
-        			if(CoConstDef.CD_MAIL_TYPE_PROJECT_MODIFIED_COMMENT.equals(bean.getMsgType())
+        			if (CoConstDef.CD_MAIL_TYPE_PROJECT_MODIFIED_COMMENT.equals(bean.getMsgType())
         					||CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_MODIFIED_COMMENT.equals(bean.getMsgType())
         					||CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_MODIFIED_COMMENT.equals(bean.getMsgType())
         					||CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_MODIFIED_COMMENT.equals(bean.getMsgType())
@@ -311,11 +311,11 @@ public class CoMailManager extends CoTopComponent {
         			convertDataMap.put("comment", bean.getComment());
         		}
     			
-    			if(isEmpty(bean.getModifier())) {
+    			if (isEmpty(bean.getModifier())) {
     				bean.setModifier(bean.getLoginUserName());
     			}
     			convertDataMap.put("modifier", bean.getModifier());
-    			if(isEmpty(bean.getModifiedDate())) {
+    			if (isEmpty(bean.getModifiedDate())) {
     				bean.setModifiedDate(DateUtil.getCurrentDateAsString());
     			}
     			convertDataMap.put("modifiedDate", bean.getModifiedDate());
@@ -327,50 +327,50 @@ public class CoMailManager extends CoTopComponent {
     			convertDataMap.put("modifierNm", makeUserNameFormatWithDivision(userInfo));
     			
     			// In case of comparing changes
-    			if(bean.getCompareDataBefore() != null) {
+    			if (bean.getCompareDataBefore() != null) {
     				convertDataMap.put("before", bean.getCompareDataBefore());
     			}
 
-    			if(bean.getCompareDataAfter() != null) {
+    			if (bean.getCompareDataAfter() != null) {
     				convertDataMap.put("after", bean.getCompareDataAfter());
     			}
     			
     			// 프로젝트 기본정보가 변경된 경우, 코드변환하여 다시 맵에 격납한다.
-    			if(CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED.equals(bean.getMsgType())
+    			if (CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED.equals(bean.getMsgType())
     					|| CoConstDef.CD_MAIL_TYPE_PROJECT_COPIED.equals(bean.getMsgType())) {
     				convertDataMap.put("before", convertCodeProjectBaiscInfo( bean.getCompareDataBefore()));
     				convertDataMap.put("after", convertCodeProjectBaiscInfo( bean.getCompareDataAfter()));
     			}
     			
-    			if(CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION.equals(bean.getMsgType())) {
+    			if (CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION.equals(bean.getMsgType())) {
     				convertDataMap.put("paramOssInfo", bean.getParamOssInfo());
     				convertModifiedData(convertDataMap, bean.getMsgType());
 				}
     			
     			// as-is, to-be 비교 메일의 경우, 변경 부분 서식을 위한 처리추가
-    			if(bean.getCompareDataBefore() != null || bean.getCompareDataAfter() != null) {
+    			if (bean.getCompareDataBefore() != null || bean.getCompareDataAfter() != null) {
     				convertModifiedData(convertDataMap, bean.getMsgType());
     			}
     			
     			// 17.08.02 sw-yun 22번 메일은 더이상 사용하지 않고, 21번 메일에 포함
-    			if(CoConstDef.CD_MAIL_TYPE_LICENSE_UPDATE.equals(bean.getMsgType()) || CoConstDef.CD_MAIL_TYPE_LICENSE_RENAME.equals(bean.getMsgType())) {
+    			if (CoConstDef.CD_MAIL_TYPE_LICENSE_UPDATE.equals(bean.getMsgType()) || CoConstDef.CD_MAIL_TYPE_LICENSE_RENAME.equals(bean.getMsgType())) {
     				// license type이 변경된 경우 사용중인 프로젝트 리스트를 표시
-    				if(!isEmpty(bean.getParamLicenseId()) 
+    				if (!isEmpty(bean.getParamLicenseId()) 
     						&&  bean.getCompareDataBefore() != null && bean.getCompareDataAfter() != null 
     						&& !((LicenseMaster) bean.getCompareDataBefore()).getLicenseType().equals(((LicenseMaster) bean.getCompareDataAfter()).getLicenseType())) {
     					
     					// license type이 변경된 oss list
     					
-    					if(bean.getParamOssList() != null) {
+    					if (bean.getParamOssList() != null) {
     						
     						List<Project> prjListFinal = new ArrayList<>();
     						List<String> duplCheckPrjIdList = new ArrayList<>();
-    						for(OssMaster ossInfo : bean.getParamOssList()) {
+    						for (OssMaster ossInfo : bean.getParamOssList()) {
             					List<Project> prjList = ossMapper.getOssChangeForUserList(ossInfo);
             					
-                				if(prjList != null && !prjList.isEmpty()) {
-                    				for(Project prjBean : prjList) {
-                    					if(!duplCheckPrjIdList.contains(prjBean.getPrjId())) {
+                				if (prjList != null && !prjList.isEmpty()) {
+                    				for (Project prjBean : prjList) {
+                    					if (!duplCheckPrjIdList.contains(prjBean.getPrjId())) {
                           					prjBean.setDistributionType(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, prjBean.getDistributionType()));
                         					prjBean.setCreator(makeUserNameFormatWithDivision(prjBean.getCreator()));
                         					prjBean.setCreatedDate(CommonFunction.formatDateSimple(prjBean.getCreatedDate()));
@@ -382,14 +382,14 @@ public class CoMailManager extends CoTopComponent {
                 				}    
     						}
     						
-    						if(!prjListFinal.isEmpty()) {
+    						if (!prjListFinal.isEmpty()) {
     							convertDataMap.put("projectList", prjListFinal);    	
     						}
 						
     						// 메일 형식으로 코드 변환
-    						for(OssMaster ossInfo : bean.getParamOssList()) {
+    						for (OssMaster ossInfo : bean.getParamOssList()) {
     							
-    							if(!isEmpty(ossInfo.getOssVersion())) {
+    							if (!isEmpty(ossInfo.getOssVersion())) {
     								ossInfo.setOssName(ossInfo.getOssName() + " (" + ossInfo.getOssVersion() +")");
     							}
     							
@@ -407,19 +407,19 @@ public class CoMailManager extends CoTopComponent {
     			}
 
     			// 17.08.02 sw-yun 12번 메일은 더이상 사용하지 않고, 11번 메일에 포함
-    			if(CoConstDef.CD_MAIL_TYPE_OSS_UPDATE.equals(bean.getMsgType()) 
+    			if (CoConstDef.CD_MAIL_TYPE_OSS_UPDATE.equals(bean.getMsgType()) 
     					|| CoConstDef.CD_MAIL_TYPE_ADDNICKNAME_UPDATE.equals(bean.getMsgType()) 
     					|| CoConstDef.CD_MAIL_TYPE_OSS_CHANGE_NAME.equals(bean.getMsgType())) {
-    				if(!isEmpty(bean.getParamOssId()) 
+    				if (!isEmpty(bean.getParamOssId()) 
     						&&  bean.getCompareDataBefore() != null && bean.getCompareDataAfter() != null 
     						&& !((OssMaster) bean.getCompareDataBefore()).getLicenseType().equals(((OssMaster) bean.getCompareDataAfter()).getLicenseType())) {
     					OssMaster paramVo = CoCodeManager.OSS_INFO_BY_ID.get(bean.getParamOssId());
-    					if(paramVo == null) {
+    					if (paramVo == null) {
     						paramVo = (OssMaster) bean.getCompareDataBefore();
     					}
         				List<Project> prjList = ossMapper.getOssChangeForUserList(paramVo);
-        				if(prjList != null && !prjList.isEmpty()) {
-            				for(Project prjBean : prjList) {
+        				if (prjList != null && !prjList.isEmpty()) {
+            				for (Project prjBean : prjList) {
             					prjBean.setDistributionType(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, prjBean.getDistributionType()));
             					prjBean.setCreator(makeUserNameFormatWithDivision(prjBean.getCreator()));
             					prjBean.setCreatedDate(CommonFunction.formatDateSimple(prjBean.getCreatedDate()));
@@ -430,12 +430,12 @@ public class CoMailManager extends CoTopComponent {
     				}
     			}
     			
-    			if(CoConstDef.CD_MAIL_TYPE_OSS_RENAME.equals(bean.getMsgType())) {
-    				if(!isEmpty(bean.getParamOssId()) 
+    			if (CoConstDef.CD_MAIL_TYPE_OSS_RENAME.equals(bean.getMsgType())) {
+    				if (!isEmpty(bean.getParamOssId()) 
     						&&  bean.getCompareDataBefore() != null && bean.getCompareDataAfter() != null) {
         				List<Project> prjList = ossMapper.getOssChangeForUserList((OssMaster) bean.getCompareDataBefore());
-        				if(prjList != null && !prjList.isEmpty()) {
-            				for(Project prjBean : prjList) {
+        				if (prjList != null && !prjList.isEmpty()) {
+            				for (Project prjBean : prjList) {
             					prjBean.setDistributionType(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, prjBean.getDistributionType()));
             					prjBean.setCreator(makeUserNameFormatWithDivision(prjBean.getCreator()));
             					prjBean.setCreatedDate(CommonFunction.formatDateSimple(prjBean.getCreatedDate()));
@@ -446,12 +446,12 @@ public class CoMailManager extends CoTopComponent {
     				}
     			}
     			
-    			if(CoConstDef.CD_MAIL_TYPE_OSS_DELETE.equals(bean.getMsgType())) {
-    				if(!isEmpty(bean.getParamOssId()) ) {
+    			if (CoConstDef.CD_MAIL_TYPE_OSS_DELETE.equals(bean.getMsgType())) {
+    				if (!isEmpty(bean.getParamOssId()) ) {
     					
         				List<Project> prjList = ossMapper.getOssChangeForUserList(bean.getParamOssInfo());
-        				if(prjList != null && !prjList.isEmpty()) {
-            				for(Project prjBean : prjList) {
+        				if (prjList != null && !prjList.isEmpty()) {
+            				for (Project prjBean : prjList) {
             					prjBean.setDistributionType(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, prjBean.getDistributionType()));
             					prjBean.setCreator(makeUserNameFormatWithDivision(prjBean.getCreator()));
             					prjBean.setCreatedDate(CommonFunction.formatDateSimple(prjBean.getCreatedDate()));
@@ -464,7 +464,7 @@ public class CoMailManager extends CoTopComponent {
     			}
 				
 
-				if(CoConstDef.CD_MAIL_TOKEN_CREATE_TYPE.equals(bean.getMsgType())) {
+				if (CoConstDef.CD_MAIL_TOKEN_CREATE_TYPE.equals(bean.getMsgType())) {
 					T2Users user = new T2Users();
 					user.setUserId(bean.getParamUserId());
 					user = userMapper.getUser(user);
@@ -476,12 +476,12 @@ public class CoMailManager extends CoTopComponent {
 	    		}
 				
 
-				if(CoConstDef.CD_MAIL_TOKEN_DELETE_TYPE.equals(bean.getMsgType())) {
+				if (CoConstDef.CD_MAIL_TOKEN_DELETE_TYPE.equals(bean.getMsgType())) {
 					convertDataMap.put("mailType", CoConstDef.CD_MAIL_TOKEN_DELETE_TYPE);
 					convertDataMap.put("tokenInfo", CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_DEFAULT_CONTENTS, CoConstDef.CD_MAIL_TOKEN_DELETE_TYPE));
 	    		}
 				
-				if(CoConstDef.CD_MAIL_PACKAGING_UPLOAD_SUCCESS.equals(bean.getMsgType())
+				if (CoConstDef.CD_MAIL_PACKAGING_UPLOAD_SUCCESS.equals(bean.getMsgType())
 						|| CoConstDef.CD_MAIL_PACKAGING_UPLOAD_FAILURE.equals(bean.getMsgType())) {
 					convertDataMap.put("mailType", bean.getMsgType());
 					convertDataMap.put("prjId", bean.getParamPrjId());
@@ -489,7 +489,7 @@ public class CoMailManager extends CoTopComponent {
 					convertDataMap.put("errorMsg", bean.getParamExpansion2());
 	    		}
     			
-				if(CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_INVATED.equals(bean.getMsgType())
+				if (CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_INVATED.equals(bean.getMsgType())
 						|| CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_REGISTED.equals(bean.getMsgType())
 						|| CoConstDef.CD_MAIL_TYPE_PARTER_WATCHER_INVATED.equals(bean.getMsgType())
 						|| CoConstDef.CD_MAIL_TYPE_PARTER_WATCHER_REGISTED.equals(bean.getMsgType())
@@ -498,54 +498,54 @@ public class CoMailManager extends CoTopComponent {
 						|| CoConstDef.CD_MAIL_TYPE_PROJECT_REQUESTTOOPEN_COMMENT.equals(bean.getMsgType())
 						|| CoConstDef.CD_MAIL_TYPE_SELFCHECK_PROJECT_WATCHER_INVATED.equals(bean.getMsgType())
 						) {
-					if(!isEmpty(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_TYPE, bean.getMsgType()))) {
+					if (!isEmpty(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_TYPE, bean.getMsgType()))) {
 						String subTitle = avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_TYPE, bean.getMsgType()));
 
 						Project project = null;
 						PartnerMaster partner = null;
 						BinaryMaster binary = null;
 						
-						if(subTitle.indexOf("${Project Name}") > -1) {
+						if (subTitle.indexOf("${Project Name}") > -1) {
 							String _s = "";
-							if(!isEmpty(bean.getParamPrjId())) {
+							if (!isEmpty(bean.getParamPrjId())) {
 								project = mailManagerMapper.getProjectInfoById(bean.getParamPrjId());
 							}
 							
-							if(project != null) {
-								if(subTitle.indexOf("${Project Name}") > -1) {
-									if(subTitle.indexOf("${Project ID}") < 0) {
+							if (project != null) {
+								if (subTitle.indexOf("${Project Name}") > -1) {
+									if (subTitle.indexOf("${Project ID}") < 0) {
 										_s += "(" + bean.getParamPrjId() +")";
 									}
 									_s += project.getPrjName();
-									if(!isEmpty(project.getPrjVersion())) {
+									if (!isEmpty(project.getPrjVersion())) {
 										_s += " (" + project.getPrjVersion() +")";
 									}
 								}
 							}
 
 							subTitle = StringUtil.replace(subTitle, "${Project Name}", _s);
-							if(subTitle.indexOf("${Project Name}") > -1) {
+							if (subTitle.indexOf("${Project Name}") > -1) {
 								subTitle = StringUtil.replace(subTitle, "${Project Name}", _s);
 							}
 						}
 						
-						if(subTitle.indexOf("${Project ID}") > -1) {
+						if (subTitle.indexOf("${Project ID}") > -1) {
 							String _s = avoidNull(bean.getParamPrjId());
 							subTitle = StringUtil.replace(subTitle, "${Project ID}", _s);
-							if(subTitle.indexOf("${Project ID}") > -1) {
+							if (subTitle.indexOf("${Project ID}") > -1) {
 								subTitle = StringUtil.replace(subTitle, "${Project ID}", _s);
 							}
 						}
 						
-						if(subTitle.indexOf("${3rd Party Name}") > -1) {
+						if (subTitle.indexOf("${3rd Party Name}") > -1) {
 							String _s = "";
-							if(!isEmpty(bean.getParamPartnerId())) {
+							if (!isEmpty(bean.getParamPartnerId())) {
 								partner = mailManagerMapper.getPartnerInfo(bean.getParamPartnerId());
 							}
 							
-							if(partner != null) {
-								if(subTitle.indexOf("${3rd Party Name}") > -1) {
-									if(subTitle.indexOf("${3rd Party ID}") < 0) {
+							if (partner != null) {
+								if (subTitle.indexOf("${3rd Party Name}") > -1) {
+									if (subTitle.indexOf("${3rd Party ID}") < 0) {
 										_s += "(" + partner.getPartnerId() +")";
 									}
 									_s += partner.getPartnerName();
@@ -553,50 +553,50 @@ public class CoMailManager extends CoTopComponent {
 							}
 
 							subTitle = StringUtil.replace(subTitle, "${3rd Party Name}", _s);
-							if(subTitle.indexOf("${3rd Party Name}") > -1) {
+							if (subTitle.indexOf("${3rd Party Name}") > -1) {
 								subTitle = StringUtil.replace(subTitle, "${3rd Party Name}", _s);
 							}
 						}
 						
-						if(subTitle.indexOf("${3rd Party ID}") > -1) {
+						if (subTitle.indexOf("${3rd Party ID}") > -1) {
 							String _s = avoidNull(bean.getParamPartnerId());
 							subTitle = StringUtil.replace(subTitle, "${3rd Party ID}", _s);
-							if(subTitle.indexOf("${3rd Party ID}") > -1) {
+							if (subTitle.indexOf("${3rd Party ID}") > -1) {
 								subTitle = StringUtil.replace(subTitle, "${3rd Party ID}", _s);
 							}
 						}
 						
-						if(subTitle.indexOf("${SelfCheck Project Name}") > -1) {
+						if (subTitle.indexOf("${SelfCheck Project Name}") > -1) {
 							String _s = "";
-							if(!isEmpty(bean.getParamPrjId())) {
+							if (!isEmpty(bean.getParamPrjId())) {
 								project = mailManagerMapper.getSelfCheckProjectInfoById(bean.getParamPrjId());
 							}
 							
-							if(project != null) {
-								if(subTitle.indexOf("${SelfCheck Project Name}") > -1) {
+							if (project != null) {
+								if (subTitle.indexOf("${SelfCheck Project Name}") > -1) {
 									_s += "(" + bean.getParamPrjId() +")";  // SelfCheck project ID
 									_s += project.getPrjName();				// SelfCheck Project Name
-									if(!isEmpty(project.getPrjVersion())) { // SelfCheck Project Version
+									if (!isEmpty(project.getPrjVersion())) { // SelfCheck Project Version
 										_s += " (" + project.getPrjVersion() +")";
 									}
 								}
 							}
 
 							subTitle = StringUtil.replace(subTitle, "${SelfCheck Project Name}", _s);
-							if(subTitle.indexOf("${SelfCheck Project Name}") > -1) {
+							if (subTitle.indexOf("${SelfCheck Project Name}") > -1) {
 								subTitle = StringUtil.replace(subTitle, "${SelfCheck Project Name}", _s);
 							}
 						}
 						
-						if(subTitle.indexOf("${Binary Name}") > -1) {
+						if (subTitle.indexOf("${Binary Name}") > -1) {
 							String _s = "";
-							if(!isEmpty(bean.getParamPrjId())) {
+							if (!isEmpty(bean.getParamPrjId())) {
 								binary = mailManagerMapper.getBinaryInfo(bean.getParamBatId());
 							}
 							
-							if(binary != null) {
-								if(subTitle.indexOf("${Binary Name}") > -1) {
-									if(subTitle.indexOf("${Binary ID}") < 0) {
+							if (binary != null) {
+								if (subTitle.indexOf("${Binary Name}") > -1) {
+									if (subTitle.indexOf("${Binary ID}") < 0) {
 										_s += "(" + binary.getBatId() +")";
 									}
 									_s += binary.getBinaryFileName();
@@ -604,35 +604,35 @@ public class CoMailManager extends CoTopComponent {
 							}
 
 							subTitle = StringUtil.replace(subTitle, "${Binary Name}", _s);
-							if(subTitle.indexOf("${Binary Name}") > -1) {
+							if (subTitle.indexOf("${Binary Name}") > -1) {
 								subTitle = StringUtil.replace(subTitle, "${Binary Name}", _s);
 							}
 						}
 						
-						if(subTitle.indexOf("${Binary ID}") > -1) {
+						if (subTitle.indexOf("${Binary ID}") > -1) {
 							String _s = avoidNull(bean.getParamBatId());
 							subTitle = StringUtil.replace(subTitle, "${Binary ID}", _s);
-							if(subTitle.indexOf("${Binary ID}") > -1) {
+							if (subTitle.indexOf("${Binary ID}") > -1) {
 								subTitle = StringUtil.replace(subTitle, "${Binary ID}", _s);
 							}
 						}
 
-						if(subTitle.indexOf("${Email}") > -1) {
+						if (subTitle.indexOf("${Email}") > -1) {
 							String _convEmail = avoidNull(bean.getParamEmail());
 
 							subTitle = StringUtil.replace(subTitle, "${Email}", _convEmail);
 						}
 
-						if(subTitle.indexOf("${User}") > -1) {
+						if (subTitle.indexOf("${User}") > -1) {
 							String _convUser = avoidNull(makeUserNameFormatWithDivision(!isEmpty(bean.getParamUserId()) ? bean.getParamUserId() : bean.getLoginUserName()));
 
 							subTitle = StringUtil.replace(subTitle, "${User}", _convUser);
-							if(subTitle.indexOf("${User}") > -1) {
+							if (subTitle.indexOf("${User}") > -1) {
 								subTitle = StringUtil.replace(subTitle, "${User}", _convUser);
 							}
 						}
 						
-						if(subTitle.indexOf("${Stage}") > -1) {
+						if (subTitle.indexOf("${Stage}") > -1) {
 							String _stage = avoidNull(bean.getStage());
 
 							subTitle = StringUtil.replace(subTitle, "${Stage}", _stage);
@@ -641,33 +641,33 @@ public class CoMailManager extends CoTopComponent {
 						convertDataMap.put("contentsSubTitle", subTitle);
 						
 					}
-				} else if(CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_DELETED.equals(bean.getMsgType()) 
+				} else if (CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_DELETED.equals(bean.getMsgType()) 
 						|| CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_DIFF_FILE.equals(bean.getMsgType())) {
 
-					if(!isEmpty(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_TYPE, bean.getMsgType()))) {
+					if (!isEmpty(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_TYPE, bean.getMsgType()))) {
 						String subTitle = avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_TYPE, bean.getMsgType()));
 						
-						if(subTitle.indexOf("${Param1}") > -1) {
+						if (subTitle.indexOf("${Param1}") > -1) {
 							subTitle = StringUtil.replace(subTitle, "${Param1}", avoidNull(bean.getParamExpansion1()));
 						}
-						if(subTitle.indexOf("${Param2}") > -1) {
+						if (subTitle.indexOf("${Param2}") > -1) {
 							subTitle = StringUtil.replace(subTitle, "${Param2}", avoidNull(bean.getParamExpansion2()));
 						}
-						if(subTitle.indexOf("${Param3}") > -1) {
+						if (subTitle.indexOf("${Param3}") > -1) {
 							subTitle = StringUtil.replace(subTitle, "${Param3}", avoidNull(bean.getParamExpansion3()));
 						}
 						convertDataMap.put("contentsSubTitle", subTitle);
 					}
-				} else if(CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_COMPLETE.equals(bean.getMsgType()) && !isEmpty(bean.getParamExpansion1())
+				} else if (CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_COMPLETE.equals(bean.getMsgType()) && !isEmpty(bean.getParamExpansion1())
 						|| CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_EDIT_FILE.equals(bean.getMsgType()) && !isEmpty(bean.getParamExpansion1())
 						|| CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_EDIT_DESCRIPTION.equals(bean.getMsgType()) && !isEmpty(bean.getParamExpansion1())) {
 					String subTitle = "";
 					
 					subTitle += "<br>" + bean.getParamExpansion1();
-					if(!isEmpty(bean.getParamExpansion2())) {
+					if (!isEmpty(bean.getParamExpansion2())) {
 						subTitle += bean.getParamExpansion2();
 					}
-					if(!isEmpty(bean.getParamExpansion3())) {
+					if (!isEmpty(bean.getParamExpansion3())) {
 						subTitle += bean.getParamExpansion3();
 					}
 
@@ -677,7 +677,7 @@ public class CoMailManager extends CoTopComponent {
     		
     		// mail Template
     		String msgContents = getVelocityTemplateContent(getTemplateFilePath(bean.getMsgType()), convertDataMap);
-    		if(isEmpty(msgContents)) {
+    		if (isEmpty(msgContents)) {
     			throw new Exception("Can not convert mail contents Email Type : " + bean.getMsgType());
     		}
     		
@@ -766,7 +766,7 @@ public class CoMailManager extends CoTopComponent {
     			// to : project creator + cc : watcher + reviewer
     			prjInfo = mailManagerMapper.getProjectInfo(bean.getParamPrjId());
     			
-    			if(CoConstDef.CD_MAIL_TYPE_PROJECT_MODIFIED_COMMENT.equals(bean.getMsgType())
+    			if (CoConstDef.CD_MAIL_TYPE_PROJECT_MODIFIED_COMMENT.equals(bean.getMsgType())
     					|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_MODIFIED_COMMENT.equals(bean.getMsgType())
     					|| CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_MODIFIED_COMMENT.equals(bean.getMsgType())
     					|| CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_MODIFIED_COMMENT.equals(bean.getMsgType())    					
@@ -774,31 +774,31 @@ public class CoMailManager extends CoTopComponent {
     				toList = new ArrayList<>();
     				ccList = new ArrayList<>();
     				// 로그인 사용자가 Admin이면 to : project creator cc: reviewer, watcher
-    				if(CommonFunction.isAdmin()) {
+    				if (CommonFunction.isAdmin()) {
     					toList.addAll(mailManagerMapper.setProjectWatcherMailList(bean.getParamPrjId())); // creator를 포함하고 있음
-        				if(!isEmpty(prjInfo.getReviewer())) {
+        				if (!isEmpty(prjInfo.getReviewer())) {
         					ccList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getReviewer()})));
         				} else {
         					ccList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
     				} else {
     					ccList.addAll(mailManagerMapper.setProjectWatcherMailList(bean.getParamPrjId())); // creator를 포함하고 있음
-        				if(!isEmpty(prjInfo.getReviewer())) {
+        				if (!isEmpty(prjInfo.getReviewer())) {
         					toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getReviewer()})));
         				} else {
         					toList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
     				}
     				
-        			if(toList != null && !toList.isEmpty()) {
+        			if (toList != null && !toList.isEmpty()) {
         				bean.setToIds(toList.toArray(new String[toList.size()]));
         			}
-        			if(ccList != null && !ccList.isEmpty()) {
+        			if (ccList != null && !ccList.isEmpty()) {
         				bean.setCcIds(ccList.toArray(new String[ccList.size()]));
         			}
     				
     			}
-    			else if(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_ADDED_COMMENT.equals(bean.getMsgType()) 
+    			else if (CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_ADDED_COMMENT.equals(bean.getMsgType()) 
     					|| CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_ADDED_COMMENT.equals(bean.getMsgType())
     					|| CoConstDef.CD_MAIL_TYPE_PROJECT_ADDED_COMMENT.equals(bean.getMsgType())
     					|| CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_ADDED_COMMENT.equals(bean.getMsgType())) {
@@ -806,32 +806,32 @@ public class CoMailManager extends CoTopComponent {
     				toList = new ArrayList<>();
     				ccList = new ArrayList<>();
     				
-    				if("W".equals(bean.getReceiveFlag())) {
+    				if ("W".equals(bean.getReceiveFlag())) {
             			watcherList = mailManagerMapper.setProjectWatcherMailList(bean.getParamPrjId());
-            			if(watcherList != null && !watcherList.isEmpty()) {
+            			if (watcherList != null && !watcherList.isEmpty()) {
             				toList.addAll(watcherList);
             			} else {
             				// watcher가 설정되어 있지 않은 경우, 그냥 자신에게 보낸다
             				toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{bean.getLoginUserName()})));
             			}
-    				} else if("R".equals(bean.getReceiveFlag())) {
-        				if(!isEmpty(prjInfo.getReviewer())) {
+    				} else if ("R".equals(bean.getReceiveFlag())) {
+        				if (!isEmpty(prjInfo.getReviewer())) {
     						toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getReviewer()})));
         				} else {
         					toList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
-    				} else if("C".equals(bean.getReceiveFlag())) {
+    				} else if ("C".equals(bean.getReceiveFlag())) {
 						toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getCreator()})));
-    				} else if("WR".equals(bean.getReceiveFlag())) {
+    				} else if ("WR".equals(bean.getReceiveFlag())) {
 
             			watcherList = mailManagerMapper.setProjectWatcherMailList(bean.getParamPrjId());
-            			if(watcherList != null && !watcherList.isEmpty()) {
+            			if (watcherList != null && !watcherList.isEmpty()) {
             				toList.addAll(watcherList);
             			} else {
             				// watcher가 설정되어 있지 않은 경우, 그냥 자신에게 보낸다
             				toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{bean.getLoginUserName()})));
             			}
-        				if(!isEmpty(prjInfo.getReviewer())) {
+        				if (!isEmpty(prjInfo.getReviewer())) {
         					toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getReviewer()})));
         				} else {
         					toList.addAll(Arrays.asList(selectAdminMailAddr()));
@@ -839,10 +839,10 @@ public class CoMailManager extends CoTopComponent {
     				
     				}
     				
-        			if(toList != null && !toList.isEmpty()) {
+        			if (toList != null && !toList.isEmpty()) {
         				bean.setToIds(toList.toArray(new String[toList.size()]));
         			}
-        			if(ccList != null && !ccList.isEmpty()) {
+        			if (ccList != null && !ccList.isEmpty()) {
         				bean.setCcIds(ccList.toArray(new String[ccList.size()]));
         			}
     				
@@ -853,14 +853,14 @@ public class CoMailManager extends CoTopComponent {
     				
     				// to 설정 -------------------------------------
     				// Reviewer
-    				if(CoConstDef.CD_MAIL_TYPE_PROJECT_REVIEWER_ADD.equals(bean.getMsgType())
+    				if (CoConstDef.CD_MAIL_TYPE_PROJECT_REVIEWER_ADD.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_REVIEWER_CHANGED.equals(bean.getMsgType())) {
-    					if(bean.getToIds() != null && bean.getToIds().length > 0) {
+    					if (bean.getToIds() != null && bean.getToIds().length > 0) {
     						toList.addAll(Arrays.asList(selectMailAddrFromIds(bean.getToIds())));
-    					} else if(!isEmpty(prjInfo.getReviewer())) {
+    					} else if (!isEmpty(prjInfo.getReviewer())) {
     						toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getReviewer()})));
     					}
-    				} else if(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_REQ_REVIEW.equals(bean.getMsgType())
+    				} else if (CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_REQ_REVIEW.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_SELF_REJECT.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_REQ_REVIEW.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_CANCELED_CONF.equals(bean.getMsgType())
@@ -877,31 +877,31 @@ public class CoMailManager extends CoTopComponent {
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_REQUESTTOOPEN_COMMENT.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_BINARY_DATA_COMMIT.equals(bean.getMsgType())
     						) {
-        				if(!isEmpty(prjInfo.getReviewer())) {
+        				if (!isEmpty(prjInfo.getReviewer())) {
         					toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getReviewer()})));
         				} else {
         					toList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
     				}
     				// Creator, watcher, Reviewer
-    				else if(CoConstDef.CD_MAIL_TYPE_PROJECT_DELETED.equals(bean.getMsgType())
+    				else if (CoConstDef.CD_MAIL_TYPE_PROJECT_DELETED.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_COPIED.equals(bean.getMsgType())
     						){
-    					if(!bean.isToIdsCheckDivision()) {
+    					if (!bean.isToIdsCheckDivision()) {
     						toList.addAll(mailManagerMapper.setProjectWatcherMailList(bean.getParamPrjId())); // creator를 포함하고 있음
     					} else {
     						toList.addAll(mailManagerMapper.setProjectWatcherMailListNotCheckDivision(bean.getParamPrjId()));
     					}
     					
-        				if(!isEmpty(prjInfo.getReviewer())) {
+        				if (!isEmpty(prjInfo.getReviewer())) {
         					toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getReviewer()})));
         				} else {
         					toList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
     				} 
     				// Creator, watcher
-    				else if(CoConstDef.CD_MAIL_TYPE_PROJECT_CREATED.equals(bean.getMsgType())
+    				else if (CoConstDef.CD_MAIL_TYPE_PROJECT_CREATED.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_CONF.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_CANCELED_CONF.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_REJECT.equals(bean.getMsgType())
@@ -919,12 +919,12 @@ public class CoMailManager extends CoTopComponent {
 						toList.addAll(mailManagerMapper.setProjectWatcherMailList(bean.getParamPrjId())); // creator를 포함
     				}
     				// Creator only
-    				else if(CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_REGISTED.equals(bean.getMsgType())) {
+    				else if (CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_REGISTED.equals(bean.getMsgType())) {
     					toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getCreator()})));
     				}
     				
     				// cc 설정 ------------------------------------
-    				if(CoConstDef.CD_MAIL_TYPE_PROJECT_REVIEWER_ADD.equals(bean.getMsgType())
+    				if (CoConstDef.CD_MAIL_TYPE_PROJECT_REVIEWER_ADD.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_REVIEWER_CHANGED.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_REQ_REVIEW.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_SELF_REJECT.equals(bean.getMsgType())
@@ -944,17 +944,17 @@ public class CoMailManager extends CoTopComponent {
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_REQUESTTOOPEN_COMMENT.equals(bean.getMsgType())
     						) {
     					ccList.addAll(mailManagerMapper.setProjectWatcherMailList(bean.getParamPrjId()));
-    					if(CoConstDef.CD_MAIL_TYPE_PROJECT_REVIEWER_ADD.equals(bean.getMsgType())
+    					if (CoConstDef.CD_MAIL_TYPE_PROJECT_REVIEWER_ADD.equals(bean.getMsgType())
     							|| CoConstDef.CD_MAIL_TYPE_PROJECT_REVIEWER_CHANGED.equals(bean.getMsgType())){
     						ccList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{bean.getLoginUserName()})));	
     					}
     				}
     				// admin all
-    				else if(CoConstDef.CD_MAIL_TYPE_PROJECT_CREATED.equals(bean.getMsgType())) {
+    				else if (CoConstDef.CD_MAIL_TYPE_PROJECT_CREATED.equals(bean.getMsgType())) {
     					ccList.addAll(Arrays.asList(selectAdminMailAddr()));
     				}
     				// Reviewer
-    				else if(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_CONF.equals(bean.getMsgType())
+    				else if (CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_CONF.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_CANCELED_CONF.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_REJECT.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_CONFIRMED_ONLY.equals(bean.getMsgType())
@@ -970,14 +970,14 @@ public class CoMailManager extends CoTopComponent {
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_DROPPED.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PROJECT_REOPENED.equals(bean.getMsgType())
     						) {
-        				if(!isEmpty(prjInfo.getReviewer())) {
+        				if (!isEmpty(prjInfo.getReviewer())) {
         					ccList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{prjInfo.getReviewer()})));
         				} else {
         					ccList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
         				
         				// Secuirty 파트 추가
-        				if(!isTest && 
+        				if (!isTest && 
         						(
         								CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT.equals(bean.getMsgType()) 
         								|| CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_RECALCULATED.equals(bean.getMsgType()))
@@ -987,10 +987,10 @@ public class CoMailManager extends CoTopComponent {
     				}
     				
     				
-    				if(toList != null && !toList.isEmpty()) {
+    				if (toList != null && !toList.isEmpty()) {
     					bean.setToIds(toList.toArray(new String[toList.size()]));
     				}
-        			if(ccList != null && !ccList.isEmpty()) {
+        			if (ccList != null && !ccList.isEmpty()) {
         				bean.setCcIds(ccList.toArray(new String[ccList.size()]));
         			}
     			}
@@ -1011,74 +1011,74 @@ public class CoMailManager extends CoTopComponent {
     		case CoConstDef.CD_MAIL_TYPE_PARTNER_BINARY_DATA_COMMIT:
     			// to :  creator + cc : watcher + reviewer
     			partnerInfo = mailManagerMapper.getPartnerInfo(bean.getParamPartnerId());
-    			if(CoConstDef.CD_MAIL_TYPE_PARTER_MODIFIED_COMMENT.equals(bean.getMsgType())) {
+    			if (CoConstDef.CD_MAIL_TYPE_PARTER_MODIFIED_COMMENT.equals(bean.getMsgType())) {
 					toList = new ArrayList<>();
     				ccList = new ArrayList<>();
     				// 로그인 사용자가 Admin이면 to : project creator cc: reviewer, watcher
-    				if(CommonFunction.isAdmin()) {
+    				if (CommonFunction.isAdmin()) {
     					toList.addAll(mailManagerMapper.setPartnerWatcherMailList(bean.getParamPartnerId())); // creator를 포함하고 있음
-        				if(!isEmpty(partnerInfo.getReviewer())) {
+        				if (!isEmpty(partnerInfo.getReviewer())) {
         					ccList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{partnerInfo.getReviewer()})));
         				} else {
         					ccList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
     				} else {
     					ccList.addAll(mailManagerMapper.setPartnerWatcherMailList(bean.getParamPartnerId())); // creator를 포함하고 있음
-        				if(!isEmpty(partnerInfo.getReviewer())) {
+        				if (!isEmpty(partnerInfo.getReviewer())) {
         					toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{partnerInfo.getReviewer()})));
         				} else {
         					toList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
     				}
     				
-        			if(toList != null && !toList.isEmpty()) {
+        			if (toList != null && !toList.isEmpty()) {
         				bean.setToIds(toList.toArray(new String[toList.size()]));
         			}
-        			if(ccList != null && !ccList.isEmpty()) {
+        			if (ccList != null && !ccList.isEmpty()) {
         				bean.setCcIds(ccList.toArray(new String[ccList.size()]));
         			}
         			
     			}
-    			else if(CoConstDef.CD_MAIL_TYPE_PARTER_ADDED_COMMENT.equals(bean.getMsgType())) {
+    			else if (CoConstDef.CD_MAIL_TYPE_PARTER_ADDED_COMMENT.equals(bean.getMsgType())) {
     				// comment send의 경우, 일단 자신은 cc로 보낸다.
 					toList = new ArrayList<>();
     				ccList = new ArrayList<>();
     				
-    				if("W".equals(bean.getReceiveFlag())) {
+    				if ("W".equals(bean.getReceiveFlag())) {
             			watcherList = mailManagerMapper.setPartnerWatcherMailList(bean.getParamPartnerId());
-            			if(watcherList != null && !watcherList.isEmpty()) {
+            			if (watcherList != null && !watcherList.isEmpty()) {
             				toList.addAll(watcherList);
             			} else {
             				// watcher가 설정되어 있지 않은 경우, 그냥 자신에게 보낸다
             				toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{bean.getLoginUserName()})));
             			}
-    				} else if("R".equals(bean.getReceiveFlag())) {
-        				if(!isEmpty(partnerInfo.getReviewer())) {
+    				} else if ("R".equals(bean.getReceiveFlag())) {
+        				if (!isEmpty(partnerInfo.getReviewer())) {
     						toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{partnerInfo.getReviewer()})));
         				} else {
         					toList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
-    				} else if("C".equals(bean.getReceiveFlag())) {
+    				} else if ("C".equals(bean.getReceiveFlag())) {
 						toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{partnerInfo.getCreator()})));
-    				} else if("WR".equals(bean.getReceiveFlag())) {
+    				} else if ("WR".equals(bean.getReceiveFlag())) {
             			watcherList = mailManagerMapper.setPartnerWatcherMailList(bean.getParamPartnerId());
-            			if(watcherList != null && !watcherList.isEmpty()) {
+            			if (watcherList != null && !watcherList.isEmpty()) {
             				toList.addAll(watcherList);
             			} else {
             				// watcher가 설정되어 있지 않은 경우, 그냥 자신에게 보낸다
             				toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{bean.getLoginUserName()})));
             			}
-        				if(!isEmpty(partnerInfo.getReviewer())) {
+        				if (!isEmpty(partnerInfo.getReviewer())) {
         					toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{partnerInfo.getReviewer()})));
         				} else {
         					toList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
     				}
     				
-        			if(toList != null && !toList.isEmpty()) {
+        			if (toList != null && !toList.isEmpty()) {
         				bean.setToIds(toList.toArray(new String[toList.size()]));
         			}
-        			if(ccList != null && !ccList.isEmpty()) {
+        			if (ccList != null && !ccList.isEmpty()) {
         				bean.setCcIds(ccList.toArray(new String[ccList.size()]));
         			}
     				
@@ -1089,27 +1089,27 @@ public class CoMailManager extends CoTopComponent {
         			// to list ------------------------------------------------------------
         			
         			// reviewer
-    				if(CoConstDef.CD_MAIL_TYPE_PARTER_REVIEWER_CHANGED.equals(bean.getMsgType())) {
-    					if(bean.getToIds() != null && bean.getToIds().length > 0) {
+    				if (CoConstDef.CD_MAIL_TYPE_PARTER_REVIEWER_CHANGED.equals(bean.getMsgType())) {
+    					if (bean.getToIds() != null && bean.getToIds().length > 0) {
     						toList.addAll(Arrays.asList(selectMailAddrFromIds(bean.getToIds())));
-    					} else if(!isEmpty(partnerInfo.getReviewer())) {
+    					} else if (!isEmpty(partnerInfo.getReviewer())) {
     						toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{partnerInfo.getReviewer()})));
     					}
     				} 
     				// Reviewer
-    				if(CoConstDef.CD_MAIL_TYPE_PARTER_REQ_REVIEW.equals(bean.getMsgType())
+    				if (CoConstDef.CD_MAIL_TYPE_PARTER_REQ_REVIEW.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_SELF_REJECT.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_DELETED.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTNER_BINARY_DATA_COMMIT.equals(bean.getMsgType())
     						) {
-        				if(!isEmpty(partnerInfo.getReviewer())) {
+        				if (!isEmpty(partnerInfo.getReviewer())) {
         					toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{partnerInfo.getReviewer()})));
         				} else {
         					toList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
     				}
     				// creator, watcher
-    				else if(CoConstDef.CD_MAIL_TYPE_PARTER_CONF.equals(bean.getMsgType())
+    				else if (CoConstDef.CD_MAIL_TYPE_PARTER_CONF.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_CANCELED_CONF.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_REJECT.equals(bean.getMsgType())
     						) {
@@ -1117,40 +1117,40 @@ public class CoMailManager extends CoTopComponent {
     					toList.addAll(mailManagerMapper.setPartnerWatcherMailList(bean.getParamPartnerId()));
     				}
     				// Creator only
-    				else if(CoConstDef.CD_MAIL_TYPE_PARTER_WATCHER_REGISTED.equals(bean.getMsgType())) {
+    				else if (CoConstDef.CD_MAIL_TYPE_PARTER_WATCHER_REGISTED.equals(bean.getMsgType())) {
     					toList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{partnerInfo.getCreator()})));
     				}
     				
     				// cc -----------------------------------------------------------------------
 
     				// Creator, Watcher
-    				if(CoConstDef.CD_MAIL_TYPE_PARTER_REVIEWER_CHANGED.equals(bean.getMsgType())
+    				if (CoConstDef.CD_MAIL_TYPE_PARTER_REVIEWER_CHANGED.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_REQ_REVIEW.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_SELF_REJECT.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_DELETED.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_WATCHER_REGISTED.equals(bean.getMsgType())
     						) {
     					ccList.addAll(mailManagerMapper.setPartnerWatcherMailList(bean.getParamPartnerId()));
-    					if(CoConstDef.CD_MAIL_TYPE_PARTER_REVIEWER_CHANGED.equals(bean.getMsgType())) {
+    					if (CoConstDef.CD_MAIL_TYPE_PARTER_REVIEWER_CHANGED.equals(bean.getMsgType())) {
     						ccList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{bean.getLoginUserName()})));
     					}
     				} 
     				// Reviwer
-    				else if(CoConstDef.CD_MAIL_TYPE_PARTER_CANCELED_CONF.equals(bean.getMsgType())
+    				else if (CoConstDef.CD_MAIL_TYPE_PARTER_CANCELED_CONF.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_CONF.equals(bean.getMsgType())
     						|| CoConstDef.CD_MAIL_TYPE_PARTER_REJECT.equals(bean.getMsgType())
     						) {
-        				if(!isEmpty(partnerInfo.getReviewer())) {
+        				if (!isEmpty(partnerInfo.getReviewer())) {
         					ccList.addAll(Arrays.asList(selectMailAddrFromIds(new String[]{partnerInfo.getReviewer()})));
         				} else {
         					ccList.addAll(Arrays.asList(selectAdminMailAddr()));
         				}
     				}
     				
-        			if(toList != null && !toList.isEmpty()) {
+        			if (toList != null && !toList.isEmpty()) {
         				bean.setToIds(toList.toArray(new String[toList.size()]));
         			}
-        			if(ccList != null && !ccList.isEmpty()) {
+        			if (ccList != null && !ccList.isEmpty()) {
         				bean.setCcIds(ccList.toArray(new String[ccList.size()]));
         			}
     			}
@@ -1169,10 +1169,10 @@ public class CoMailManager extends CoTopComponent {
 				// cc -----------------------------------------------------------------------
 				// Creator, Watcher
 				ccList.addAll(mailManagerMapper.binaryWatcherMailList(bean.getParamBatId()));
-    			if(toList != null && !toList.isEmpty()) {
+    			if (toList != null && !toList.isEmpty()) {
     				bean.setToIds(toList.toArray(new String[toList.size()]));
     			}
-    			if(ccList != null && !ccList.isEmpty()) {
+    			if (ccList != null && !ccList.isEmpty()) {
     				bean.setCcIds(ccList.toArray(new String[ccList.size()]));
     			}
     			break;
@@ -1185,13 +1185,13 @@ public class CoMailManager extends CoTopComponent {
     			break;
     		default:
     			// 호출하는 쪽에서 설정된 경우
-    			if(bean.getToIds() != null && bean.getToIds().length > 0) {
+    			if (bean.getToIds() != null && bean.getToIds().length > 0) {
     				bean.setToIds(selectMailAddrFromIds(bean.getToIds()));
     			}
-    			if(bean.getCcIds() != null && bean.getCcIds().length > 0) {
+    			if (bean.getCcIds() != null && bean.getCcIds().length > 0) {
     				bean.setCcIds(selectMailAddrFromIds(bean.getCcIds()));
     			}
-    			if(bean.getBccIds() != null && bean.getBccIds().length > 0) {
+    			if (bean.getBccIds() != null && bean.getBccIds().length > 0) {
     				bean.setBccIds(selectMailAddrFromIds(bean.getBccIds()));
     			}
     			
@@ -1199,11 +1199,11 @@ public class CoMailManager extends CoTopComponent {
     		}
     		
     		// BAT 분석 실패시 Admin 담당자 bcc 추가
-    		if(CoConstDef.CD_MAIL_TYPE_BAT_ERROR.equals(bean.getMsgType())) {
+    		if (CoConstDef.CD_MAIL_TYPE_BAT_ERROR.equals(bean.getMsgType())) {
     			bean.setBccIds(BAT_FAILED_BCC);
     		}
     		
-    		if((Boolean) convertDataMap.get("isModify")
+    		if ((Boolean) convertDataMap.get("isModify")
     				&& !isEmpty(bean.getComment())
     				&& ( CoConstDef.CD_MAIL_TYPE_OSS_UPDATE.equals(bean.getMsgType()) 
     						|| CoConstDef.CD_MAIL_TYPE_ADDNICKNAME_UPDATE.equals(bean.getMsgType())
@@ -1214,17 +1214,17 @@ public class CoMailManager extends CoTopComponent {
     		}
     		
 
-    		if(!(Boolean) convertDataMap.get("isModify")){
+    		if (!(Boolean) convertDataMap.get("isModify")){
     			// 수신자 중복문제 수정
     			try {
     				List<String> _toList = null;
     				List<String> _ccList = null;
-    				if(bean.getToIds() != null) {
+    				if (bean.getToIds() != null) {
     					_toList = Arrays.asList(bean.getToIds());
     				} else {
     					_toList = new ArrayList<>();
     				}
-    				if(bean.getCcIds() != null) {
+    				if (bean.getCcIds() != null) {
     					_ccList = Arrays.asList(bean.getCcIds());
     				} else {
     					_ccList = new ArrayList<>();
@@ -1237,8 +1237,8 @@ public class CoMailManager extends CoTopComponent {
     				List<String> _ccListTmp = new ArrayList<String>(new HashSet<String>(_ccList));
     				
     				// tolist를 기준으로 cclist에서 삭제
-    				for(String s : _ccListTmp) {
-    					if(!_toListFinal.contains(s)) {
+    				for (String s : _ccListTmp) {
+    					if (!_toListFinal.contains(s)) {
     						_ccListFinal.add(s);
     					}
     				}
@@ -1277,47 +1277,47 @@ public class CoMailManager extends CoTopComponent {
 		convBean.setDistributeTarget(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTE_CODE, convBean.getDistributeTarget()));
 		// due date
 		// modified date
-		if(!isEmpty(convBean.getModifiedDate())) {
+		if (!isEmpty(convBean.getModifiedDate())) {
 			convBean.setModifiedDate(DateUtil.dateFormatConvert(convBean.getModifiedDate(), DateUtil.TIMESTAMP_PATTERN, DateUtil.DATE_PATTERN_DASH));
 		}
 		// modifier
-		if(!isEmpty(convBean.getModifier())) {
+		if (!isEmpty(convBean.getModifier())) {
 			convBean.setModifier(makeUserNameFormatWithDivision(convBean.getModifier()));
 		}
 		// reviewer
-		if(!isEmpty(convBean.getReviewer())) {
+		if (!isEmpty(convBean.getReviewer())) {
 			convBean.setReviewer(makeUserNameFormatWithDivision(convBean.getReviewer()));
 		}
 		
 		// created date
-		if(!isEmpty(convBean.getCreatedDate())) {
+		if (!isEmpty(convBean.getCreatedDate())) {
 			convBean.setCreatedDate(DateUtil.dateFormatConvert(convBean.getCreatedDate(), DateUtil.TIMESTAMP_PATTERN, DateUtil.DATE_PATTERN_DASH));
 		}
 		// creator
-		if(!isEmpty(convBean.getCreator())) {
+		if (!isEmpty(convBean.getCreator())) {
 			convBean.setCreator(makeUserNameFormatWithDivision(convBean.getCreator()));
 		}
 		
 		
 		String noticeTypeEtc = null;
-		if(!isEmpty(convBean.getNoticeTypeEtc())) {
+		if (!isEmpty(convBean.getNoticeTypeEtc())) {
 			noticeTypeEtc = " (" +CoCodeManager.getCodeString(CoConstDef.CD_PLATFORM_GENERATED, convBean.getNoticeTypeEtc()) + ")";
 		}
 		
-		if(!isEmpty(convBean.getNoticeType())) {
+		if (!isEmpty(convBean.getNoticeType())) {
 			String noticeType = CoCodeManager.getCodeString(CoConstDef.CD_NOTICE_TYPE, convBean.getNoticeType());
-			if(!isEmpty(noticeTypeEtc)) {
+			if (!isEmpty(noticeTypeEtc)) {
 				noticeType += noticeTypeEtc;
 			}
 			
 			convBean.setNoticeType(noticeType);
 		}
 		
-		if(!isEmpty(convBean.getPriority())) {
+		if (!isEmpty(convBean.getPriority())) {
 			convBean.setPriority(CoCodeManager.getCodeString(CoConstDef.CD_PROJECT_PRIORITY, convBean.getPriority()));
 		}
 		
-		if(!isEmpty(convBean.getDivision())) {
+		if (!isEmpty(convBean.getDivision())) {
 			convBean.setDivision(CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, convBean.getDivision()));
 		}
 
@@ -1344,15 +1344,15 @@ public class CoMailManager extends CoTopComponent {
      */
 	private String makeMailSubject(String title, CoMail bean, boolean isMailBodySubject) {
 
-		if(title.indexOf("${User}") > -1) {
-			if(CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_COMPLETE.equals(bean.getMsgType())) { // 예약한 사용자명으로 치환해야함
-				if("BATCH".equals(bean.getJobType())) {
+		if (title.indexOf("${User}") > -1) {
+			if (CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_COMPLETE.equals(bean.getMsgType())) { // 예약한 사용자명으로 치환해야함
+				if ("BATCH".equals(bean.getJobType())) {
 					title = StringUtil.replace(title, "${User}", avoidNull(makeUserNameFormat(avoidNull(mailManagerMapper.getDistributeReservedUser(bean.getParamPrjId()), bean.getLoginUserName()) )));
 				} else {
 					title = StringUtil.replace(title, "${User}", avoidNull(makeUserNameFormat(bean.getLoginUserName())));					
 				}
 			}
-			else if(CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_INVATED.equals(bean.getMsgType())
+			else if (CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_INVATED.equals(bean.getMsgType())
 					|| CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_REGISTED.equals(bean.getMsgType())
 					|| CoConstDef.CD_MAIL_TYPE_PARTER_WATCHER_INVATED.equals(bean.getMsgType())
 					|| CoConstDef.CD_MAIL_TYPE_PARTER_WATCHER_REGISTED.equals(bean.getMsgType())
@@ -1365,7 +1365,7 @@ public class CoMailManager extends CoTopComponent {
 				String _convUser = avoidNull(makeUserNameFormat(!isEmpty(bean.getParamUserId()) ? bean.getParamUserId() : bean.getLoginUserName()));
 
 				title = StringUtil.replace(title, "${User}", _convUser);
-				if(title.indexOf("${User}") > -1) {
+				if (title.indexOf("${User}") > -1) {
 					title = StringUtil.replace(title, "${User}", _convUser);
 				}
 			}
@@ -1375,27 +1375,27 @@ public class CoMailManager extends CoTopComponent {
 		}
 		
 		
-		if(title.indexOf("${OSS Name}") > -1) {
+		if (title.indexOf("${OSS Name}") > -1) {
 			String _s = "";
 			OssMaster ossInfo = null;
 
 			// rename인 경우
 			// oss name = after oss
 			// before oss name = before oss
-			if(CoConstDef.CD_MAIL_TYPE_OSS_RENAME.equals(bean.getMsgType())) {
+			if (CoConstDef.CD_MAIL_TYPE_OSS_RENAME.equals(bean.getMsgType())) {
 				ossInfo = (OssMaster) bean.getCompareDataAfter();
 			}
-			else if(!isEmpty(bean.getParamOssId())) {
+			else if (!isEmpty(bean.getParamOssId())) {
 				ossInfo = mailManagerMapper.getOssInfoById(bean.getParamOssId());
 			}
 			
-			if(ossInfo != null) {
-				if(title.indexOf("${OSS ID}") < 0) {
+			if (ossInfo != null) {
+				if (title.indexOf("${OSS ID}") < 0) {
 					_s += "(" + bean.getParamOssId() +")";
 				}
 				_s += ossInfo.getOssName();
 				// Admin에게만 발송되는 oss 관련 메일의 경우 바로가기 link 형식으로 발송
-				if(isMailBodySubject 
+				if (isMailBodySubject 
 						&& (
 								CoConstDef.CD_MAIL_TYPE_OSS_REGIST.equals(bean.getMsgType()) 
 								|| CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION.equals(bean.getMsgType())
@@ -1412,7 +1412,7 @@ public class CoMailManager extends CoTopComponent {
 					linkUrl += "/oss/list/" + ossInfo.getOssName();
 					_s = "<a href='" + linkUrl + "' style='font-size:16px;' target='_blank'>" + _s + "</a>";
 					
-					if(!isEmpty(ossInfo.getOssVersion())) {
+					if (!isEmpty(ossInfo.getOssVersion())) {
 						_s += " (" + ossInfo.getOssVersion() +")";
 					}
 				}
@@ -1421,8 +1421,8 @@ public class CoMailManager extends CoTopComponent {
 			title = StringUtil.replace(title, "${OSS Name}", _s);
 		}
 		
-		if(title.indexOf("${OSS ID}") > -1) {
-			if(isMailBodySubject 
+		if (title.indexOf("${OSS ID}") > -1) {
+			if (isMailBodySubject 
 					&& (
 							CoConstDef.CD_MAIL_TYPE_OSS_REGIST.equals(bean.getMsgType()) 
 							|| CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION.equals(bean.getMsgType())
@@ -1446,17 +1446,17 @@ public class CoMailManager extends CoTopComponent {
 		}
 		
 		// 삭제된 이메일에 대한 정보
-		if(title.indexOf("${OSS Before Name}") > -1) {
+		if (title.indexOf("${OSS Before Name}") > -1) {
 			String _s = "";
 			OssMaster ossInfo = null;
 			
-			if(bean.getCompareDataBefore() != null) {
+			if (bean.getCompareDataBefore() != null) {
 				ossInfo = (OssMaster) bean.getCompareDataBefore();
 			}
 			
-			if(ossInfo != null) {
+			if (ossInfo != null) {
 				_s += ossInfo.getOssName();
-				if(!isEmpty(ossInfo.getOssVersion())) {
+				if (!isEmpty(ossInfo.getOssVersion())) {
 					_s += " (" + ossInfo.getOssVersion() +")";
 				}
 			}
@@ -1464,15 +1464,15 @@ public class CoMailManager extends CoTopComponent {
 			title = StringUtil.replace(title, "${OSS Before Name}", _s);
 		}
 		
-		if(title.indexOf("${License Name}") > -1) {
+		if (title.indexOf("${License Name}") > -1) {
 			String _s = "";
 			LicenseMaster licenseInfo = null;
-			if(!isEmpty(bean.getParamLicenseId())) {
+			if (!isEmpty(bean.getParamLicenseId())) {
 				licenseInfo = mailManagerMapper.getLicenseInfoById(bean.getParamLicenseId());
 			}
 			
-			if(licenseInfo != null) {
-				if(title.indexOf("${License ID}") < 0) {
+			if (licenseInfo != null) {
+				if (title.indexOf("${License ID}") < 0) {
 					_s += "(" + bean.getParamLicenseId() +")";
 				}
 				_s += licenseInfo.getLicenseName();
@@ -1491,42 +1491,42 @@ public class CoMailManager extends CoTopComponent {
 			title = StringUtil.replace(title, "${License Name}", _s);
 		}
 		
-		if(title.indexOf("${License ID}") > -1) {
+		if (title.indexOf("${License ID}") > -1) {
 			title = StringUtil.replace(title, "${License ID}", avoidNull(bean.getParamLicenseId()));
 		}
 		
-		if(title.indexOf("${License Before Name}") > -1) {
+		if (title.indexOf("${License Before Name}") > -1) {
 			String _s = "";
 			LicenseMaster licenseInfo = null;
 			
-			if(bean.getCompareDataBefore() != null) {
+			if (bean.getCompareDataBefore() != null) {
 				licenseInfo = (LicenseMaster) bean.getCompareDataBefore();
 			}
-			if(licenseInfo != null) {
+			if (licenseInfo != null) {
 				_s += licenseInfo.getLicenseName();
 			}
 			
 			title = StringUtil.replace(title, "${License Before Name}", _s);
 		}
 		
-		if(title.indexOf("${Project Name}") > -1) {
+		if (title.indexOf("${Project Name}") > -1) {
 			String _s = "";
 			String _s2 = "";
 			String _s3 = "";
 			String _s4 = "";
 			String _s5 = "";
 			Project project = null;
-			if(!isEmpty(bean.getParamPrjId())) {
+			if (!isEmpty(bean.getParamPrjId())) {
 				project = mailManagerMapper.getProjectInfoById(bean.getParamPrjId());
 			}
 			
-			if(project != null) {
-				if(title.indexOf("${Project Name}") > -1) {
-					if(title.indexOf("${Project ID}") < 0) {
+			if (project != null) {
+				if (title.indexOf("${Project Name}") > -1) {
+					if (title.indexOf("${Project ID}") < 0) {
 						_s += "(" + bean.getParamPrjId() +")";
 					}
 					_s += project.getPrjName();
-					if(!isEmpty(project.getPrjVersion())) {
+					if (!isEmpty(project.getPrjVersion())) {
 						_s += " (" + project.getPrjVersion() +")";
 					}
 					
@@ -1534,77 +1534,77 @@ public class CoMailManager extends CoTopComponent {
 					_s = "<a href='"+url+"' target='_blank'>" + _s + "</a>";
 				}
 				
-				if(title.indexOf("${Creator}") > -1) {
+				if (title.indexOf("${Creator}") > -1) {
 					_s2 = avoidNull(makeUserNameFormat(project.getCreator()));
 				}
 				
-				if(title.indexOf("${ReviewerTo}") == -1 
+				if (title.indexOf("${ReviewerTo}") == -1 
 						&& title.indexOf("${Reviewer}") > -1 
 						&& !isEmpty(project.getReviewer())) {
 					_s3 = avoidNull(makeUserNameFormat(project.getReviewer()));
 				}
 				
-				if(title.indexOf("${LastDistributor}") > -1) {
-					if(!isEmpty(project.getDistributeDeployUser())) {
+				if (title.indexOf("${LastDistributor}") > -1) {
+					if (!isEmpty(project.getDistributeDeployUser())) {
 						_s4 = avoidNull(makeUserNameFormat(project.getDistributeDeployUser()));
 					} else {
 						_s4 = avoidNull(makeUserNameFormat(project.getCreator()));
 					}
 				}
 				
-				if(title.indexOf("${Rejector}") > -1 && !isEmpty(project.getDistributeRejector())) {
+				if (title.indexOf("${Rejector}") > -1 && !isEmpty(project.getDistributeRejector())) {
 					_s5 = avoidNull(makeUserNameFormat(project.getDistributeRejector()));
 				}
 			}
 
-			if(title.indexOf("${Project Name}") > -1) {
+			if (title.indexOf("${Project Name}") > -1) {
 				title = StringUtil.replace(title, "${Project Name}", _s);
 			}
 
-			if(title.indexOf("${Creator}") > -1) {
+			if (title.indexOf("${Creator}") > -1) {
 				title = StringUtil.replace(title, "${Creator}", _s2);
 			}
 			
-			if(title.indexOf("${ReviewerTo}") > -1) {
+			if (title.indexOf("${ReviewerTo}") > -1) {
 				String[] toIds = bean.getToIds();
 				title = StringUtil.replace(title, "${Reviewer}", avoidNull(makeUserNameFormat(toIds[0])));
 				title = StringUtil.replace(title, "${ReviewerTo}", avoidNull(makeUserNameFormat(toIds[1])));
 			}
 			
-			if(title.indexOf("${ReviewerTo}") == -1 && title.indexOf("${Reviewer}") > -1) {
+			if (title.indexOf("${ReviewerTo}") == -1 && title.indexOf("${Reviewer}") > -1) {
 				title = StringUtil.replace(title, "${Reviewer}", _s3);
 			}
 			
-			if(title.indexOf("${LastDistributor}") > -1) {
+			if (title.indexOf("${LastDistributor}") > -1) {
 				title = StringUtil.replace(title, "${LastDistributor}", _s4);
 			}
 
-			if(title.indexOf("${Rejector}") > -1) {
+			if (title.indexOf("${Rejector}") > -1) {
 				title = StringUtil.replace(title, "${Rejector}", _s5);
 			}
 			
-			if(title.indexOf("${Project ID}") > -1) {
+			if (title.indexOf("${Project ID}") > -1) {
 				title = StringUtil.replace(title, "${Project ID}", avoidNull(bean.getParamPrjId()));
 			}
 		}
 		
-		if(title.indexOf("${3rd Party Name}") > -1) {
+		if (title.indexOf("${3rd Party Name}") > -1) {
 			String _s = "";
 			String _s2 = "";
 			String _s3 = "";
 			
 			PartnerMaster partnerInfo = null;
-			if(!isEmpty(bean.getParamPartnerId())) {
+			if (!isEmpty(bean.getParamPartnerId())) {
 				partnerInfo = mailManagerMapper.getPartnerInfo(bean.getParamPartnerId());
 			}
 			
-			if(partnerInfo != null) {
-				if(title.indexOf("${3rd Party Name}") > -1) {
-					if(title.indexOf("${3rd Party ID}") < 0) {
+			if (partnerInfo != null) {
+				if (title.indexOf("${3rd Party Name}") > -1) {
+					if (title.indexOf("${3rd Party ID}") < 0) {
 						_s += "(" + bean.getParamPartnerId() +")";
 					}
 					_s += partnerInfo.getPartnerName();
-					if(!isEmpty(partnerInfo.getSoftwareName())) {
+					if (!isEmpty(partnerInfo.getSoftwareName())) {
 						_s += " (" + partnerInfo.getSoftwareName() +")";
 					}
 					
@@ -1612,80 +1612,80 @@ public class CoMailManager extends CoTopComponent {
 					_s = "<a href='" + url + "' target='_blank'>" + _s + "</a>";
 				}
 				
-				if(title.indexOf("${Creator}") > -1) {
+				if (title.indexOf("${Creator}") > -1) {
 					_s2 = avoidNull(makeUserNameFormat(partnerInfo.getCreator()));
 				}
 
-				if(title.indexOf("${Reviewer}") > -1 && !isEmpty(partnerInfo.getReviewer())) {
+				if (title.indexOf("${Reviewer}") > -1 && !isEmpty(partnerInfo.getReviewer())) {
 					_s3 = avoidNull(makeUserNameFormat(partnerInfo.getReviewer()));
 				}
 			}
 
 			
-			if(title.indexOf("${3rd Party Name}") > -1) {
+			if (title.indexOf("${3rd Party Name}") > -1) {
 				title = StringUtil.replace(title, "${3rd Party Name}", _s);
 			}
 
-			if(title.indexOf("${Creator}") > -1) {
+			if (title.indexOf("${Creator}") > -1) {
 				title = StringUtil.replace(title, "${Creator}", _s2);
 			}
 			
-			if(title.indexOf("${Reviewer}") > -1) {
+			if (title.indexOf("${Reviewer}") > -1) {
 				title = StringUtil.replace(title, "${Reviewer}", _s3);
 			}
 			
-			if(title.indexOf("${3rd Party ID}") > -1) {
+			if (title.indexOf("${3rd Party ID}") > -1) {
 				title = StringUtil.replace(title, "${3rd Party ID}", avoidNull(bean.getParamPartnerId()));
 			}
 		}
 		
-		if(title.indexOf("${Binary Name}") > -1) {
+		if (title.indexOf("${Binary Name}") > -1) {
 			String _s = "";
 			BinaryMaster binaryInfo = null;
-			if(!isEmpty(bean.getParamBatId())) {
+			if (!isEmpty(bean.getParamBatId())) {
 				binaryInfo = mailManagerMapper.getBinaryInfo(bean.getParamBatId());
-				if(title.indexOf("${Binary ID}") < 0) {
+				if (title.indexOf("${Binary ID}") < 0) {
 					_s = "(" + bean.getParamBatId() + ")";
 				}
 			}
 			
-			if(binaryInfo != null) {
+			if (binaryInfo != null) {
 				_s += binaryInfo.getBinaryFileName();
 			}
 			
 			title = StringUtil.replace(title, "${Binary Name}", _s);
 			
-			if(title.indexOf("${Binary ID}") > -1) {
+			if (title.indexOf("${Binary ID}") > -1) {
 				title = StringUtil.replace(title, "${Binary ID}", avoidNull(bean.getParamBatId()));
 			}
 		}
 		
 
-		if(title.indexOf("${Email}") > -1) {
+		if (title.indexOf("${Email}") > -1) {
 			String _convEmail = avoidNull(bean.getParamEmail());
 
 			title = StringUtil.replace(title, "${Email}", _convEmail);
 		}
 		
-		if(title.indexOf("${Copied Project ID}") > -1) {
+		if (title.indexOf("${Copied Project ID}") > -1) {
 			Project projectInfo = (Project) bean.getCompareDataBefore();
 
 			title = StringUtil.replace(title, "${Copied Project ID}", projectInfo.getPrjId());
 			title = StringUtil.replace(title, "${Copied Project Name}", projectInfo.getPrjName());
 		}
 		
-		if(CoConstDef.CD_MAIL_PACKAGING_UPLOAD_SUCCESS.equals(bean.getMsgType())
+		if (CoConstDef.CD_MAIL_PACKAGING_UPLOAD_SUCCESS.equals(bean.getMsgType())
 				|| CoConstDef.CD_MAIL_PACKAGING_UPLOAD_FAILURE.equals(bean.getMsgType())) {
-			if(title.indexOf("${File Name}") > -1) {
+			if (title.indexOf("${File Name}") > -1) {
 				title = StringUtil.replace(title, "${File Name}", bean.getParamExpansion1()); // file name set
 			}
 
-			if(title.indexOf("${Project ID}") > -1) {
+			if (title.indexOf("${Project ID}") > -1) {
 				title = StringUtil.replace(title, "${Project ID}", bean.getParamPrjId());
 			}
 		}
 		
-		if(title.indexOf("${BinaryCommitResult}") > -1) {
+		if (title.indexOf("${BinaryCommitResult}") > -1) {
 			title = StringUtil.replace(title, "${BinaryCommitResult}", bean.getBinaryCommitResult());
 		}
 		
@@ -1694,13 +1694,13 @@ public class CoMailManager extends CoTopComponent {
 
 	private Map<String, Object> convertModifiedData(Map<String, Object> convertDataMap, String msgType) {
 		boolean isModified = false;
-		if(CoConstDef.CD_MAIL_TYPE_OSS_UPDATE.equals(msgType)
+		if (CoConstDef.CD_MAIL_TYPE_OSS_UPDATE.equals(msgType)
 				|| CoConstDef.CD_MAIL_TYPE_ADDNICKNAME_UPDATE.equals(msgType)
 				|| CoConstDef.CD_MAIL_TYPE_OSS_CHANGE_NAME.equals(msgType)
 				|| CoConstDef.CD_MAIL_TYPE_OSS_RENAME.equals(msgType)
 				) {
 			
-			if(CoConstDef.CD_MAIL_TYPE_OSS_RENAME.equals(msgType)) {
+			if (CoConstDef.CD_MAIL_TYPE_OSS_RENAME.equals(msgType)) {
 				isModified = true;
 			}
 			OssMaster before = (OssMaster) convertDataMap.get("before");
@@ -1715,7 +1715,7 @@ public class CoMailManager extends CoTopComponent {
 			
 			after.setOssName(appendChangeStyleMultiLine(before.getOssName(), after.getOssName()));
 			isModified = checkEquals(before.getOssName(), after.getOssName(), isModified);
-			if(before.getOssNicknames() != null || after.getOssNicknames() != null) {
+			if (before.getOssNicknames() != null || after.getOssNicknames() != null) {
 				List<String> _beforeList = before.getOssNicknames() == null ? new ArrayList<>() : Arrays.asList(before.getOssNicknames());
 				List<String> _afterList = after.getOssNicknames() == null ? new ArrayList<>() : Arrays.asList(after.getOssNicknames());
 				
@@ -1730,16 +1730,16 @@ public class CoMailManager extends CoTopComponent {
 				List<String> delList = new ArrayList<>();
 				
 				// 삭제 여부 체크
-				for(String s : _newBeforeList) {
-					if(!isEmpty(s) && !_newAfterList.contains(s)) {
+				for (String s : _newBeforeList) {
+					if (!isEmpty(s) && !_newAfterList.contains(s)) {
 						delList.add(s);
 						//_newAfterList.add(idx, "");
 						isModified = true;
 					}
 				}
 				// 추가 여부 체크
-				for(String s : _newAfterList) {
-					if(!isEmpty(s) && !_newBeforeList.contains(s)) {
+				for (String s : _newAfterList) {
+					if (!isEmpty(s) && !_newBeforeList.contains(s)) {
 						addList.add(s);
 						//_newBeforeList.add(idx, "");
 						isModified = true;
@@ -1755,11 +1755,11 @@ public class CoMailManager extends CoTopComponent {
 
 				List<String> _finalBeforeList = new ArrayList<>();
 				List<String> _finalAfterList = new ArrayList<>();
-				for(String s : mergeList) {
-					if(delList.contains(s)) {
+				for (String s : mergeList) {
+					if (delList.contains(s)) {
 						_finalBeforeList.add(appendChangeStyleMultiLine(s, ""));
 						_finalAfterList.add("");
-					} else if(addList.contains(s)) {
+					} else if (addList.contains(s)) {
 						_finalAfterList.add(appendChangeStyleMultiLine("", s));
 						_finalBeforeList.add("");
 					} else {
@@ -1780,16 +1780,16 @@ public class CoMailManager extends CoTopComponent {
 			isModified = checkEquals(before.getOssVersion(), after.getOssVersion(), isModified);
 			after.setLicenseName(appendChangeStyleMultiLine(before.getLicenseName(), after.getLicenseName()));
 			isModified = checkEquals(before.getLicenseName(), after.getLicenseName(), isModified);
-			if(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_DIV, "M").equals(after.getLicenseDiv())){ // multi license일때 만
+			if (CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_DIV, "M").equals(after.getLicenseDiv())){ // multi license일때 만
 				List<OssLicense> beforeLicenses = before.getOssLicenses();
 				List<OssLicense> afterLicenses = after.getOssLicenses();
 				int len = beforeLicenses.size() > afterLicenses.size() ? beforeLicenses.size() : afterLicenses.size();
 
-				for(int i = 0 ; i < len ; i++){
+				for (int i = 0 ; i < len ; i++){
 					boolean isBefore = beforeLicenses.size() > i;
 					boolean isAfter = afterLicenses.size() > i;
 					
-					if(isBefore && isAfter){ // 수정시
+					if (isBefore && isAfter){ // 수정시
 						OssLicense beforeLicense = beforeLicenses.get(i);
 						OssLicense afterLicense = afterLicenses.get(i);
 						
@@ -1800,7 +1800,7 @@ public class CoMailManager extends CoTopComponent {
 						
 						afterLicenses.set(i, afterLicense);
 						
-					}else if(!isBefore && isAfter) { // 신규 등록시
+					}else if (!isBefore && isAfter) { // 신규 등록시
 						OssLicense afterLicense = afterLicenses.get(i);
 						
 						afterLicense.setOssLicenseComb(appendChangeStyle("", afterLicense.getOssLicenseComb()));
@@ -1809,7 +1809,7 @@ public class CoMailManager extends CoTopComponent {
 						isModified = checkEquals("", afterLicense.getOssCopyright(), isModified);
 						
 						afterLicenses.set(i, afterLicense);
-					}else if(isBefore && !isAfter){ // 삭제시
+					}else if (isBefore && !isAfter){ // 삭제시
 						OssLicense beforeLicense = beforeLicenses.get(i);
 						OssLicense afterLicense = new OssLicense(); 
 						
@@ -1842,7 +1842,7 @@ public class CoMailManager extends CoTopComponent {
 			String beforeDetectedLicense = before.getDetectedLicense();
 			String afterDetectedLicense = after.getDetectedLicense();
 			
-			if(!isEmpty(beforeDetectedLicense) || !isEmpty(afterDetectedLicense)) {
+			if (!isEmpty(beforeDetectedLicense) || !isEmpty(afterDetectedLicense)) {
 				List<String> _beforeList = Arrays.asList(beforeDetectedLicense.split(","));
 				List<String> _afterList = Arrays.asList(afterDetectedLicense.split(","));
 
@@ -1853,21 +1853,21 @@ public class CoMailManager extends CoTopComponent {
 				List<String> delList = new ArrayList<>();
 				
 				// 삭제 여부 체크
-				for(String s : _beforeList) {
-					if(!isEmpty(s) && !_afterList.contains(s)) {
+				for (String s : _beforeList) {
+					if (!isEmpty(s) && !_afterList.contains(s)) {
 						delList.add(s);
 						isModified = true;
 					}
 				}
 				// 추가 여부 체크
-				for(String s : _afterList) {
-					if(!isEmpty(s) && !_beforeList.contains(s)) {
+				for (String s : _afterList) {
+					if (!isEmpty(s) && !_beforeList.contains(s)) {
 						addList.add(s);
 						isModified = true;
 					}
 				}
 				
-				if(_beforeList.size() != _afterList.size()) {
+				if (_beforeList.size() != _afterList.size()) {
 					isModified = true;
 				}
 				
@@ -1880,11 +1880,11 @@ public class CoMailManager extends CoTopComponent {
 				List<String> _finalBeforeList = new ArrayList<>();
 				List<String> _finalAfterList = new ArrayList<>();
 				
-				for(String s : mergeList) {
-					if(!isEmpty(s)) {
-						if(delList.contains(s)) {						
+				for (String s : mergeList) {
+					if (!isEmpty(s)) {
+						if (delList.contains(s)) {						
 							_finalBeforeList.add(appendChangeStyleMultiLine(s, ""));
-						} else if(addList.contains(s)) {
+						} else if (addList.contains(s)) {
 							_finalAfterList.add(appendChangeStyleMultiLine("", s));
 						} else {
 							_finalBeforeList.add(s);
@@ -1901,14 +1901,14 @@ public class CoMailManager extends CoTopComponent {
 			}
 			
 			//데이터 변경 없을시
-			if(!isModified){
+			if (!isModified){
 				convertDataMap.replace("isModify", true);
 			}
 			
 			convertDataMap.replace("before", before);
 			convertDataMap.replace("after", after);
 			// oss modify
-		} else if(CoConstDef.CD_MAIL_TYPE_LICENSE_UPDATE.equals(msgType) || CoConstDef.CD_MAIL_TYPE_LICENSE_RENAME.equals(msgType)) {
+		} else if (CoConstDef.CD_MAIL_TYPE_LICENSE_UPDATE.equals(msgType) || CoConstDef.CD_MAIL_TYPE_LICENSE_RENAME.equals(msgType)) {
 			// license modify
 			LicenseMaster before = (LicenseMaster) convertDataMap.get("before");
 			LicenseMaster after = (LicenseMaster) convertDataMap.get("after");
@@ -1924,7 +1924,7 @@ public class CoMailManager extends CoTopComponent {
 			isModified = checkEquals(before.getLicenseName(), after.getLicenseName(), isModified);
 			after.setShortIdentifier(appendChangeStyle(before.getShortIdentifier(), after.getShortIdentifier()));
 			isModified = checkEquals(before.getShortIdentifier(), after.getShortIdentifier(), isModified);
-			if(before.getLicenseNicknames() != null || after.getLicenseNicknames() != null) {
+			if (before.getLicenseNicknames() != null || after.getLicenseNicknames() != null) {
 				List<String> _beforeList = before.getLicenseNicknames() == null ? new ArrayList<>() : Arrays.asList(before.getLicenseNicknames());
 				List<String> _afterList = after.getLicenseNicknames() == null ? new ArrayList<>() : Arrays.asList(after.getLicenseNicknames());
 				
@@ -1935,12 +1935,12 @@ public class CoMailManager extends CoTopComponent {
 				Collections.sort(_afterList);
 				
 				// 갯수를 맞춰서 정렬
-				if(_beforeList.size() < _afterList.size()) {
-					for(int i=_beforeList.size(); i<_afterList.size(); i++) {
+				if (_beforeList.size() < _afterList.size()) {
+					for (int i=_beforeList.size(); i<_afterList.size(); i++) {
 						_newBeforeList.add("");
 					}
-				} else if(_afterList.size() < _beforeList.size()) {
-					for(int i=_afterList.size(); i<_beforeList.size(); i++) {
+				} else if (_afterList.size() < _beforeList.size()) {
+					for (int i=_afterList.size(); i<_beforeList.size(); i++) {
 						_newAfterList.add("");
 					}
 				}
@@ -1949,9 +1949,9 @@ public class CoMailManager extends CoTopComponent {
 				_afterList = _newAfterList;
 				
 				// delete case
-				for(int i=0; i<_beforeList.size(); i++) {
+				for (int i=0; i<_beforeList.size(); i++) {
 					String s = _beforeList.get(i);
-					if(!isEmpty(s) && !s.equals(_afterList.get(i))) {
+					if (!isEmpty(s) && !s.equals(_afterList.get(i))) {
 						// 동일한 position에 값이 다른 경우 삭제로 판단
 						_newAfterList.add(i, "");
 						_newBeforeList.add(""); // size를 맞춰준다.
@@ -1962,9 +1962,9 @@ public class CoMailManager extends CoTopComponent {
 				_afterList = _newAfterList;
 				
 				// add
-				for(int i=0; i<_afterList.size(); i++) {
+				for (int i=0; i<_afterList.size(); i++) {
 					String s = _afterList.get(i);
-					if(!isEmpty(s) && !s.equals(_beforeList.get(i))) {
+					if (!isEmpty(s) && !s.equals(_beforeList.get(i))) {
 						_newBeforeList.add(i, "");
 						appendChangeStyle(_newAfterList.get(i));
 						isModified = true;
@@ -1977,15 +1977,15 @@ public class CoMailManager extends CoTopComponent {
 				_afterList = _newAfterList;
 				
 				// before and after 모두 공백인 row는 삭제
-				for(int i=0; i<_beforeList.size(); i++) {
-					if(isEmpty(_beforeList.get(i)) && isEmpty(_afterList.get(i))) {
+				for (int i=0; i<_beforeList.size(); i++) {
+					if (isEmpty(_beforeList.get(i)) && isEmpty(_afterList.get(i))) {
 						_newBeforeList.remove(i);
 						_newAfterList.remove(i);
 					}
 				}
 				
-				for(int i=0; i<_newBeforeList.size(); i++) {
-					if(isEmpty(_newAfterList.get(i))){
+				for (int i=0; i<_newBeforeList.size(); i++) {
+					if (isEmpty(_newAfterList.get(i))){
 						_newBeforeList.set(i, appendChangeStyle(_newBeforeList.get(i), _newAfterList.get(i)));
 					}else{
 						_newAfterList.set(i, appendChangeStyle(_newBeforeList.get(i), _newAfterList.get(i)));
@@ -2016,7 +2016,7 @@ public class CoMailManager extends CoTopComponent {
 			after.setLicenseText(appendChangeStyleMultiLine(before.getLicenseText(), after.getLicenseText(), true));
 			isModified = checkEquals(before.getLicenseText(), after.getLicenseText(), isModified);
 			
-			if(before.getRestriction() != null || after.getRestriction() != null) {
+			if (before.getRestriction() != null || after.getRestriction() != null) {
 				List<String> _beforeList = before.getRestriction() == null ? new ArrayList<>() : Arrays.asList(before.getRestriction().split(","));
 				List<String> _afterList = after.getRestriction() == null ? new ArrayList<>() : Arrays.asList(after.getRestriction().split(","));
 				
@@ -2024,20 +2024,20 @@ public class CoMailManager extends CoTopComponent {
 				List<String> _newBeforeList = new ArrayList<>();
 				List<String> _newAfterList = new ArrayList<>();
 				
-				for(String cd : CoCodeManager.getCodes(CoConstDef.CD_LICENSE_RESTRICTION)) {
+				for (String cd : CoCodeManager.getCodes(CoConstDef.CD_LICENSE_RESTRICTION)) {
 					// 둘다 없으면 변경사항 없음
-					if(!_beforeList.contains(cd) && !_afterList.contains(cd)) {
+					if (!_beforeList.contains(cd) && !_afterList.contains(cd)) {
 						continue;
 					}
 					
 					// add
-					if(!_beforeList.contains(cd) && _afterList.contains(cd)) {
+					if (!_beforeList.contains(cd) && _afterList.contains(cd)) {
 						_newBeforeList.add("");
 						_newAfterList.add(changeStyle(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, cd), "mod"));
 						isModified = true;
 					}
 					// delete
-					else if(_beforeList.contains(cd) && !_afterList.contains(cd)) {
+					else if (_beforeList.contains(cd) && !_afterList.contains(cd)) {
 						_newBeforeList.add(changeStyle(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, cd), "del", true));
 						_newBeforeList.add("");
 						isModified = true;
@@ -2058,14 +2058,14 @@ public class CoMailManager extends CoTopComponent {
 			}
 			
 			//데이터 변경 없을시
-			if(!isModified){
+			if (!isModified){
 				convertDataMap.replace("isModify", true);
 			}
 			
 			convertDataMap.replace("before", before);
 			convertDataMap.replace("after", after);
 			
-		} else if(CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED.equals(msgType)||CoConstDef.CD_MAIL_TYPE_PROJECT_COPIED.equals(msgType)) {
+		} else if (CoConstDef.CD_MAIL_TYPE_PROJECT_CHANGED.equals(msgType)||CoConstDef.CD_MAIL_TYPE_PROJECT_COPIED.equals(msgType)) {
 			// Project modify
 			Project before = (Project) convertDataMap.get("before");
 			Project after = (Project) convertDataMap.get("after");
@@ -2095,11 +2095,11 @@ public class CoMailManager extends CoTopComponent {
 			after.setDivision(appendChangeStyle(before.getDivision(), after.getDivision()));
 			
 
-			if(before.getModelList().size() > 0 || after.getModelList().size() > 0) {
+			if (before.getModelList().size() > 0 || after.getModelList().size() > 0) {
 
 				List<String> _beforeList = new ArrayList<>();
-				if(before.getModelList().size() > 0){
-					for(int i=0; i < before.getModelList().size(); i++){
+				if (before.getModelList().size() > 0){
+					for (int i=0; i < before.getModelList().size(); i++){
 						String categoryName = CommonFunction.makeCategoryFormat(before.getDistributeTarget(),before.getModelList().get(i).getCategory());
 						String before_str = categoryName+"/"+before.getModelList().get(i).getModelName()+"/"+before.getModelList().get(i).getReleaseDate();
 						_beforeList.add(before_str);
@@ -2107,8 +2107,8 @@ public class CoMailManager extends CoTopComponent {
 				}
 						 
 				List<String> _afterList = new ArrayList<>();
-				if(after.getModelList().size() > 0){
-					for(int i=0; i < after.getModelList().size(); i++){
+				if (after.getModelList().size() > 0){
+					for (int i=0; i < after.getModelList().size(); i++){
 						String categoryName = CommonFunction.makeCategoryFormat(after.getDistributeTarget(),after.getModelList().get(i).getCategory());
 						String after_str = categoryName+"/"+after.getModelList().get(i).getModelName()+"/"+after.getModelList().get(i).getReleaseDate();
 						_afterList.add(after_str);
@@ -2122,12 +2122,12 @@ public class CoMailManager extends CoTopComponent {
 				Collections.sort(_afterList);
 				
 				// 갯수를 맞춰서 정렬
-				if(_beforeList.size() < _afterList.size()) {
-					for(int i=_beforeList.size(); i<_afterList.size(); i++) {
+				if (_beforeList.size() < _afterList.size()) {
+					for (int i=_beforeList.size(); i<_afterList.size(); i++) {
 						_newBeforeList.add("");
 					}
-				} else if(_afterList.size() < _beforeList.size()) {
-					for(int i=_afterList.size(); i<_beforeList.size(); i++) {
+				} else if (_afterList.size() < _beforeList.size()) {
+					for (int i=_afterList.size(); i<_beforeList.size(); i++) {
 						_newAfterList.add("");
 					}
 				}
@@ -2137,9 +2137,9 @@ public class CoMailManager extends CoTopComponent {
 
 				// delete case
 				int b_size = _beforeList.size();
-				for(int i=0; i<b_size; i++) {
+				for (int i=0; i<b_size; i++) {
 					String s = _beforeList.get(i);
-					if(!isEmpty(s) && !s.equals(_afterList.get(i))) {
+					if (!isEmpty(s) && !s.equals(_afterList.get(i))) {
 						// 동일한 position에 값이 다른 경우 삭제로 판단
 						_newAfterList.add(i, "");
 						_newBeforeList.add(i+1,""); // size를 맞춰준다.
@@ -2151,10 +2151,10 @@ public class CoMailManager extends CoTopComponent {
 				
 				// add
 				int a_size = _afterList.size();
-				for(int i=0; i<a_size; i++) {
+				for (int i=0; i<a_size; i++) {
 					String s = _afterList.get(i);
-					if(!isEmpty(s) && !s.equals(_beforeList.get(i))) {
-						if(!isEmpty(_beforeList.get(i))){
+					if (!isEmpty(s) && !s.equals(_beforeList.get(i))) {
+						if (!isEmpty(_beforeList.get(i))){
 							_newBeforeList.add(i, "");
 							appendChangeStyle(_newAfterList.get(i));
 							isModified = true;
@@ -2167,15 +2167,15 @@ public class CoMailManager extends CoTopComponent {
 				_afterList = _newAfterList;
 				
 				// before and after 모두 공백인 row는 삭제
-				for(int i=0; i<_beforeList.size(); i++) {
-					if(isEmpty(_beforeList.get(i)) && isEmpty(_afterList.get(i))) {
+				for (int i=0; i<_beforeList.size(); i++) {
+					if (isEmpty(_beforeList.get(i)) && isEmpty(_afterList.get(i))) {
 						_newBeforeList.remove(i);
 						_newAfterList.remove(i);
 					}
 				}
 
-				for(int i=0; i<_newBeforeList.size(); i++) {
-					if(isEmpty(_newAfterList.get(i))){
+				for (int i=0; i<_newBeforeList.size(); i++) {
+					if (isEmpty(_newAfterList.get(i))){
 						_newBeforeList.set(i, appendChangeStyle(_newBeforeList.get(i), _newAfterList.get(i)));
 					}else{
 						_newAfterList.set(i, appendChangeStyle(_newBeforeList.get(i), _newAfterList.get(i)));
@@ -2189,13 +2189,13 @@ public class CoMailManager extends CoTopComponent {
 				after.setModelListInfo(_newAfterList);
 			}
 			//watcher
-			if(before.getWatcherList().size() > 0 || after.getWatchers() != null) {
+			if (before.getWatcherList().size() > 0 || after.getWatchers() != null) {
 
 				List<String> _beforeList = new ArrayList<>();
-				if(before.getWatcherList().size() > 0){
-					for(int i=0; i < before.getWatcherList().size(); i++){
+				if (before.getWatcherList().size() > 0){
+					for (int i=0; i < before.getWatcherList().size(); i++){
 						String before_str = "";
-						if(isEmpty(before.getWatcherList().get(i).getPrjEmail())){
+						if (isEmpty(before.getWatcherList().get(i).getPrjEmail())){
 							before_str = makeUserNameFormatWithDivision(before.getWatcherList().get(i).getPrjDivision(), before.getWatcherList().get(i).getPrjUserId());
 						}else{
 							before_str = before.getWatcherList().get(i).getPrjEmail();
@@ -2206,11 +2206,11 @@ public class CoMailManager extends CoTopComponent {
 
 				List<String> _afterList = new ArrayList<>();
 				String[] watchers = after.getWatchers();
-				if(watchers != null && watchers.length > 0){
-					for(int i=0; i < watchers.length; i++){
+				if (watchers != null && watchers.length > 0){
+					for (int i=0; i < watchers.length; i++){
 						String[] after_array = watchers[i].split("/");
 						String after_str = "";
-						if("Email".equals(after_array[1])){
+						if ("Email".equals(after_array[1])){
 							after_str = after_array[0];
 						}else{
 							after_str = makeUserNameFormatWithDivision(after_array[0], after_array[1]);
@@ -2226,12 +2226,12 @@ public class CoMailManager extends CoTopComponent {
 				Collections.sort(_afterList);
 				
 				// 갯수를 맞춰서 정렬
-				if(_beforeList.size() < _afterList.size()) {
-					for(int i=_beforeList.size(); i<_afterList.size(); i++) {
+				if (_beforeList.size() < _afterList.size()) {
+					for (int i=_beforeList.size(); i<_afterList.size(); i++) {
 						_newBeforeList.add("");
 					}
-				} else if(_afterList.size() < _beforeList.size()) {
-					for(int i=_afterList.size(); i<_beforeList.size(); i++) {
+				} else if (_afterList.size() < _beforeList.size()) {
+					for (int i=_afterList.size(); i<_beforeList.size(); i++) {
 						_newAfterList.add("");
 					}
 				}
@@ -2241,9 +2241,9 @@ public class CoMailManager extends CoTopComponent {
 
 				// delete case
 				int b_size = _beforeList.size();
-				for(int i=0; i<b_size; i++) {
+				for (int i=0; i<b_size; i++) {
 					String s = _beforeList.get(i);
-					if(!isEmpty(s) && !s.equals(_afterList.get(i))) {
+					if (!isEmpty(s) && !s.equals(_afterList.get(i))) {
 						// 동일한 position에 값이 다른 경우 삭제로 판단
 						_newAfterList.add(i, "");
 						_newBeforeList.add(i+1,""); // size를 맞춰준다.
@@ -2255,10 +2255,10 @@ public class CoMailManager extends CoTopComponent {
 				
 				// add
 				int a_size = _afterList.size();
-				for(int i=0; i<a_size; i++) {
+				for (int i=0; i<a_size; i++) {
 					String s = _afterList.get(i);
-					if(!isEmpty(s) && !s.equals(_beforeList.get(i))) {
-						if(!isEmpty(_beforeList.get(i))){
+					if (!isEmpty(s) && !s.equals(_beforeList.get(i))) {
+						if (!isEmpty(_beforeList.get(i))){
 							_newBeforeList.add(i, "");
 							appendChangeStyle(_newAfterList.get(i));
 							isModified = true;
@@ -2271,15 +2271,15 @@ public class CoMailManager extends CoTopComponent {
 				_afterList = _newAfterList;
 				
 				// before and after 모두 공백인 row는 삭제
-				for(int i=0; i<_beforeList.size(); i++) {
-					if(isEmpty(_beforeList.get(i)) && isEmpty(_afterList.get(i))) {
+				for (int i=0; i<_beforeList.size(); i++) {
+					if (isEmpty(_beforeList.get(i)) && isEmpty(_afterList.get(i))) {
 						_newBeforeList.remove(i);
 						_newAfterList.remove(i);
 					}
 				}
 
-				for(int i=0; i<_newBeforeList.size(); i++) {
-					if(isEmpty(_newAfterList.get(i))){
+				for (int i=0; i<_newBeforeList.size(); i++) {
+					if (isEmpty(_newAfterList.get(i))){
 						_newBeforeList.set(i, appendChangeStyle(_newBeforeList.get(i), _newAfterList.get(i)));
 					}else{
 						_newAfterList.set(i, appendChangeStyle(_newBeforeList.get(i), _newAfterList.get(i)));
@@ -2294,43 +2294,43 @@ public class CoMailManager extends CoTopComponent {
 			}
 			
 			//데이터 변경 없을시
-			if(!isModified){
+			if (!isModified){
 				convertDataMap.replace("isModify", true);
 			}
 			
 			convertDataMap.replace("before", before);
 			convertDataMap.replace("after", after);
-		}else if(CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION.equals(msgType)) {
+		}else if (CoConstDef.CD_MAIL_TYPE_OSS_REGIST_NEWVERSION.equals(msgType)) {
 			OssMaster om = (OssMaster) convertDataMap.get("paramOssInfo");
 						
-			if(om != null) {
+			if (om != null) {
 				List<String> checkOssNickNamesAdd = new ArrayList<>();
 				
-				if(om.getOssNicknames() != null && om.getOssNicknames().length > 0) {
-					if(om.getExistOssNickNames() != null && om.getExistOssNickNames().length > 0) {
+				if (om.getOssNicknames() != null && om.getOssNicknames().length > 0) {
+					if (om.getExistOssNickNames() != null && om.getExistOssNickNames().length > 0) {
 						checkOssNickNamesAdd = Arrays.asList(om.getOssNicknames()).stream().filter(x -> !Arrays.asList(om.getExistOssNickNames()).contains(x)).collect(Collectors.toList());
 					}else {
 						checkOssNickNamesAdd = Arrays.asList(om.getOssNicknames());
 					}
 				}
 				
-				if(checkOssNickNamesAdd != null && checkOssNickNamesAdd.size() > 0) {
+				if (checkOssNickNamesAdd != null && checkOssNickNamesAdd.size() > 0) {
 					String changeOssNickName = "";
 					
-					if(om.getExistOssNickNames() != null && om.getExistOssNickNames().length > 0) {
-						for(String nickName : om.getExistOssNickNames()) {
+					if (om.getExistOssNickNames() != null && om.getExistOssNickNames().length > 0) {
+						for (String nickName : om.getExistOssNickNames()) {
 							changeOssNickName += nickName + "<br/>";
 						}
 					}
 					
-					for(String ossNickName : checkOssNickNamesAdd) {
-						if(!isEmpty(ossNickName)) {
+					for (String ossNickName : checkOssNickNamesAdd) {
+						if (!isEmpty(ossNickName)) {
 							ossNickName = appendChangeStyle("newVersion_ossNickNameAdd", ossNickName);
 							changeOssNickName += ossNickName + "<br/>";
 						}
 					}
 					
-					if(!isEmpty(changeOssNickName)) {
+					if (!isEmpty(changeOssNickName)) {
 						OssMaster ossBasicInfo = (OssMaster) convertDataMap.get("oss_basic_info");
 						ossBasicInfo.setOssNickname(changeOssNickName);
 						convertDataMap.replace("oss_basic_info", ossBasicInfo);
@@ -2343,7 +2343,7 @@ public class CoMailManager extends CoTopComponent {
 
 
 	private boolean checkEquals(String before, String after, boolean isModified) {
-		if(isModified) {
+		if (isModified) {
 			return isModified;
 		}
 		return !avoidNull(before).equals(after);
@@ -2357,8 +2357,8 @@ public class CoMailManager extends CoTopComponent {
 		String[] downloadLocation = avoidNull(downloadLocations).split(",");
 		String result = "";
 		
-		for(int idx = 0; idx < downloadLocation.length; idx++){
-			if(idx > 0){
+		for (int idx = 0; idx < downloadLocation.length; idx++){
+			if (idx > 0){
 				result += "<br>";
 			}
 			
@@ -2377,10 +2377,10 @@ public class CoMailManager extends CoTopComponent {
 		String beforeVal = (before.length > seq ? before[seq] : "");
 		String afterVal = (after.length > seq ? after[seq] : "");
 		
-		if(length == seq) {
+		if (length == seq) {
 			return result;
 		} else {
-			if(seq > 0) {
+			if (seq > 0) {
 				result = "<br>";
 			}
 		}
@@ -2393,8 +2393,8 @@ public class CoMailManager extends CoTopComponent {
 	private String appendChangeStyle(String before, String after) {
 		before = avoidNull(before).trim();
 		after = avoidNull(after).trim();
-		if(!avoidNull(before).equals(after)) {
-			if(isEmpty(after)){
+		if (!avoidNull(before).equals(after)) {
+			if (isEmpty(after)){
 				after = changeStyle(before,"del");
 			}else{
 				after = changeStyle(after,"mod");
@@ -2416,25 +2416,25 @@ public class CoMailManager extends CoTopComponent {
         List<String> udiff = DiffUtils.generateUnifiedDiff("original", "revised",
                 original, patch, 100);
         // 변경된 부분이 있다면, after에 삭제와 추가를 모푸 포함해서 return 한다.
-        if(udiff != null && udiff.size() > 0) {
+        if (udiff != null && udiff.size() > 0) {
         	String changeStr = "";
         	int ignoreIdx = 0;
-        	for(String s : udiff) {
-        		if(ignoreIdx < 3) {
+        	for (String s : udiff) {
+        		if (ignoreIdx < 3) {
             		ignoreIdx ++;
         			continue;
         		}
         		
         		// flag를 받아서 필요한 영역에서만 br tag를 넣음
-        		if(!isEmpty(changeStr) && brFlag) {
+        		if (!isEmpty(changeStr) && brFlag) {
         			changeStr += "<br/>";
         		}
         		
         		String changeMode = s.substring(0, 1);
         		String str = s.substring(1);
-        		if("+".equals(changeMode)) {
+        		if ("+".equals(changeMode)) {
         			changeStr += changeStyle(str,"mod", true);
-        		} else if("-".equals(changeMode)) {
+        		} else if ("-".equals(changeMode)) {
         			changeStr += changeStyle(str,"del", true);
         		} else {
         			changeStr += str;
@@ -2451,8 +2451,8 @@ public class CoMailManager extends CoTopComponent {
 	private String appendChangeStyleDiv(String before, String after) {
 		before = avoidNull(before).trim();
 		after = avoidNull(after).trim();
-		if(!avoidNull(before).equals(after)) {
-			if(isEmpty(after)){
+		if (!avoidNull(before).equals(after)) {
+			if (isEmpty(after)){
 				after = changeStyleDiv(before,"del");
 			}else{
 				after = changeStyleDiv(after,"mod");
@@ -2471,13 +2471,13 @@ public class CoMailManager extends CoTopComponent {
 	
 	private String changeStyle(String s, String tp, boolean useLineDeco) {
 		String appendHtml = "";
-		if(tp == "del"){
-			if(useLineDeco) {
+		if (tp == "del"){
+			if (useLineDeco) {
 				appendHtml = "<span style=\"background-color:red;text-decoration:line-through;\">" + s + "</span>";
 			} else {
 				appendHtml = "<span style=\"background-color:red\">" + s + "</span>";
 			}
-		}else if(tp == "mod"){
+		}else if (tp == "mod"){
 			appendHtml = "<span style=\"background-color:yellow\">" + s + "</span>";
 		}
 		return appendHtml;
@@ -2491,18 +2491,18 @@ public class CoMailManager extends CoTopComponent {
 	 */
 	private String changeStyleDiv(String s, String tp) {
 		String appendHtml = "";
-		if(tp == "del"){
+		if (tp == "del"){
 			appendHtml = "<div style=\"background-color:red\">" + s + "</div>";
-		}else if(tp == "mod"){
+		}else if (tp == "mod"){
 			appendHtml = "<div style=\"background-color:yellow\">" + s + "</div>";
 		}
 		return appendHtml;
 	}
 
 	private String getTemplateFilePath(String msgType) {
-		for(String s : CoCodeManager.getCodes(CoConstDef.CD_MAIL_COMPONENT_TEMPLATE)) {
-			for(String type : CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_COMPONENT_TEMPLATE, s).split(",")) {
-				if(msgType.equals(type.trim())) {
+		for (String s : CoCodeManager.getCodes(CoConstDef.CD_MAIL_COMPONENT_TEMPLATE)) {
+			for (String type : CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_COMPONENT_TEMPLATE, s).split(",")) {
+				if (msgType.equals(type.trim())) {
 					return "/template/email/" + CoCodeManager.getCodeString(CoConstDef.CD_MAIL_COMPONENT_TEMPLATE, s);
 				}
 			}
@@ -2512,7 +2512,7 @@ public class CoMailManager extends CoTopComponent {
 
 	private String makeUserNameFormat(T2Users userInfo) {
 		String rtn = "";
-		if(userInfo != null) {
+		if (userInfo != null) {
 			rtn += avoidNull(userInfo.getUserName());
 			rtn += "(" + avoidNull(userInfo.getUserId()) + ")";
 		}
@@ -2521,10 +2521,10 @@ public class CoMailManager extends CoTopComponent {
 	
 	private String makeUserNameFormatWithDivision(T2Users userInfo) {
 		String rtn = "";
-		if(userInfo != null) {
-			if(!isEmpty(userInfo.getDivision())) {
+		if (userInfo != null) {
+			if (!isEmpty(userInfo.getDivision())) {
 				String _division = CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, userInfo.getDivision());
-				if(!isEmpty(_division)) {
+				if (!isEmpty(_division)) {
 					rtn += _division + " ";
 				}
 			}
@@ -2535,7 +2535,7 @@ public class CoMailManager extends CoTopComponent {
 	}
 	
 	public String makeUserNameFormat(String userId) {
-		if(isEmpty(userId)) {
+		if (isEmpty(userId)) {
 			return "";
 		}
 		T2Users userParam = new T2Users();
@@ -2549,19 +2549,19 @@ public class CoMailManager extends CoTopComponent {
 	public String makeUserNameFormatWithDivision(String divisionCd, String userId) {
 		String rtnVal = "";
 		
-		if(!isEmpty(divisionCd) && "all".equalsIgnoreCase(userId)) {
+		if (!isEmpty(divisionCd) && "all".equalsIgnoreCase(userId)) {
 			String _division = CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, divisionCd);
-			if(!isEmpty(_division)) {
+			if (!isEmpty(_division)) {
 				rtnVal += _division + "/" + userId;
 			}
 		} else {
 			T2Users userParam = new T2Users();
 			userParam.setUserId(userId);
 			T2Users userInfo = userMapper.getUser(userParam);
-			if(userInfo != null && !isEmpty(userInfo.getUserName())) {
-				if(!isEmpty(userInfo.getDivision())) {
+			if (userInfo != null && !isEmpty(userInfo.getUserName())) {
+				if (!isEmpty(userInfo.getDivision())) {
 					String _division = CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, userInfo.getDivision());
-					if(!isEmpty(_division)) {
+					if (!isEmpty(_division)) {
 						rtnVal += _division + " ";
 					}
 				}
@@ -2571,7 +2571,7 @@ public class CoMailManager extends CoTopComponent {
 		}
 
 		
-		if(isEmpty(rtnVal)) {
+		if (isEmpty(rtnVal)) {
 			return userId;
 		}
 
@@ -2600,7 +2600,7 @@ public class CoMailManager extends CoTopComponent {
 				ossListParam.setMerge(CoConstDef.FLAG_NO);
 				Map<String, Object> mailComponentDataMap = projectService.getIdentificationGridList(ossListParam);
 				
-				if(CoConstDef.CD_MAIL_COMPONENT_PROJECT_DISCROSEOSSINFO.equals(component)) {
+				if (CoConstDef.CD_MAIL_COMPONENT_PROJECT_DISCROSEOSSINFO.equals(component)) {
 					Project project = new Project();
 					project.setPrjId(bean.getParamPrjId());
 					mailComponentDataMap.put("projectBean", projectService.getProjectDetail(project));
@@ -2651,9 +2651,9 @@ public class CoMailManager extends CoTopComponent {
 	private List<OssComponents> makePartnerOssListInfo(List<Map<String, Object>> mailComponentData) {
 		List<OssComponents> list = null;
 		Set<Map<String, String>> ossSet = new HashSet<Map<String, String>>();
-		if(mailComponentData != null && !mailComponentData.isEmpty()) {
+		if (mailComponentData != null && !mailComponentData.isEmpty()) {
 			list = new ArrayList<>();
-			for(Map<String, Object> dataMap : mailComponentData) {
+			for (Map<String, Object> dataMap : mailComponentData) {
 				Map<String, String> oss = new HashMap<String, String>();
 				oss.put("OSS_NAME", (String)dataMap.get("OSS_NAME"));
 				oss.put("OSS_VERSION", (String)dataMap.get("OSS_VERSION"));
@@ -2661,7 +2661,7 @@ public class CoMailManager extends CoTopComponent {
 				ossSet.add(oss);
 			}
 
-			for(Map<String, String> dataSet : ossSet) {
+			for (Map<String, String> dataSet : ossSet) {
 				OssComponents bean = new OssComponents();
 				bean.setOssName(dataSet.get("OSS_NAME"));
 				bean.setOssVersion(dataSet.get("OSS_VERSION"));
@@ -2676,16 +2676,16 @@ public class CoMailManager extends CoTopComponent {
 	private List<OssMaster> makeVulnerabilityInfo(List<Map<String, Object>> mailComponentData) {
 		List<OssMaster> list = null;
 		OssMaster bean;
-		for(Map<String, Object> dataMap : mailComponentData) {
-			if(list == null) {
+		for (Map<String, Object> dataMap : mailComponentData) {
+			if (list == null) {
 				list = new ArrayList<>();
 			}
 			bean = new OssMaster();
 			
-			if(dataMap.containsKey("PRJ_ID")) {
+			if (dataMap.containsKey("PRJ_ID")) {
 				bean.setPrjId((String) dataMap.get("PRJ_ID"));
 			}
-			if(dataMap.containsKey("COMPONENT_ID")) {
+			if (dataMap.containsKey("COMPONENT_ID")) {
 				bean.setComponentId((String) dataMap.get("COMPONENT_ID"));
 			}
 			
@@ -2705,7 +2705,7 @@ public class CoMailManager extends CoTopComponent {
 
 	private BinaryMaster makeBatResultInfo(List<Map<String, Object>> mailComponentData) {
 		BinaryMaster bean = null;
-		for(Map<String, Object> dataMap : mailComponentData) {
+		for (Map<String, Object> dataMap : mailComponentData) {
 			bean = new BinaryMaster();
 			bean.setBatId((String) dataMap.get("BAT_ID"));
 			bean.setSoftwareName((String) dataMap.get("SOFTWARE_NAME"));
@@ -2716,13 +2716,13 @@ public class CoMailManager extends CoTopComponent {
 			bean.setBatResultCount((String) dataMap.get("BAT_RESULT_COUNT"));
 			bean.setCreator(makeUserNameFormatWithDivision((String) dataMap.get("CREATOR")));
 			
-			if(!isEmpty((String) dataMap.get("BAT_ERROR_MSG"))) {
+			if (!isEmpty((String) dataMap.get("BAT_ERROR_MSG"))) {
 				bean.setBatErrorMsg((String) dataMap.get("BAT_ERROR_MSG"));
 			}
 			break;
 		}
 		
-		if(bean != null && !isEmpty(bean.getBatStatus())) {
+		if (bean != null && !isEmpty(bean.getBatStatus())) {
 			bean.setBatStatus(CoCodeManager.getCodeString(CoConstDef.CD_BAT_STATUS, bean.getBatStatus()));
 		}
 		return bean;
@@ -2730,7 +2730,7 @@ public class CoMailManager extends CoTopComponent {
 
 	private PartnerMaster makePartnerBasicInfo(List<Map<String, Object>> mailComponentData) {
 		PartnerMaster bean = null;
-		for(Map<String, Object> dataMap : mailComponentData) {
+		for (Map<String, Object> dataMap : mailComponentData) {
 			bean = new PartnerMaster();
 			bean.setPartnerId((String) dataMap.get("PARTNER_ID"));
 			bean.setStatus((String) dataMap.get("STATUS"));
@@ -2754,11 +2754,11 @@ public class CoMailManager extends CoTopComponent {
 		List<Project> list = null;
 		Project bean;
 		String distributeTargetCode = null;
-		for(Map<String, Object> dataMap : mailComponentData) {
-			if(list == null) {
+		for (Map<String, Object> dataMap : mailComponentData) {
+			if (list == null) {
 				list = new ArrayList<>();
 			}
-			if(isEmpty(distributeTargetCode)) {
+			if (isEmpty(distributeTargetCode)) {
 				distributeTargetCode = CoConstDef.CD_DTL_DISTRIBUTE_SKS.equals(avoidNull( (String) dataMap.get("DISTRIBUTE_TARGET"), CoConstDef.CD_DTL_DISTRIBUTE_LGE)) ? CoConstDef.CD_MODEL_TYPE2 : CoConstDef.CD_MODEL_TYPE;
 			}
 			bean = new Project();
@@ -2767,17 +2767,17 @@ public class CoMailManager extends CoTopComponent {
 			bean.setModelName((String) dataMap.get("MODEL_NAME"));
 			bean.setReleaseDate(CommonFunction.formatDateSimple((String) dataMap.get("RELEASE_DATE")));
 			bean.setModifier((String) dataMap.get("MODIFIER"));
-			if(dataMap.get("MODIFIED_DATE") != null && !isEmpty((String) dataMap.get("MODIFIED_DATE"))) {
+			if (dataMap.get("MODIFIED_DATE") != null && !isEmpty((String) dataMap.get("MODIFIED_DATE"))) {
 				bean.setModifiedDate(CommonFunction.formatDateSimple((String) dataMap.get("MODIFIED_DATE")));
 			}
-			if(dataMap.containsKey("DEL_YN") && CoConstDef.FLAG_YES.equals(dataMap.get("DEL_YN"))) {
+			if (dataMap.containsKey("DEL_YN") && CoConstDef.FLAG_YES.equals(dataMap.get("DEL_YN"))) {
 				bean.setCategory(changeStyle(bean.getCategory(), "del", true));
 				bean.setModelName(changeStyle(bean.getModelName(), "del", true));
 				bean.setReleaseDate(changeStyle(bean.getReleaseDate(), "del", true));
 			} 
 			
 			// distribution 예약 및 예약취소의 경우만 modifier 가 설정되지 않은 경우, 신규 추가된 것으로 표시한다. 
-			else if( (CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_RESERVED.equals(mailType) || CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_CANCELED.equals(mailType) ) 
+			else if ( (CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_RESERVED.equals(mailType) || CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_CANCELED.equals(mailType) ) 
 					&& isEmpty(bean.getModifiedDate())) {
 				bean.setCategory(changeStyle(bean.getCategory(), "mod"));
 				bean.setModelName(changeStyle(bean.getModelName(), "mod"));
@@ -2791,7 +2791,7 @@ public class CoMailManager extends CoTopComponent {
 
 	private Project makeDistributionInfo(List<Map<String, Object>> mailComponentData) {
 		Project bean = null;
-		for(Map<String, Object> dataMap : mailComponentData) {
+		for (Map<String, Object> dataMap : mailComponentData) {
 			bean = new Project();
 			bean.setDistributeName((String) dataMap.get("DISTRIBUTE_NAME"));
 			bean.setDistributeMasterCategory((String) dataMap.get("DISTRIBUTE_MASTER_CATEGORY"));
@@ -2809,14 +2809,14 @@ public class CoMailManager extends CoTopComponent {
 			// code convert
 			
 			// master category
-			if(!isEmpty(bean.getDistributeMasterCategory())) {
+			if (!isEmpty(bean.getDistributeMasterCategory())) {
 				bean.setDistributeMasterCategory(CommonFunction.makeCategoryFormat(bean.getDistributeTarget(), bean.getDistributeMasterCategory().substring(0, 3), bean.getDistributeMasterCategory().substring(3)));
 			}
-			if(!isEmpty(bean.getDistributeSoftwareType())) {
+			if (!isEmpty(bean.getDistributeSoftwareType())) {
 				bean.setDistributeSoftwareType(CoCodeManager.getCodeString(CoConstDef.CD_NOTICE_DEFAULT_SOFTWARE_TYPE, bean.getDistributeSoftwareType()));
 			}
 			// target site
-			if(!isEmpty(bean.getDistributeTarget())) {
+			if (!isEmpty(bean.getDistributeTarget())) {
 				bean.setDistributeTarget(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTE_CODE, bean.getDistributeTarget()));
 			}
 			break;
@@ -2834,37 +2834,37 @@ public class CoMailManager extends CoTopComponent {
 		String networkServerType = "";
 		String networkRestriction = "";
 		
-		if(project != null) {
+		if (project != null) {
 			networkServerType = project.getNetworkServerType();
 			networkRestriction = CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, CoConstDef.CD_LICENSE_NETWORK_RESTRICTION).toUpperCase();
 		}
 		
-		if(mailComponentDataMap != null && (mailComponentDataMap.containsKey("mainData") || mailComponentDataMap.containsKey("rows") )) {
+		if (mailComponentDataMap != null && (mailComponentDataMap.containsKey("mainData") || mailComponentDataMap.containsKey("rows") )) {
 			projectList = (List<ProjectIdentification>) mailComponentDataMap.get(mailComponentDataMap.containsKey("mainData") ? "mainData" : "rows");
-			for(ProjectIdentification prjBean : projectList) {
+			for (ProjectIdentification prjBean : projectList) {
 				// exclude 제외
-				if(CoConstDef.FLAG_YES.equals(prjBean.getExcludeYn())) {
+				if (CoConstDef.FLAG_YES.equals(prjBean.getExcludeYn())) {
 					continue;
 				}
 				
-				if(currentGroupKey != null && currentGroupKey.equals(prjBean.getGroupingColumn())) {
+				if (currentGroupKey != null && currentGroupKey.equals(prjBean.getGroupingColumn())) {
 					continue;
 				} else {
 					currentGroupKey = prjBean.getGroupingColumn();
 				}
 				
 				
-				if(CoConstDef.CD_MAIL_COMPONENT_PROJECT_DISCROSEOSSINFO.equals(component)
+				if (CoConstDef.CD_MAIL_COMPONENT_PROJECT_DISCROSEOSSINFO.equals(component)
 						&& !CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE.equals(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(prjBean.getObligationLicense()) ? prjBean.getObligationType() : prjBean.getObligationLicense())) {
 					continue;
 				}
 				
-				if(CoConstDef.FLAG_YES.equals(networkServerType)
+				if (CoConstDef.FLAG_YES.equals(networkServerType)
 						&& !networkRestriction.equals(prjBean.getRestriction().toUpperCase())) {
 					continue;
 				}
 				
-				if(list == null) {
+				if (list == null) {
 					list = new ArrayList<>();
 				}
 				bean = new OssComponents();
@@ -2883,7 +2883,7 @@ public class CoMailManager extends CoTopComponent {
 		String packageFileName2 = null;
 		String packageFileName3 = null;
 		String noticeFileName = null;
-		for(Map<String, Object> dataMap : mailComponentData) {
+		for (Map<String, Object> dataMap : mailComponentData) {
 			bean = new Project();
 			bean.setPrjId(avoidNull((String) dataMap.get("PRJ_ID"))); 
 			bean.setPrjName(avoidNull((String) dataMap.get("PRJ_NAME"))); 
@@ -2911,70 +2911,70 @@ public class CoMailManager extends CoTopComponent {
 			break;
 		}
 
-		if(bean != null) {
+		if (bean != null) {
 			// published file 정보가 존재할 경우 + packaging 상태가 confirm인 경우 파일 정보 노출
-			if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(bean.getVerificationStatus())) {
-				if(!isEmpty(packageFileName)) {
+			if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(bean.getVerificationStatus())) {
+				if (!isEmpty(packageFileName)) {
 					T2File packageFile = fileService.selectFileInfo(packageFileName);
-					if(packageFile != null) {
+					if (packageFile != null) {
 						bean.setPackageFileId(packageFile.getOrigNm());
 					}
 				}
-				if(!isEmpty(packageFileName2)) {
+				if (!isEmpty(packageFileName2)) {
 					T2File packageFile2 = fileService.selectFileInfo(packageFileName2);
-					if(packageFile2 != null) {
+					if (packageFile2 != null) {
 						bean.setPackageFileId2(packageFile2.getOrigNm());
 					}
 				}
-				if(!isEmpty(packageFileName3)) {
+				if (!isEmpty(packageFileName3)) {
 					T2File packageFile3 = fileService.selectFileInfo(packageFileName3);
-					if(packageFile3 != null) {
+					if (packageFile3 != null) {
 						bean.setPackageFileId3(packageFile3.getOrigNm());
 					}
 				}
-				if(!isEmpty(noticeFileName)) {
+				if (!isEmpty(noticeFileName)) {
 					T2File noticeFile = fileService.selectFileInfo(noticeFileName);
-					if(noticeFile != null) {
+					if (noticeFile != null) {
 						bean.setNoticeFileId(noticeFile.getOrigNm());
 					}
 				}
 			}
 			
 			// 코드변환
-			if(!isEmpty(bean.getDistributionType())) {
+			if (!isEmpty(bean.getDistributionType())) {
 				bean.setDistributionType(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, bean.getDistributionType()));
 			}
-			if(!isEmpty(bean.getOsType())) {
+			if (!isEmpty(bean.getOsType())) {
 				bean.setOsType(CoConstDef.COMMON_SELECTED_ETC.equals(bean.getOsType()) ? bean.getOsTypeEtc() : CoCodeManager.getCodeString(CoConstDef.CD_OS_TYPE, bean.getOsType()));
 			}
-			if(!isEmpty(bean.getIdentificationStatus())) {
+			if (!isEmpty(bean.getIdentificationStatus())) {
 				bean.setIdentificationStatus(CoCodeManager.getCodeString(CoConstDef.CD_IDENTIFICATION_STATUS, bean.getIdentificationStatus()));
 			}
-			if(!isEmpty(bean.getVerificationStatus())) {
+			if (!isEmpty(bean.getVerificationStatus())) {
 				bean.setVerificationStatus(CoCodeManager.getCodeString(CoConstDef.CD_IDENTIFICATION_STATUS, bean.getVerificationStatus()));
 			}
-			if(!isEmpty(bean.getDestributionStatus())) {
+			if (!isEmpty(bean.getDestributionStatus())) {
 				bean.setDestributionStatus(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTE_STATUS, bean.getDestributionStatus()));
 			}
-			if(!isEmpty(bean.getDistributeTarget())) {
+			if (!isEmpty(bean.getDistributeTarget())) {
 				bean.setDistributeTarget(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTE_CODE, bean.getDistributeTarget()));
 			}
 			
-			if(!isEmpty(bean.getNoticeType())) {
+			if (!isEmpty(bean.getNoticeType())) {
 				String noticeType = CoCodeManager.getCodeString(CoConstDef.CD_NOTICE_TYPE, bean.getNoticeType());
 				String noticeTypeEtc = CoCodeManager.getCodeString(CoConstDef.CD_PLATFORM_GENERATED, bean.getNoticeTypeEtc());
-				if(!isEmpty(noticeTypeEtc)) {
+				if (!isEmpty(noticeTypeEtc)) {
 					noticeType += " (" + noticeTypeEtc + ")";
 				}
 				
 				bean.setNoticeType(noticeType);
 			}
 			
-			if(!isEmpty(bean.getPriority())) {
+			if (!isEmpty(bean.getPriority())) {
 				bean.setPriority(CoCodeManager.getCodeString(CoConstDef.CD_PROJECT_PRIORITY, bean.getPriority()));
 			}
 			
-			if(!isEmpty(bean.getDivision())) {
+			if (!isEmpty(bean.getDivision())) {
 				bean.setDivision(CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, bean.getDivision()));
 			}
 						
@@ -2990,7 +2990,7 @@ public class CoMailManager extends CoTopComponent {
 	 */
 	private LicenseMaster makeLicenseBasicInfo(List<Map<String, Object>> mailComponentData) {
 		LicenseMaster bean = null;
-		for(Map<String, Object> dataMap : mailComponentData) {
+		for (Map<String, Object> dataMap : mailComponentData) {
 			bean = new LicenseMaster();
 			bean.setLicenseId(avoidNull((String) dataMap.get("LICENSE_ID"))); 
 			bean.setLicenseName(avoidNull((String) dataMap.get("LICENSE_NAME"))); 
@@ -2999,17 +2999,17 @@ public class CoMailManager extends CoTopComponent {
 			bean.setObligationNotificationYn(avoidNull((String) dataMap.get("OBLIGATION_NOTIFICATION_YN"))); 
 			bean.setObligationNeedsCheckYn(avoidNull((String) dataMap.get("OBLIGATION_NEEDS_CHECK_YN"))); 
 			
-			if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNeedsCheckYn()))) {
+			if (CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNeedsCheckYn()))) {
 				bean.setObligation(CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK)); 
-			} else if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationDisclosingSrcYn()))) {
+			} else if (CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationDisclosingSrcYn()))) {
 				bean.setObligation(CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE));
-			} else if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNotificationYn()))) {
+			} else if (CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNotificationYn()))) {
 				bean.setObligation(CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, CoConstDef.CD_DTL_OBLIGATION_NOTICE));
 			}
 			
 			bean.setShortIdentifier(avoidNull((String) dataMap.get("SHORT_IDENTIFIER"))); 
 			bean.setWebpage(avoidNull((String) dataMap.get("WEBPAGE")));
-			if(!isEmpty(bean.getWebpage()) && !(bean.getWebpage().startsWith("http://") || bean.getWebpage().startsWith("https://"))) {
+			if (!isEmpty(bean.getWebpage()) && !(bean.getWebpage().startsWith("http://") || bean.getWebpage().startsWith("https://"))) {
 				bean.setWebpage("http://" + bean.getWebpage());
 			}
 			
@@ -3021,9 +3021,9 @@ public class CoMailManager extends CoTopComponent {
 			
 			// RESTRICTION 정보 메일에 추가
 			String restrictionStr = "";
-			if(!isEmpty((String) dataMap.get("RESTRICTION"))) {
-				for(String restrictionCd : ((String) dataMap.get("RESTRICTION")).split(",")) {
-					if(!isEmpty(restrictionStr)) {
+			if (!isEmpty((String) dataMap.get("RESTRICTION"))) {
+				for (String restrictionCd : ((String) dataMap.get("RESTRICTION")).split(",")) {
+					if (!isEmpty(restrictionStr)) {
 						restrictionStr += ", ";
 					}
 					restrictionStr += CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, restrictionCd);
@@ -3049,8 +3049,8 @@ public class CoMailManager extends CoTopComponent {
 		boolean isFirst = true;
 		OssLicense license = null;
 		
-		for(Map<String, Object> dataMap : mailComponentData) {
-			if(isFirst) {
+		for (Map<String, Object> dataMap : mailComponentData) {
+			if (isFirst) {
 				bean = new OssMaster();
 				bean.setOssId(avoidNull((String) dataMap.get("OSS_ID")));
 				bean.setOssName((String) dataMap.get("OSS_NAME"));
@@ -3065,22 +3065,22 @@ public class CoMailManager extends CoTopComponent {
 				bean.setLicenseType(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_TYPE, avoidNull((String) dataMap.get("OSS_LICENSE_TYPE"))));
 				bean.setObligation(CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, avoidNull((String) dataMap.get("OSS_OBLIGATION_TYPE"))));
 				bean.setOssNickname(avoidNull((String) dataMap.get("OSS_NICKNAME")));
-				if(!isEmpty((String) dataMap.get("CREATED_DATE"))) {
+				if (!isEmpty((String) dataMap.get("CREATED_DATE"))) {
 					bean.setCreatedDate(DateUtil.dateFormatConvert((String) dataMap.get("CREATED_DATE"), DateUtil.TIMESTAMP_PATTERN, DateUtil.DATE_PATTERN_DASH));
 				}
 				
-				if(!isEmpty((String) dataMap.get("CREATOR"))) {
+				if (!isEmpty((String) dataMap.get("CREATOR"))) {
 					bean.setCreator(CoMailManager.getInstance().makeUserNameFormat((String) dataMap.get("CREATOR")));
 				}
 				
-				if(!isEmpty(bean.getOssId()) && CoCodeManager.OSS_INFO_BY_ID.containsKey(bean.getOssId())) {
+				if (!isEmpty(bean.getOssId()) && CoCodeManager.OSS_INFO_BY_ID.containsKey(bean.getOssId())) {
 					bean.setMultiLicenseFlag(CoCodeManager.OSS_INFO_BY_ID.get(bean.getOssId()).getLicenseDiv());
 				}
 				
 				String detectedLicenses = dataMap.containsKey("DETECTED_LICENSE") ? (String) dataMap.get("DETECTED_LICENSE") : "";
 				bean.setDetectedLicense(detectedLicenses);
 			}
-			if(dataMap.containsKey("LICENSE_ID")) {
+			if (dataMap.containsKey("LICENSE_ID")) {
 				license = new OssLicense();
 				license.setLicenseId((String) dataMap.get("LICENSE_ID"));
 				license.setOssLicenseIdx((String) dataMap.get("OSS_LICENSE_IDX"));
@@ -3094,7 +3094,7 @@ public class CoMailManager extends CoTopComponent {
 			
 			isFirst = false;
 		}
-		if(bean != null && bean.getOssLicenses() != null && !bean.getOssLicenses().isEmpty()) {
+		if (bean != null && bean.getOssLicenses() != null && !bean.getOssLicenses().isEmpty()) {
 			bean.setLicenseName(CommonFunction.makeLicenseExpression(bean.getOssLicenses()));
 		}
 		
@@ -3176,7 +3176,7 @@ public class CoMailManager extends CoTopComponent {
 		List<Map<String, Object>> dataList = new ArrayList<>();
 		// sql param 생성
 		sql = sql.replace("?", createInQuery(params));
-		try(
+		try (
 			Connection conn = DriverManager.getConnection(connStr, connUser, connPw);
 			PreparedStatement pstmt = conn.prepareStatement(sql);
 			ResultSet rs = pstmt.executeQuery()
@@ -3188,15 +3188,15 @@ public class CoMailManager extends CoTopComponent {
 				Map<String, Object> dataMap;
 				while (rs.next()) {
 					dataMap = new HashMap<>();
-					for(int colIdx=1; colIdx<=colCount; colIdx++) {
+					for (int colIdx=1; colIdx<=colCount; colIdx++) {
 						String _contents = (String)rs.getString(colIdx);
-						if(avoidNull(_contents).indexOf("\n") > -1) {
+						if (avoidNull(_contents).indexOf("\n") > -1) {
 							_contents = _contents.replaceAll("\n", "<br />");
 						}
 						dataMap.put(rsmd.getColumnLabel(colIdx), _contents);
 					}
 					
-					if(CoConstDef.CD_MAIL_COMPONENT_VULNERABILITY_PRJ.equals(key) ||  CoConstDef.CD_MAIL_COMPONENT_VULNERABILITY_OSS.equals(key) || CoConstDef.CD_MAIL_COMPONENT_VULNERABILITY_PROJECT_RECALCULATED_ALL.equals(key)) {
+					if (CoConstDef.CD_MAIL_COMPONENT_VULNERABILITY_PRJ.equals(key) ||  CoConstDef.CD_MAIL_COMPONENT_VULNERABILITY_OSS.equals(key) || CoConstDef.CD_MAIL_COMPONENT_VULNERABILITY_PROJECT_RECALCULATED_ALL.equals(key)) {
 						dataMap.remove("noticeFileId");
 						dataMap.remove("packageFileId");
 					}
@@ -3212,8 +3212,8 @@ public class CoMailManager extends CoTopComponent {
 
 	private CharSequence createInQuery(List<String> params) {
 		StringBuilder keyList = new StringBuilder();
-		for(String key : params) {
-			if(keyList.length() > 0) {
+		for (String key : params) {
+			if (keyList.length() > 0) {
 				keyList.append(" OR ");
 			}
 			keyList.append(" CONCAT(UPPER(T1.OSS_NAME), '_', T1.OSS_VERSION) = '"+key+"'");
@@ -3235,8 +3235,8 @@ public class CoMailManager extends CoTopComponent {
 		VelocityEngine vf = new VelocityEngine();
 		Properties props = new Properties();
 		
-		for(String key : model.keySet()) {
-			if(!"templateUrl".equals(key)) {
+		for (String key : model.keySet()) {
+			if (!"templateUrl".equals(key)) {
 				context.put(key, model.get(key));
 			}
 		}
@@ -3272,7 +3272,7 @@ public class CoMailManager extends CoTopComponent {
 	private String[] selectAdminMailAddr() {
 		String adminMailStr = avoidNull(CommonFunction.getProperty("smtp.default.admin"));
 		
-		if(isEmpty(adminMailStr)) {
+		if (isEmpty(adminMailStr)) {
 			List<String> adminMailList = mailManagerMapper.selectAdminMailAddr();
 			String[] array = new String[adminMailList.size()];
 			
@@ -3288,17 +3288,17 @@ public class CoMailManager extends CoTopComponent {
 			MimeMessage message = mailSender.createMimeMessage();
 			
 			String _replyToId = "";
-			if(!isEmpty(coMail.getParamLicenseId())) {
+			if (!isEmpty(coMail.getParamLicenseId())) {
 				_replyToId = "LI" +coMail.getParamLicenseId();
-			} else if(!isEmpty(coMail.getParamOssId())) {
+			} else if (!isEmpty(coMail.getParamOssId())) {
 				_replyToId = "OS"+coMail.getParamOssId();
-			} else if(!isEmpty(coMail.getParamPrjId())) {
+			} else if (!isEmpty(coMail.getParamPrjId())) {
 				_replyToId = "PJ"+coMail.getParamPrjId();
-			} else if(!isEmpty(coMail.getParamPartnerId())) {
+			} else if (!isEmpty(coMail.getParamPartnerId())) {
 				_replyToId = "PN"+coMail.getParamPartnerId();
 			}
 			
-			if(!isEmpty(_replyToId)) {
+			if (!isEmpty(_replyToId)) {
 				_replyToId = "<OSC." +_replyToId + "@fosslight.org>";
 				message.setHeader("In-Reply-To", _replyToId);
 				message.setHeader("References", _replyToId);
@@ -3309,38 +3309,38 @@ public class CoMailManager extends CoTopComponent {
 			String userId = coMail.getLoginUserName();
 			String userName = "";
 			
-			if(isEmpty(userId)) {
+			if (isEmpty(userId)) {
 				// 시스템에서 발송하는 case
 				// 1. bat 관련
-				if(!isEmpty(coMail.getParamBatId())) {
+				if (!isEmpty(coMail.getParamBatId())) {
 					BinaryMaster batBean = mailManagerMapper.getBinaryInfo(coMail.getParamBatId());
-					if(batBean != null && !isEmpty(batBean.getCreator())) {
+					if (batBean != null && !isEmpty(batBean.getCreator())) {
 						userId = batBean.getCreator();
 					}
 				}
 			}
 			
-			if(!isEmpty(userId)) {
+			if (!isEmpty(userId)) {
 				T2Users userParam = new T2Users();
 				userParam.setUserId(userId);
 				T2Users userInfo = userMapper.getUser(userParam);
 				
-				if(userInfo != null && !isEmpty(userInfo.getUserName())) {
+				if (userInfo != null && !isEmpty(userInfo.getUserName())) {
 					userName = userInfo.getUserName();
 				}
 			}
 			
 			String mailFrom = avoidNull(CommonFunction.getProperty("mail.smtp.email"), CommonFunction.getProperty("mail.smtp.username"));
 
-			if(CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_DELETED.equals(coMail.getMsgType()) 
+			if (CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_DELETED.equals(coMail.getMsgType()) 
 						|| CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_DIFF_FILE.equals(coMail.getMsgType()) 
 						|| CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_EDIT_FILE.equals(coMail.getMsgType()) 
 						|| CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_EDIT_DESCRIPTION.equals(coMail.getMsgType()) ) {
 				InternetAddress from = new InternetAddress(mailFrom, "FOSSLight Hub" + " (FOSSLight)", "UTF-8");
 				helper.setFrom(from);
 			}
-			else if(!isEmpty(userId) && !isEmpty(userName)) {
-				if(userName.length() > 15 && userName.contains("/") && userName.split("/").length > 1) {
+			else if (!isEmpty(userId) && !isEmpty(userName)) {
+				if (userName.length() > 15 && userName.contains("/") && userName.split("/").length > 1) {
 					userName = userName.substring(0, userName.lastIndexOf("/"));
 				}
 				InternetAddress from = new InternetAddress(mailFrom, userName + " " + userId + " (FOSSLight)", "UTF-8");
@@ -3349,10 +3349,10 @@ public class CoMailManager extends CoTopComponent {
 				helper.setFrom(mailFrom);
 			}
 
-            if(!isEmpty(DEFAULT_BCC)) {
+            if (!isEmpty(DEFAULT_BCC)) {
             	String[] _bcc = coMail.getBccIds() == null ? new String[]{} : coMail.getBccIds();
             	List<String> _bccList = new ArrayList<>(Arrays.asList(_bcc));
-            	if(_bccList == null || _bccList.isEmpty()) {
+            	if (_bccList == null || _bccList.isEmpty()) {
             		_bccList = new ArrayList<>();
             	}
             	_bccList.add(DEFAULT_BCC);
@@ -3381,7 +3381,7 @@ public class CoMailManager extends CoTopComponent {
 
 	public void sendErrorMail(CoMail bean) {
 		boolean isProd = "REAL".equals(avoidNull(CommonFunction.getProperty("server.mode")));
-		if(isProd) {
+		if (isProd) {
 			bean.setToIds(selectAdminMailAddr());
 			try {
 				bean.setCreationUserId("system");

--- a/src/main/java/oss/fosslight/domain/CodeBean.java
+++ b/src/main/java/oss/fosslight/domain/CodeBean.java
@@ -226,7 +226,7 @@ public class CodeBean extends ComBean implements Serializable{
      * @return
      */
     public List<CodeDtlBean> getDtlList() {
-        if(getCdNo() == null || getCdDtlNo() == null || getCdDtlNo().length == 0) {
+        if (getCdNo() == null || getCdDtlNo() == null || getCdDtlNo().length == 0) {
             return null;
         }
         
@@ -234,15 +234,15 @@ public class CodeBean extends ComBean implements Serializable{
         
         CodeDtlBean dtlBean = null;
         int cnt = 0;
-        for(String s : getCdDtlNo()) {
-            if(s.isEmpty()) {
+        for (String s : getCdDtlNo()) {
+            if (s.isEmpty()) {
                 continue;
             }
             dtlBean = new CodeDtlBean();
             dtlBean.setCdNo(this.getCdNo());
             dtlBean.setCdDtlNo(s);
             dtlBean.setCdDtlNm(this.getCdDtlNm()[cnt]);
-            if(this.getCdDtlExp() == null || this.getCdDtlExp().length < cnt+1) {
+            if (this.getCdDtlExp() == null || this.getCdDtlExp().length < cnt+1) {
             } else {
                 dtlBean.setCdDtlExp(this.getCdDtlExp()[cnt]);
             }

--- a/src/main/java/oss/fosslight/domain/ComBean.java
+++ b/src/main/java/oss/fosslight/domain/ComBean.java
@@ -197,9 +197,9 @@ public class ComBean extends CoTopComponent implements Serializable {
      */
     public String getSidx() {
     	
-		if(!isEmpty(sidx) && CoConstDef.VALIDATION_USE_CAMELCASE) {
+		if (!isEmpty(sidx) && CoConstDef.VALIDATION_USE_CAMELCASE) {
 			String _sidx = StringUtil.convertToUnderScore(sidx).toUpperCase();
-			if(CoCodeManager.getCodeNames(CoConstDef.CD_SYSTEM_GRID_SORT_CAST).contains(_sidx)) {
+			if (CoCodeManager.getCodeNames(CoConstDef.CD_SYSTEM_GRID_SORT_CAST).contains(_sidx)) {
 				_sidx = "CAST("+ _sidx +" AS SIGNED)";
 			}
 			return _sidx;
@@ -207,7 +207,7 @@ public class ComBean extends CoTopComponent implements Serializable {
 		return sidx;
 	}
     public String getSidxEx() {
-		if(StringUtils.isEmpty(sidx)) {
+		if (StringUtils.isEmpty(sidx)) {
 			return sidx;
 		}
 
@@ -390,7 +390,7 @@ public class ComBean extends CoTopComponent implements Serializable {
 		this.startIndex = (curPage-1)*pageListSize;
 		
 		int totBlockPage = (totBlockSize / blockSize);
-		if(totBlockSize != blockSize) {
+		if (totBlockSize != blockSize) {
 			totBlockPage++;
 		}
 		this.totBlockPage = totBlockPage;
@@ -400,7 +400,7 @@ public class ComBean extends CoTopComponent implements Serializable {
 		
 		int blockStart = ((blockPage-1) * blockSize) + 1;
 		int blockEnd = blockStart+blockSize-1;
-		if(blockEnd > totBlockSize) {
+		if (blockEnd > totBlockSize) {
 			blockEnd = totBlockSize;
 		}
 		
@@ -683,7 +683,7 @@ public class ComBean extends CoTopComponent implements Serializable {
 	 * @return the 등록일
 	 */
 	public String getCreatedDate() {
-		if(this.createdDate == null){
+		if (this.createdDate == null){
 			Date now = new Date();
 			SimpleDateFormat sdf = new SimpleDateFormat(CoConstDef.DATABASE_FORMAT_DATE_ALL);
 			this.createdDate = sdf.format(now);
@@ -965,9 +965,9 @@ public class ComBean extends CoTopComponent implements Serializable {
 	protected static String getBitArraySum(String value){
 		int sum = 0;
 		
-		if(value != null){
+		if (value != null){
 			String arr[] = value.split(",");
-			if(arr.length > 1){
+			if (arr.length > 1){
 				
 				for (String s : arr) {
 					try{
@@ -1004,15 +1004,15 @@ public class ComBean extends CoTopComponent implements Serializable {
 		Type collectionType1 = new TypeToken<Map<String, Object>>() {}.getType();
 		String[] dateField = {"creationDate", "publDate", "modiDate", "regDt"};
 
-		if(filters != null) {
+		if (filters != null) {
 			filtersMap = (Map<String, Object>) fromJson(filters, collectionType1);
-			if(filtersMap.containsKey("rules")) {
-				for(Map<String, String> ruleMap : (List<LinkedTreeMap<String, String>>)filtersMap.get("rules")) {
+			if (filtersMap.containsKey("rules")) {
+				for (Map<String, String> ruleMap : (List<LinkedTreeMap<String, String>>)filtersMap.get("rules")) {
 					String field = ruleMap.get("field");
 					String data = ruleMap.get("data");
 					
-					for(String date : dateField) {
-						if(date.equalsIgnoreCase(field)) {
+					for (String date : dateField) {
+						if (date.equalsIgnoreCase(field)) {
 							ruleMap.put("data", CommonFunction.formatDateSimple(data));
 						}
 					}

--- a/src/main/java/oss/fosslight/domain/ImageView.java
+++ b/src/main/java/oss/fosslight/domain/ImageView.java
@@ -48,7 +48,7 @@ public class ImageView extends AbstractView {
 	private byte[] readFile(String filePath, String fileName) throws IOException {
 		String path = filePath + "/" + fileName;
 		byte[] bytes = null;
-		try(
+		try (
 			BufferedInputStream bis = new BufferedInputStream(new FileInputStream(path));
 		) {
 			int length = bis.available();

--- a/src/main/java/oss/fosslight/domain/LicenseMaster.java
+++ b/src/main/java/oss/fosslight/domain/LicenseMaster.java
@@ -283,7 +283,7 @@ public class LicenseMaster extends ComBean implements Serializable {
 	 */
 	public void setDescription(String description) {
 		this.description = description;
-		if(!isEmptyWithLineSeparator(description)) {
+		if (!isEmptyWithLineSeparator(description)) {
 			this.descriptionHtml = CommonFunction.makeHtmlLinkTagWithText(CommonFunction.lineReplaceToBR(description));
 		}
 	}
@@ -628,7 +628,7 @@ public class LicenseMaster extends ComBean implements Serializable {
 	 * @param licenseNicknameStr the license nickname str
 	 */
 	public void addLicenseNicknameList(String licenseNicknameStr) {
-		if(this.licenseNicknameList == null) {
+		if (this.licenseNicknameList == null) {
 			this.licenseNicknameList = new ArrayList<>();
 		}
 		this.licenseNicknameList.add(licenseNicknameStr);
@@ -739,13 +739,13 @@ public class LicenseMaster extends ComBean implements Serializable {
 	}
 
 	public String getWebpageLinkFormat() {
-		if(StringUtil.isEmpty(this.webpageLinkFormat) && !StringUtil.isEmpty(this.webpage)) {
-			if(this.webpage.contains(",")){
+		if (StringUtil.isEmpty(this.webpageLinkFormat) && !StringUtil.isEmpty(this.webpage)) {
+			if (this.webpage.contains(",")){
 				String[] webpages = this.webpage.split(",");
 				String result = "";
 							
-				for(int i = 0 ; i < webpages.length ; i++){
-					if(i > 0){ result += "<br>"; }
+				for (int i = 0 ; i < webpages.length ; i++){
+					if (i > 0){ result += "<br>"; }
 								
 					result += "<a href='"+webpages[i]+"' target='_blank'>" + webpages[i] + "</a>";
 				}

--- a/src/main/java/oss/fosslight/domain/OssComponents.java
+++ b/src/main/java/oss/fosslight/domain/OssComponents.java
@@ -388,10 +388,10 @@ public class OssComponents extends ComBean implements Serializable {
 	}
 	
 	public void addOssComponentsIdList(String s) {
-		if(this.ossComponentsIdList == null) {
+		if (this.ossComponentsIdList == null) {
 			this.ossComponentsIdList = new ArrayList<>();
 		}
-		if(!isEmpty(s)) {
+		if (!isEmpty(s)) {
 			this.ossComponentsIdList.add(s);
 		}
 	}

--- a/src/main/java/oss/fosslight/domain/OssMaster.java
+++ b/src/main/java/oss/fosslight/domain/OssMaster.java
@@ -769,7 +769,7 @@ public class OssMaster extends ComBean implements Serializable{
 	 */
 	public void setCopyrights(String copyrights) {
 		String[] copys = copyrights.split("\r\n");
-		if(copys[0].equals("") && copys.length == 1){
+		if (copys[0].equals("") && copys.length == 1){
 			this.copyrights = null; 
 		}else{
 			this.copyrights = copys;
@@ -863,15 +863,15 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @param ossType the new oss type
 	 */
 	public void setOssType(String ossType) {
-		if(ossType != null && ossType.length() == 3) {
+		if (ossType != null && ossType.length() == 3) {
 			String _rtn = "";
-			if("1".equals(ossType.substring(0, 1))) {
+			if ("1".equals(ossType.substring(0, 1))) {
 				_rtn += "M";
 			}
-			if("1".equals(ossType.substring(1,2))) {
+			if ("1".equals(ossType.substring(1,2))) {
 				_rtn += "D";
 			}
-			if("1".equals(ossType.substring(2, 3))) {
+			if ("1".equals(ossType.substring(2, 3))) {
 				_rtn += "V";
 			}
 			ossType = _rtn;
@@ -921,8 +921,8 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @param bean the bean
 	 */
 	public void addOssLicense(OssLicense bean) {
-		if(bean != null) {
-			if(this.ossLicenses == null) {
+		if (bean != null) {
+			if (this.ossLicenses == null) {
 				this.ossLicenses = new ArrayList<>();
 			}
 			this.ossLicenses.add(bean);
@@ -970,16 +970,16 @@ public class OssMaster extends ComBean implements Serializable{
 	public void setCvssScoreIcon() {
 		String convertCvssScore = cvssScore;
 		
-		if(!StringUtil.isEmpty(convertCvssScore)){
-			if(convertCvssScore.indexOf("->") > -1) {
+		if (!StringUtil.isEmpty(convertCvssScore)){
+			if (convertCvssScore.indexOf("->") > -1) {
 				convertCvssScore = convertCvssScore.split("->")[1].trim();
 			}
 			
-			if(Double.parseDouble(convertCvssScore) <= 3.9){
+			if (Double.parseDouble(convertCvssScore) <= 3.9){
 				cvssScoreIcon = "L";
-			}else if(Double.parseDouble(convertCvssScore) <= 6.9){
+			}else if (Double.parseDouble(convertCvssScore) <= 6.9){
 				cvssScoreIcon = "M";
-			}else if(Double.parseDouble(convertCvssScore) <= 10.0){
+			}else if (Double.parseDouble(convertCvssScore) <= 10.0){
 				cvssScoreIcon = "H";
 			}
 		}
@@ -1025,8 +1025,8 @@ public class OssMaster extends ComBean implements Serializable{
 	 * Sets the cve id text.
 	 */
 	public void setCveIdText() {
-		if(!StringUtil.isEmpty(cveId)){
-			if(cveId.indexOf("CVE-") == -1){
+		if (!StringUtil.isEmpty(cveId)){
+			if (cveId.indexOf("CVE-") == -1){
 				cveId = "CVE-"+cveId;
 			}
 		}
@@ -1074,7 +1074,7 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @return the license opr exp
 	 */
 	public String getLicenseOprExp() {
-		if(isEmpty(licenseOprExp) && this.ossLicenses != null && !this.ossLicenses.isEmpty()) {
+		if (isEmpty(licenseOprExp) && this.ossLicenses != null && !this.ossLicenses.isEmpty()) {
 			return CommonFunction.makeLicenseExpression(getOssLicenses());
 		}
 		return licenseOprExp;
@@ -1149,10 +1149,10 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @param s the s
 	 */
 	public void addOssIdList(String s) {
-		if(this.ossIdList == null) {
+		if (this.ossIdList == null) {
 			this.ossIdList = new ArrayList<>();
 		}
-		if(!isEmpty(s) && !ossIdList.contains(s)) {
+		if (!isEmpty(s) && !ossIdList.contains(s)) {
 			this.ossIdList.add(s);
 		}
 	}
@@ -1163,7 +1163,7 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @param s the s
 	 */
 	public void addLicenseIdList(String s) {
-		if(this.licenseIdList == null) {
+		if (this.licenseIdList == null) {
 			this.licenseIdList = new ArrayList<>();
 		}
 		this.licenseIdList.add(s);
@@ -1211,7 +1211,7 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @param s the s
 	 */
 	public void addLicenseCombList(String s) {
-		if(this.licenseCombList == null) {
+		if (this.licenseCombList == null) {
 			this.licenseCombList = new ArrayList<>();
 		}
 		this.licenseCombList.add(s);
@@ -1241,7 +1241,7 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @param s the s
 	 */
 	public void appendOssType(String s) {
-		if(this.ossType == null){
+		if (this.ossType == null){
 			this.ossType="";
 		}
 		this.ossType += s;
@@ -1550,13 +1550,13 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @return the download location link format
 	 */
 	public String getDownloadLocationLinkFormat() {
-		if(StringUtil.isEmpty(this.downloadLocationLinkFormat) && !StringUtil.isEmpty(this.downloadLocation)) {
-			if(this.downloadLocation.contains(",")){
+		if (StringUtil.isEmpty(this.downloadLocationLinkFormat) && !StringUtil.isEmpty(this.downloadLocation)) {
+			if (this.downloadLocation.contains(",")){
 				String[] downloadLocations = this.downloadLocation.split(",");
 				String result = "";
 				
-				for(int i = 0 ; i < downloadLocations.length ; i++){
-					if(i > 0){ result += "<br>"; }
+				for (int i = 0 ; i < downloadLocations.length ; i++){
+					if (i > 0){ result += "<br>"; }
 					
 					result += "<a href='"+downloadLocations[i]+"' target='_blank'>" + downloadLocations[i] + "</a>";
 				}
@@ -1584,7 +1584,7 @@ public class OssMaster extends ComBean implements Serializable{
 	 * @return the homepage link format
 	 */
 	public String getHomepageLinkFormat() {
-		if(StringUtil.isEmpty(this.homepageLinkFormat) && !StringUtil.isEmpty(this.homepage)) {
+		if (StringUtil.isEmpty(this.homepageLinkFormat) && !StringUtil.isEmpty(this.homepage)) {
 			return "<a href='"+this.homepage+"' target='_blank'>" + this.homepage + "</a>";
 		}
 		return homepageLinkFormat;
@@ -1761,7 +1761,7 @@ public class OssMaster extends ComBean implements Serializable{
 
 	public void setDownloadLocationGroup(String downloadLocationGroup) {
 		// OSS를 삭제하면서 다른 OSS로 rename시, "This oss has multiple version"이라 뜨며 에러 발생. / NullPointException
-		if(!isEmpty(downloadLocationGroup)){
+		if (!isEmpty(downloadLocationGroup)){
 			this.downloadLocations = downloadLocationGroup.split(",");
 		}
 		
@@ -1841,8 +1841,8 @@ public class OssMaster extends ComBean implements Serializable{
 		
 		this.detectedLicenses = null; // clear
 		
-		for(String s : list) {
-			if(!isEmpty(s)) {
+		for (String s : list) {
+			if (!isEmpty(s)) {
 				this.addDetectedLicense(s.trim());
 			}
 		}
@@ -1863,7 +1863,7 @@ public class OssMaster extends ComBean implements Serializable{
 	}
 	
 	public void addDetectedLicense(String s) {
-		if(this.detectedLicenses == null) {
+		if (this.detectedLicenses == null) {
 			this.detectedLicenses = new ArrayList<>();
 		}
 		
@@ -1977,7 +1977,7 @@ public class OssMaster extends ComBean implements Serializable{
 	}
 
 	public void addDeclaredLicense(String s) {
-		if(this.declaredLicenses == null) {
+		if (this.declaredLicenses == null) {
 			this.declaredLicenses = new ArrayList<>();
 		}
 		this.declaredLicenses.add(s);
@@ -1987,8 +1987,8 @@ public class OssMaster extends ComBean implements Serializable{
 		String[] list = declaredLicense.split(",");
 
 		this.declaredLicenses = null; // clear
-		for(String s : list) {
-			if(!isEmpty(s)) {
+		for (String s : list) {
+			if (!isEmpty(s)) {
 				this.addDeclaredLicense(s.trim());
 			}
 		}

--- a/src/main/java/oss/fosslight/domain/Project.java
+++ b/src/main/java/oss/fosslight/domain/Project.java
@@ -819,7 +819,7 @@ public class Project extends ComBean implements Serializable {
 	 */
 	public void setDistributionType(String distributionType) {
 		this.distributionType = distributionType;
-		if(!isEmpty(distributionType) && isEmpty(this.distributionTypeOfCodeDtlExp)) {
+		if (!isEmpty(distributionType) && isEmpty(this.distributionTypeOfCodeDtlExp)) {
 			this.distributionTypeOfCodeDtlExp = CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE, distributionType);
 		}
 	}
@@ -2500,7 +2500,7 @@ public class Project extends ComBean implements Serializable {
 	 * @param prjId the prj id
 	 */
 	public void addPrjIdList(String prjId) {
-		if(this.prjIdList == null) {
+		if (this.prjIdList == null) {
 			this.prjIdList = new ArrayList<>();
 		}
 		this.prjIdList.add(prjId);

--- a/src/main/java/oss/fosslight/domain/ProjectIdentification.java
+++ b/src/main/java/oss/fosslight/domain/ProjectIdentification.java
@@ -1308,7 +1308,7 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	 * @param s the s
 	 */
 	public void addComponentIdList(String s) {
-		if(this.componentIdList == null) {
+		if (this.componentIdList == null) {
 			this.componentIdList = new ArrayList<>();
 		}
 		this.componentIdList.add(s);
@@ -1338,7 +1338,7 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	 * @param license the license
 	 */
 	public void addComponentLicenseList(ProjectIdentification license) {
-		if(this.componentLicenseList == null) {
+		if (this.componentLicenseList == null) {
 			this.componentLicenseList = new ArrayList<>();
 		}
 		this.componentLicenseList.add(license);
@@ -1368,7 +1368,7 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	 * @param bean the bean
 	 */
 	public void addOssComponentsLicense(OssComponentsLicense bean) {
-		if(this.ossComponentsLicenseList == null) {
+		if (this.ossComponentsLicenseList == null) {
 			this.ossComponentsLicenseList = new ArrayList<>();
 		}
 		this.ossComponentsLicenseList.add(bean);

--- a/src/main/java/oss/fosslight/domain/Statistics.java
+++ b/src/main/java/oss/fosslight/domain/Statistics.java
@@ -46,7 +46,7 @@ public class Statistics extends ComBean implements Serializable {
 	private int total;
 	
 	public void addCategoryCnt(int categoryCnt, int idx) {
-		if(this.dataArray.size() == idx) {
+		if (this.dataArray.size() == idx) {
 			this.dataArray.add(new ArrayList<Integer>());
 		}
 		this.dataArray.get(idx).add(categoryCnt);
@@ -67,7 +67,7 @@ public class Statistics extends ComBean implements Serializable {
 	private List<String> categoryList;
 	
 	public void addCategoryList(String columnName) {
-		if(this.categoryList == null) {
+		if (this.categoryList == null) {
 			this.categoryList = new ArrayList<String>();
 		}
 		this.categoryList.add(columnName);

--- a/src/main/java/oss/fosslight/domain/T2File.java
+++ b/src/main/java/oss/fosslight/domain/T2File.java
@@ -58,7 +58,7 @@ public class T2File extends ComBean implements Serializable {
 	}
 
 	public void setBeforeOrigNm(String beforeOrigNm) {
-		if(beforeOrigNm != null) {
+		if (beforeOrigNm != null) {
 			beforeOrigNm = beforeOrigNm.replaceAll("\t", "").trim();
 		}
 		this.beforeOrigNm = beforeOrigNm;
@@ -69,7 +69,7 @@ public class T2File extends ComBean implements Serializable {
 	}
 	
 	public void setOrigNm(String origNm) {
-		if(origNm != null) {
+		if (origNm != null) {
 			origNm = origNm.replaceAll("\t", "").trim();
 		}
 		this.origNm = origNm;
@@ -78,7 +78,7 @@ public class T2File extends ComBean implements Serializable {
 		return logiNm;
 	}
 	public void setLogiNm(String logiNm) {
-		if(logiNm != null) {
+		if (logiNm != null) {
 			logiNm = logiNm.replaceAll("\t", "").trim();
 		}
 		this.logiNm = logiNm;

--- a/src/main/java/oss/fosslight/domain/T2Users.java
+++ b/src/main/java/oss/fosslight/domain/T2Users.java
@@ -326,24 +326,24 @@ public class T2Users extends ComBean implements Serializable{
 	}
 
 	public String getDefaultTabAnchor() {
-		if(isEmpty(defaultTabAnchor) && !isEmpty(defaultTab)) {
+		if (isEmpty(defaultTabAnchor) && !isEmpty(defaultTab)) {
 			String _temp = "";
-			for(String s : defaultTab.split(",")) {
+			for (String s : defaultTab.split(",")) {
 				String _anchor = CoCodeManager.getCodeExpString(CoConstDef.CD_DEFAULT_TAB, s);
-				if(!isEmpty(_anchor)) {
-					if(!isEmpty(_temp)) {
+				if (!isEmpty(_anchor)) {
+					if (!isEmpty(_temp)) {
 						_temp += ",";
 					}
 					_temp += _anchor;
 				}
 			}
 			
-			if(!isEmpty(_temp)) {
+			if (!isEmpty(_temp)) {
 				return _temp;
 			}
 		}
 		
-		for(String[] dtlCd : CoCodeManager.getValues(CoConstDef.CD_DEFAULT_TAB)) {
+		for (String[] dtlCd : CoCodeManager.getValues(CoConstDef.CD_DEFAULT_TAB)) {
 			defaultTab = dtlCd[0]; // detail No
 			defaultTabAnchor = dtlCd[3]; // detail Description
 			

--- a/src/main/java/oss/fosslight/interceptor/AjaxInterceptor.java
+++ b/src/main/java/oss/fosslight/interceptor/AjaxInterceptor.java
@@ -32,9 +32,9 @@ public class AjaxInterceptor implements HandlerInterceptor {
     		SecurityContext sc = SecurityContextHolder.getContext();
 			Authentication auth = sc.getAuthentication();
 			
-			if(auth == null) {
+			if (auth == null) {
 				//Ajax 콜인지 아닌지 판단
-                if(isAjaxRequest(request)){
+                if (isAjaxRequest(request)){
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
                     return false;
                 }

--- a/src/main/java/oss/fosslight/scheduler/SchedulerWorkerTask.java
+++ b/src/main/java/oss/fosslight/scheduler/SchedulerWorkerTask.java
@@ -55,9 +55,9 @@ public class SchedulerWorkerTask extends CoTopComponent {
 		String fileNm = "internalLicense.zip";
 		Path copyPath = Paths.get(internalUrlDirPath);
 		
-		if(!new File(internalUrlDirPath+"/"+fileNm).exists()) {
+		if (!new File(internalUrlDirPath+"/"+fileNm).exists()) {
 			try (InputStream is = new ClassPathResource("/template/"+fileNm).getInputStream()) {
-				if(!Files.exists(copyPath)) {
+				if (!Files.exists(copyPath)) {
 					Files.createDirectories(copyPath);
 				}
 				
@@ -79,7 +79,7 @@ public class SchedulerWorkerTask extends CoTopComponent {
 		try {
 			resCd = nvdService.executeNvdDataSync();
 			
-			if(resCd == "00") {
+			if (resCd == "00") {
 				vulnerabilityService.doSyncOSSNvdInfo();
 				log.info("nvdDataIfJob end");
 			} else {

--- a/src/main/java/oss/fosslight/service/NvdDataService.java
+++ b/src/main/java/oss/fosslight/service/NvdDataService.java
@@ -78,11 +78,11 @@ public class NvdDataService {
 		// 작업등록
 		try {
 			boolean fileCheck = nvdMetaCheckJob(NVD_DATA_FILE_NAME_CPEMATCH, "MATCH");
-			if(!fileCheck) {
+			if (!fileCheck) {
 				fileCheck = nvdMetaRetryCheckJob(NVD_DATA_FILE_NAME_CPEMATCH, "MATCH", fileCheck, 0);
 			}
 			
-			if(fileCheck) {
+			if (fileCheck) {
 				nvdFeedDataDownloadJob(NVD_DATA_FILE_NAME_CPEMATCH);
 				nvdMetaDataSyncJob();
 			}
@@ -94,7 +94,7 @@ public class NvdDataService {
 		try {
 			// initialize NVD Data Feed
 			// check initialize flag
-			if("Y".equalsIgnoreCase(codeMapper.getCodeDtlNm("990", "100")) ) {
+			if ("Y".equalsIgnoreCase(codeMapper.getCodeDtlNm("990", "100")) ) {
 				codeMapper.updateCodeDtlNm("990", "100", "N");
 
 				// delete all NVD Data and Max Score
@@ -110,11 +110,11 @@ public class NvdDataService {
 
 		try {
 			boolean fileCheck = nvdMetaCheckJob(NVD_DATA_FILE_NAME_NVDCVE, "CVE");
-			if(!fileCheck) {
+			if (!fileCheck) {
 				fileCheck = nvdMetaRetryCheckJob(NVD_DATA_FILE_NAME_NVDCVE, "CVE", fileCheck, 0);
 			}
 			
-			if(fileCheck) {
+			if (fileCheck) {
 				nvdFeedDataDownloadJob(NVD_DATA_FILE_NAME_NVDCVE);
 				nvdCveDataSyncJob();
 			}
@@ -138,7 +138,7 @@ public class NvdDataService {
 		
 		boolean updateFlag = false;
 		// 2. Json File -> DB Insert
-		for(Map<String, Object> wMetaMap : waitList){
+		for (Map<String, Object> wMetaMap : waitList){
 
 			param.put("fileNm", wMetaMap.get("fileNm"));
 			param.put("modiDate", wMetaMap.get("modiDate"));
@@ -147,7 +147,7 @@ public class NvdDataService {
 			nvdDataMapper.updateJobStatus(param);
 			
 			String NVD_CVE_PATH = env.getProperty("root.dir");
-			if(StringUtil.isEmpty(NVD_CVE_PATH)) {
+			if (StringUtil.isEmpty(NVD_CVE_PATH)) {
 				NVD_CVE_PATH = new FileSystemResource("").getFile().getAbsolutePath();
 			}
 			NVD_CVE_PATH = Paths.get(NVD_CVE_PATH, "nvd/cve").toString();
@@ -163,7 +163,7 @@ public class NvdDataService {
 		// truncate and insert 처리
 		// 위험성 : truncate는 transaction 으로 관리 할 수 없다. truncate이후에 insert 실패시 data 없을 수 있음
 		
-		if(updateFlag){
+		if (updateFlag){
 			String insertQuery = "INSERT INTO NVD_DATA_TEMP_V3 (PRODUCT, VERSION, VENDOR, CVE_ID, CVSS_SCORE, VULN_SUMMARY, MODI_DATE ) VALUES (?,?,?,?,?,?,?) "
 					+ "ON DUPLICATE KEY UPDATE PRODUCT = values(PRODUCT), VERSION = values(VERSION), VENDOR = values(VENDOR), CVE_ID = values(CVE_ID), CVSS_SCORE = values(CVSS_SCORE), VULN_SUMMARY = values(VULN_SUMMARY), MODI_DATE = values(MODI_DATE)";
 			
@@ -204,7 +204,7 @@ public class NvdDataService {
 				getMaxScoreProductVerStmt = conn1.prepareStatement(selectQuery2);
 				insertStmt = conn2.prepareStatement(insertQuery);
 				
-				for(int idx = 0; idx < cnt; ) {
+				for (int idx = 0; idx < cnt; ) {
 					if (endIdx >= cnt) {
 						endIdx = cnt;
 					}
@@ -213,7 +213,7 @@ public class NvdDataService {
 					idx = idx+BATCH_SIZE;
 					endIdx = idx+BATCH_SIZE;
 					
-					if(idx % 10000 == 0) {
+					if (idx % 10000 == 0) {
 						log.info("NVD_DATA_TEMP_V3 process : " + idx + " / " + cnt);
 					}
 				}
@@ -293,7 +293,7 @@ public class NvdDataService {
 		}
 		
 		int nickNameMgrCnt = nvdDataMapper.selectNickNameMgrtNvdDataScoreV3();
-		if(nickNameMgrCnt > 0) {
+		if (nickNameMgrCnt > 0) {
 			log.info("Nickname Migration Count : " + nickNameMgrCnt);
 			// OSS_NICKNAME 기준으로 NVD_DATA_SCORE_V3에 NICKNAME을 추가함.
 			nvdDataMapper.insertNickNameMgrtNvdDataScoreV3();
@@ -302,7 +302,7 @@ public class NvdDataService {
 		}
 		
 		int MaxCvssScoreCnt = nvdDataMapper.selectMaxCvssScoreNvdDataScoreV3();
-		if(MaxCvssScoreCnt > 0) {
+		if (MaxCvssScoreCnt > 0) {
 			log.info("MaxCvssScore Added Count : " + MaxCvssScoreCnt);
 			// NVD_DATA_SCORE_V3에서 CVSS_SCORE MAX값을 기준으로 PRODUCT에서 VERSION이 없는 DATA를 추가함.
 			nvdDataMapper.insertMaxCvssScoreNvdDataScoreV3();
@@ -311,7 +311,7 @@ public class NvdDataService {
 		}
 		
 		int diffCvssScoreCnt = nvdDataMapper.ossNameNickNameCvssScoreDiffCnt();
-		if(diffCvssScoreCnt > 0){
+		if (diffCvssScoreCnt > 0){
 			log.info("ossName <-> NickName cvssScore Diff Count : " + diffCvssScoreCnt);
 			// ossName과 NickName의 nvd data가 동일한 version일 경우에 cvss score만 다를때 더 높은 값으로 변경을 함. 변경시 CVE ID 도 같이 변경을 함.
 			nvdDataMapper.ossNameToNickNameMgrtCvssScore();
@@ -344,13 +344,13 @@ public class NvdDataService {
 				
 				itemList.add(itemMap);
 				
-				if(itemList.size() % BATCH_SIZE == 0) {
+				if (itemList.size() % BATCH_SIZE == 0) {
 					preparedStatementGetMaxScoreProductVer(conn2, getMaxScoreProductVerStmt, insertStmt, itemList, params);
 					itemList.clear();
 				}
 			}
 			
-			if(itemList.size() > 0) {
+			if (itemList.size() > 0) {
 				preparedStatementGetMaxScoreProductVer(conn2, getMaxScoreProductVerStmt, insertStmt, itemList, params);
 			}
 		} catch(Exception e) {
@@ -379,10 +379,10 @@ public class NvdDataService {
 			String vendor = "";
 			List<String> vendorList = new ArrayList<>();
 			
-			for(Map<String, Object> item : itemList) {
+			for (Map<String, Object> item : itemList) {
 				vendor = (String) item.get("vendor");
-				for(String chk : vendor.split(",")) {
-					if(!StringUtil.isEmpty(chk)) {
+				for (String chk : vendor.split(",")) {
+					if (!StringUtil.isEmpty(chk)) {
 						vendorList.add(chk);
 					}
 				}
@@ -396,9 +396,9 @@ public class NvdDataService {
 				
 				getMaxScoreProductVerStmt.clearParameters();
 				
-				if(vendorList.size() > 0) {
+				if (vendorList.size() > 0) {
 					while (getMaxScoreProductVerRs.next()) {
-						for(String vn : vendorList) {
+						for (String vn : vendorList) {
 							paramMap = new HashMap<>();
 							paramMap.put("PRODUCT", getMaxScoreProductVerRs.getString(1));
 							paramMap.put("VERSION", getMaxScoreProductVerRs.getString(2));
@@ -410,7 +410,7 @@ public class NvdDataService {
 							
 							params.add(paramMap);
 							
-							if(params.size() % BATCH_SIZE == 0) {
+							if (params.size() % BATCH_SIZE == 0) {
 								preparedStatementInsertNvdDataListTempV3(conn2, insertStmt, params);
 								params.clear();
 							}
@@ -429,7 +429,7 @@ public class NvdDataService {
 						
 						params.add(paramMap);
 						
-						if(params.size() % BATCH_SIZE == 0) {
+						if (params.size() % BATCH_SIZE == 0) {
 							preparedStatementInsertNvdDataListTempV3(conn2, insertStmt, params);
 							params.clear();
 						}
@@ -439,7 +439,7 @@ public class NvdDataService {
 				vendorList.clear();
 			}
 			
-			if(params.size() > 0) {
+			if (params.size() > 0) {
 				preparedStatementInsertNvdDataListTempV3(conn2, insertStmt, params);
 				params.clear();
 			}
@@ -468,7 +468,7 @@ public class NvdDataService {
 	
 	private void preparedStatementInsertNvdDataListTempV3(Connection conn2, PreparedStatement insertStmt, List<Map<String, Object>> params) {
 		try{
-			for(Map<String, Object> item : params) {
+			for (Map<String, Object> item : params) {
 				insertStmt.setString(1, (String) item.get("PRODUCT"));
 				insertStmt.setString(2, (String) item.get("VERSION"));
 				insertStmt.setString(3, (String) item.get("VENDOR"));
@@ -496,7 +496,7 @@ public class NvdDataService {
 		ObjectMapper mapper = new ObjectMapper();
 		Map<String, Object> map = mapper.readValue(  new File(cpeFileRootPath + File.separator + cpeFileName + ".json") , new TypeReference<Map<String, Object>>() { });
 		
-		if(map.containsKey("CVE_Items")) {
+		if (map.containsKey("CVE_Items")) {
 			List<Map<String, Object>> cveItems = (List<Map<String, Object>>) map.get("CVE_Items");
 			Map<String, Object> cveInfo = null;
 			Map<String, Object> comapare = null;
@@ -505,10 +505,10 @@ public class NvdDataService {
 			
 			List<Map<String, Object>> cpe_match_all = null;
 			
-			for(Map<String, Object> cveItem : cveItems) {
+			for (Map<String, Object> cveItem : cveItems) {
 				
 				cveInfo = cveDatajsonReader(cveItem);
-				if(cveInfo == null || cveInfo.isEmpty()) {
+				if (cveInfo == null || cveInfo.isEmpty()) {
 					continue;
 				}
 				
@@ -519,7 +519,7 @@ public class NvdDataService {
 				List<String> matchNames = null;
 				cpe_match_all = (List<Map<String, Object>>) cveInfo.get("cpe_match_all");
 				
-//				if(cpe_match_all.isEmpty()) {
+//				if (cpe_match_all.isEmpty()) {
 //					log.info("REJECTED CVE " + cveId);
 //				}
 				
@@ -574,42 +574,42 @@ public class NvdDataService {
 
 				comapare = nvdDataMapper.selectOneCveInfoV3(cveInfo);
 				// 신규등록
-				if(comapare == null){
+				if (comapare == null){
 					nvdDataMapper.insertCveInfoV3(cveInfo);
 					
-					if(!ossList.isEmpty()) {
+					if (!ossList.isEmpty()) {
 						insertDataList.addAll(ossList);
 					}
 					
 					updateFlag = true;
 				}
 				// 변경(delete > insert)
-				else if(!DateUtil.equals((Date)comapare.get("modiDate"), (Date) cveInfo.get("modiDate"))
+				else if (!DateUtil.equals((Date)comapare.get("modiDate"), (Date) cveInfo.get("modiDate"))
 						|| !((Float)comapare.get("cvssScore")).equals(Float.valueOf((String)cveInfo.get("cvssScore"))) ){
 					// 기존 데이터 삭제
 					nvdDataMapper.deleteCveDataV3(cveInfo);
 					nvdDataMapper.deleteNvdDataV3(cveInfo);
 					// 변경 데이터 등록
 					nvdDataMapper.insertCveInfoV3(cveInfo);
-					if(!ossList.isEmpty()) {
+					if (!ossList.isEmpty()) {
 						insertDataList.addAll(ossList);
 					}
 				} else if (DateUtil.equals((Date)comapare.get("modiDate"), (Date) cveInfo.get("modiDate"))
 						&& ((Float)comapare.get("cvssScore")).equals(Float.valueOf((String)cveInfo.get("cvssScore")))) {
 					// NVD_CVE_V3는 변경 대상이 아니지만 NVD_DATA_V3에 적용 될 대상이 존재 한 경우
 					
-					if(!ossList.isEmpty()) {
+					if (!ossList.isEmpty()) {
 						insertDataList.addAll(ossList);
 					}
 				}
 				
-				if(insertDataList.size() % BATCH_SIZE == 0) {
+				if (insertDataList.size() % BATCH_SIZE == 0) {
 					prepareStatementUpdateNvdData(insertDataList);
 					insertDataList.clear();
 				}
 			}
 			
-			if(insertDataList.size() > 0) {
+			if (insertDataList.size() > 0) {
 				prepareStatementUpdateNvdData(insertDataList);
 			}
 		}
@@ -631,7 +631,7 @@ public class NvdDataService {
 			
 			int seq = 1;
 			
-			for(Map<String, String> item : insertDataList){
+			for (Map<String, String> item : insertDataList){
 				stmt.setString(1, (String) item.get("cveId"));
 				stmt.setString(2, (String) item.get("product"));
 				stmt.setString(3, (String) item.get("version"));
@@ -639,7 +639,7 @@ public class NvdDataService {
 				stmt.addBatch();
 				stmt.clearParameters();
 				
-				if((seq % BATCH_SIZE) == 0 ) {
+				if ((seq % BATCH_SIZE) == 0 ) {
 					stmt.executeBatch();
 					stmt.clearBatch();
 					conn.commit();
@@ -652,7 +652,7 @@ public class NvdDataService {
 			conn.commit();
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
-			if(conn != null) {
+			if (conn != null) {
 				try {
 					conn.rollback();
 				} catch (Exception e2) {
@@ -687,7 +687,7 @@ public class NvdDataService {
 		// impact
 		Map<String, Object> impact = (Map<String, Object>) cveItem.get("impact");
 
-//		if(!impact.containsKey("baseMetricV3") && !impact.containsKey("baseMetricV2")) {
+//		if (!impact.containsKey("baseMetricV3") && !impact.containsKey("baseMetricV2")) {
 //			// REJECT
 //			return null;
 //		}
@@ -695,12 +695,12 @@ public class NvdDataService {
 		// CVSS V3가 없는 경우 V2 Score를 사용
 		String baseScore = "0";
 		String baseMetric = "";
-		if(impact.containsKey("baseMetricV3")) {
+		if (impact.containsKey("baseMetricV3")) {
 			Map<String, Object> baseMetricV3 = (Map<String, Object>) impact.get("baseMetricV3");
 			Map<String, Object> cvssV3 = (Map<String, Object>) baseMetricV3.get("cvssV3");
 			baseScore = String.valueOf(cvssV3.get("baseScore"));
 			baseMetric = "V3";					
-		} else if(impact.containsKey("baseMetricV2")){
+		} else if (impact.containsKey("baseMetricV2")){
 			Map<String, Object> baseMetricV2 = (Map<String, Object>) impact.get("baseMetricV2");
 			Map<String, Object> cvssV2 = (Map<String, Object>) baseMetricV2.get("cvssV2");
 			baseScore = String.valueOf(cvssV2.get("baseScore"));
@@ -714,17 +714,17 @@ public class NvdDataService {
 		List<Map<String, Object>> configurations_nodes = (List<Map<String, Object>>) configurationsInfo.get("nodes");
 		
 		// 정의된 모든 cpe match 정보
-		for(Map<String, Object> node_data : configurations_nodes) {
+		for (Map<String, Object> node_data : configurations_nodes) {
 			// children cpe_match 대신 children 노드가 존재하는 경우, children 노드 하위에서 cpe_match 정보를 취득한다.
-			if(node_data.containsKey("cpe_match")) {
+			if (node_data.containsKey("cpe_match")) {
 				cpe_match_all.addAll((List<Map<String, Object>>) node_data.get("cpe_match"));
 			}
 			
-			if(node_data.containsKey("children")) {
+			if (node_data.containsKey("children")) {
 				List<Map<String, Object>> children = (List<Map<String, Object>>) node_data.get("children");
 				// 스키마 구조상으로는 children 하위 노드에서 다시 operator AND 조건이 발생할 수 있지만, 실제 Data 존재하지 않았기 때문에
 				// 재귀처리는 생략하고 1Depth 까지만 찾는다.
-				for(Map<String, Object> children_data : children) {
+				for (Map<String, Object> children_data : children) {
 					cpe_match_all.addAll((List<Map<String, Object>>) children_data.get("cpe_match"));
 				}
 			}
@@ -734,8 +734,8 @@ public class NvdDataService {
 		Map<String, Object> description = (Map<String, Object>) cveInfo.get("description");
 		List<Map<String, Object>> description_datas = (List<Map<String, Object>>) description.get("description_data");
 		String descriptionStr = "";
-		for(Map<String, Object> description_data : description_datas) {
-			if(!StringUtil.isEmpty(descriptionStr)) {
+		for (Map<String, Object> description_data : description_datas) {
+			if (!StringUtil.isEmpty(descriptionStr)) {
 				descriptionStr += "\n";
 			}
 			descriptionStr += description_data.get("value");
@@ -756,7 +756,7 @@ public class NvdDataService {
 
 	private boolean nvdMetaCheckJob(String FILE_NM, String FILE_TYPE) throws IOException {
 		HashMap<String, String> metaInfo = nvdMetaData(FILE_NM);
-		if(metaInfo != null){
+		if (metaInfo != null){
 			// 1. 사용중인 메타 데이터 조회
 			HashMap<String, Object> param = new HashMap<String, Object>();
 			param.put("fileType", FILE_TYPE);
@@ -764,7 +764,7 @@ public class NvdDataService {
 			List<HashMap<String, Object>> useList = nvdDataMapper.selectUseMetaData(param);
 			// 2. 메타 데이터를 비교한다.
 			// 2.1. 신규 파일면 메타 데이터를 신규 등록한다.
-			if( useList.size() == 0 || !metaInfo.get("modiDate").equals(useList.get(0).get("modiDate")) ){
+			if ( useList.size() == 0 || !metaInfo.get("modiDate").equals(useList.get(0).get("modiDate")) ){
 				param.put("modiDate", metaInfo.get("modiDate"));
 				param.put("size", Integer.parseInt(metaInfo.get("size")));
 				param.put("zipSize",Integer.parseInt(metaInfo.get("zipSize")));
@@ -774,7 +774,7 @@ public class NvdDataService {
 				return true;
 			}
 			// 2.2. 변경된 파일이면 메타 데이터를 삭제한다.
-			if( useList.size() > 0 && !metaInfo.get("modiDate").equals(useList.get(0).get("modiDate")) ){
+			if ( useList.size() > 0 && !metaInfo.get("modiDate").equals(useList.get(0).get("modiDate")) ){
 				param.put("fileNm", FILE_NM);
 				param.put("modiDate", useList.get(0).get("modiDate"));
 				param.put("useYn", "N");
@@ -808,7 +808,7 @@ public class NvdDataService {
 			log.error(ioe.getMessage(), ioe);
 		}
 		
-		if(!fileCheck && cnt < maxCnt) {
+		if (!fileCheck && cnt < maxCnt) {
 			fileCheck = nvdMetaRetryCheckJob(FILE_NM, FILE_TYPE, fileCheck, ++cnt);
 		}
 		
@@ -823,7 +823,7 @@ public class NvdDataService {
 	 */
 	private void nvdFeedDataDownloadJob(String FILE_NAME) throws Exception  {
 		String NVD_CVE_PATH = env.getProperty("root.dir");
-		if(StringUtil.isEmpty(NVD_CVE_PATH)) {
+		if (StringUtil.isEmpty(NVD_CVE_PATH)) {
 			NVD_CVE_PATH = new FileSystemResource("").getFile().getAbsolutePath();
 		}
 		String NVD_DATA_BACKUP_PATH = NVD_CVE_PATH;
@@ -842,7 +842,7 @@ public class NvdDataService {
 			log.warn(e.getMessage(), e);
 			Thread.sleep(1000 * 30);
 			log.info("Retry downloading the NVD data file. FILE_NAME : " + FILE_NAME);
-			if(Paths.get(NVD_CVE_PATH, FILE_NAME + ".json.zip").toFile().exists()) {
+			if (Paths.get(NVD_CVE_PATH, FILE_NAME + ".json.zip").toFile().exists()) {
 				try {
 					Paths.get(NVD_CVE_PATH, FILE_NAME + ".json.zip").toFile().delete();
 				} catch (Exception e2) {}
@@ -864,7 +864,7 @@ public class NvdDataService {
 
 		
 		String NVD_CVE_PATH = env.getProperty("root.dir");
-		if(StringUtil.isEmpty(NVD_CVE_PATH)) {
+		if (StringUtil.isEmpty(NVD_CVE_PATH)) {
 			NVD_CVE_PATH = new FileSystemResource("").getFile().getAbsolutePath();
 		}
 		NVD_CVE_PATH = Paths.get(NVD_CVE_PATH, "nvd/cve").toString();
@@ -950,16 +950,16 @@ public class NvdDataService {
 							stmt.clearParameters();
 
 							// CPE Names
-							if(matchItem.containsKey("cpe_name")) {
+							if (matchItem.containsKey("cpe_name")) {
 								int nameIdx = 0;
-								for(Map<String, Object> cpe_name : (List<Map<String, Object>>) matchItem.get("cpe_name")) {
+								for (Map<String, Object> cpe_name : (List<Map<String, Object>>) matchItem.get("cpe_name")) {
 									stmt2.setInt(1, seq);
 									stmt2.setInt(2, nameIdx);
 									stmt2.setString(3, (String) cpe_name.get("cpe23Uri"));
 									stmt2.addBatch();
 									stmt2.clearParameters();
 									
-									if(seq2 % BATCH_SIZE == 0) {
+									if (seq2 % BATCH_SIZE == 0) {
 										stmt2.executeBatch(); // Batch 실행
 										stmt2.clearBatch(); // Batch 초기화
 					                    conn.commit(); // 커밋
@@ -969,7 +969,7 @@ public class NvdDataService {
 								}
 							}
 							
-							if(seq % BATCH_SIZE == 0) {
+							if (seq % BATCH_SIZE == 0) {
 								stmt.executeBatch(); // Batch 실행
 			                    stmt.clearBatch(); // Batch 초기화
 			                    conn.commit(); // 커밋
@@ -984,7 +984,7 @@ public class NvdDataService {
 						conn.commit();
 					} catch (Exception e) {
 						log.error(e.getMessage(), e);
-						if(conn != null) {
+						if (conn != null) {
 							try {
 								conn.rollback();
 							} catch (Exception e2) {
@@ -1010,7 +1010,7 @@ public class NvdDataService {
 					}
 				}
 
-				if(totSize > 0) {
+				if (totSize > 0) {
 					nvdDataMapper.truncateCpeMatch();
 					nvdDataMapper.truncateCpeMatchNames();
 					nvdDataMapper.copyNvdDataMatchFromTemp();
@@ -1043,10 +1043,10 @@ public class NvdDataService {
 			URL url = new URL( (NVD_DATA_FILE_NAME_CPEMATCH.equals(FILE_NM) ? NVD_META_URL : NVD_CVE_URL) +FILE_NM+".meta");
 			con = (HttpURLConnection)url.openConnection();
 			con.setRequestMethod("HEAD");
-			if(con.getResponseCode() == HttpURLConnection.HTTP_OK){
+			if (con.getResponseCode() == HttpURLConnection.HTTP_OK){
 				s = new Scanner(url.openConnection().getInputStream());
 				metaInfo = new HashMap<String, String>();
-				while(s.hasNext()){
+				while (s.hasNext()){
 					String txt = s.next();
 					String[] d = txt.split(":");
 					String k = d[0].equals("lastModifiedDate") ? "modiDate" : d[0];
@@ -1060,10 +1060,10 @@ public class NvdDataService {
 			log.error("unknownHost connection error : " + CommonFunction.httpCodePrint(con.getResponseCode()) + " - " + con.getResponseCode() + ", file name:" + FILE_NM);
 			return metaInfo;
 		} finally {
-			if(s != null) {
+			if (s != null) {
 				try {s.close();} catch (Exception e) {}
 			}
-			if(con != null) {
+			if (con != null) {
 				try {con.disconnect();} catch (Exception e) {}
 			}
 		}
@@ -1076,16 +1076,16 @@ public class NvdDataService {
 
 		int nvdBeginDateYear = 2002;
 		int currentDateYear = StringUtil.string2integer(DateUtil.getCurrentDateAsString("yyyy")) ;
-		for(int year = nvdBeginDateYear; year <= currentDateYear; year ++) {
+		for (int year = nvdBeginDateYear; year <= currentDateYear; year ++) {
 			nvdFeedDataDownloadJob("nvdcve-1.1-" + year);
 		}
 		
 		String NVD_CVE_PATH = env.getProperty("root.dir");
-		if(StringUtil.isEmpty(NVD_CVE_PATH)) {
+		if (StringUtil.isEmpty(NVD_CVE_PATH)) {
 			NVD_CVE_PATH = new FileSystemResource("").getFile().getAbsolutePath();
 		}
 		NVD_CVE_PATH = Paths.get(NVD_CVE_PATH, "nvd/cve").toString();
-		for(int year = nvdBeginDateYear; year <= currentDateYear; year ++) {
+		for (int year = nvdBeginDateYear; year <= currentDateYear; year ++) {
 			updateNvdData(NVD_CVE_PATH, "nvdcve-1.1-" + year);
 		}
 		

--- a/src/main/java/oss/fosslight/service/impl/ApiBatServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiBatServiceImpl.java
@@ -63,37 +63,37 @@ public class ApiBatServiceImpl implements ApiBatService {
 			{	
 				String fileName = (String) paramMap.get("fileName");
 				
-				if(!StringUtil.isEmpty(fileName)) {
+				if (!StringUtil.isEmpty(fileName)) {
 					strWhere += " AND UPPER(filename) LIKE UPPER('%" + fileName + "%') ";
 				}
 				
 				String tlsh = (String) paramMap.get("tlsh");
 				
-				if(!StringUtil.isEmpty(tlsh)){
+				if (!StringUtil.isEmpty(tlsh)){
 					strWhere += " AND UPPER(tlshchecksum) = UPPER('" + tlsh + "') ";
 				}
 
 				String checksum = (String) paramMap.get("checksum");
 				
-				if(!StringUtil.isEmpty(checksum)){
+				if (!StringUtil.isEmpty(checksum)){
 					strWhere += " AND UPPER(checksum) = UPPER('" + checksum + "') ";
 				}
 				
 				String platformName = (String) paramMap.get("platformName");
 				
-				if(!StringUtil.isEmpty(platformName)) {
+				if (!StringUtil.isEmpty(platformName)) {
 					strWhere += " AND UPPER(platformname) LIKE UPPER('%"+ platformName +"%') ";
 				}
 				
 				String platformVersion = (String) paramMap.get("platformVersion");
 				
-				if(!StringUtil.isEmpty(platformVersion)) {
+				if (!StringUtil.isEmpty(platformVersion)) {
 					strWhere += " AND UPPER(platformversion) LIKE UPPER('"+ platformVersion +"%') ";
 				}
 				
 				String sourcePath = (String) paramMap.get("sourcePath");
 				
-				if(!StringUtil.isEmpty(sourcePath)) {
+				if (!StringUtil.isEmpty(sourcePath)) {
 					strWhere += " AND UPPER(ossname) LIKE UPPER('%"+ sourcePath +"%') ";
 				}
 			}
@@ -104,7 +104,7 @@ public class ApiBatServiceImpl implements ApiBatService {
 			
 			rs = stmt.executeQuery(sql);
 			
-			while(rs.next()) {
+			while (rs.next()) {
 				Map<String, Object> batData = new HashMap<String, Object>();
 				
 				batData.put("binaryFileName", 	rs.getString("filename"));
@@ -125,13 +125,13 @@ public class ApiBatServiceImpl implements ApiBatService {
 		} catch(Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(totalRs != null) {
+			if (totalRs != null) {
 				try {
 					totalRs.close();
 				} catch (Exception e) {}
 			}
 			
-			if(rs != null) {
+			if (rs != null) {
 				try {
 					rs.close();
 				} catch (Exception e) {}

--- a/src/main/java/oss/fosslight/service/impl/ApiFileServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiFileServiceImpl.java
@@ -46,11 +46,11 @@ public class ApiFileServiceImpl implements ApiFileService {
 		UploadFile upFile = new UploadFile();
 		T2File registFile = new T2File();
 		
-		if(StringUtil.isEmpty(mFile.getOriginalFilename())) {
+		if (StringUtil.isEmpty(mFile.getOriginalFilename())) {
 			throw new RuntimeException("File Name is empty");
 		}
 		
-		if(mFile.getSize() <= 0) {
+		if (mFile.getSize() <= 0) {
 			throw new RuntimeException("File Size is 0");
 		}
 		
@@ -59,12 +59,12 @@ public class ApiFileServiceImpl implements ApiFileService {
 		// originalFileName에 경로가 포함되어 있는 경우 처리
 		log.debug("File upload OriginalFileName : " + originalFileName);
 		
-		if(originalFileName.indexOf("/") > -1) {
+		if (originalFileName.indexOf("/") > -1) {
 			originalFileName = originalFileName.substring(originalFileName.lastIndexOf("/") + 1);
 			
 			log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
 		}
-		if(originalFileName.indexOf("\\") > -1) {
+		if (originalFileName.indexOf("\\") > -1) {
 			originalFileName = originalFileName.substring(originalFileName.lastIndexOf("\\") + 1);
 			
 			log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
@@ -72,11 +72,11 @@ public class ApiFileServiceImpl implements ApiFileService {
 		
 		String fileExt = FilenameUtils.getExtension(originalFileName);
 		
-		if(originalFileName.toLowerCase().endsWith(".tgz.gz")) {
+		if (originalFileName.toLowerCase().endsWith(".tgz.gz")) {
 			fileExt = "tgz.gz";
-		} else if(originalFileName.toLowerCase().endsWith(".tar.bz2")) {
+		} else if (originalFileName.toLowerCase().endsWith(".tar.bz2")) {
 			fileExt = "tar.bz2";
-		} else if(originalFileName.toLowerCase().endsWith(".tar.gz")) {
+		} else if (originalFileName.toLowerCase().endsWith(".tar.gz")) {
 			fileExt = "tar.gz";
 		}
 		
@@ -84,7 +84,7 @@ public class ApiFileServiceImpl implements ApiFileService {
 		String uploadThumbFilePath = "";
 		
 		try {
-			if(StringUtil.isEmpty(filePath)) {
+			if (StringUtil.isEmpty(filePath)) {
 				uploadFilePath = CommonFunction.emptyCheckProperty("upload.path", "/upload");
 				uploadThumbFilePath = CommonFunction.emptyCheckProperty("image.path", "/image");
 			} else {
@@ -93,7 +93,7 @@ public class ApiFileServiceImpl implements ApiFileService {
 				
 				File packagingFile = new File(filePath);
 				
-				if(!packagingFile.exists()) {
+				if (!packagingFile.exists()) {
 					packagingFile.mkdirs();
 				}
 			}
@@ -135,13 +135,13 @@ public class ApiFileServiceImpl implements ApiFileService {
 		upFile.setRegistSeq(registFile(registFile));
 		upFile.setCreatedDate(CommonFunction.getCurrentDateTime(CoConstDef.DATABASE_FORMAT_DATE_ALL));
 		
-		if(mFile.getSize()!=0) { //File Null Check
-			if(! file.exists()) { //경로상에 파일이 존재하지 않을 경우
+		if (mFile.getSize()!=0) { //File Null Check
+			if (! file.exists()) { //경로상에 파일이 존재하지 않을 경우
 				try {
-					if(file.getParentFile() != null && file.getParentFile().mkdirs()) { //경로에 해당하는 디렉토리들을 생성
+					if (file.getParentFile() != null && file.getParentFile().mkdirs()) { //경로에 해당하는 디렉토리들을 생성
 						boolean upSucc = file.createNewFile(); //이후 파일 생성
 						
-						if(!upSucc) {
+						if (!upSucc) {
 							uploadSucc=false;
 						}
 					}
@@ -171,11 +171,11 @@ public class ApiFileServiceImpl implements ApiFileService {
 		boolean uploadSucc = true;
 		String fileName = mFile.getOriginalFilename();
 		
-		if(StringUtil.isEmpty(mFile.getOriginalFilename())) {
+		if (StringUtil.isEmpty(mFile.getOriginalFilename())) {
 			throw new RuntimeException("File Name is empty");
 		}
 		
-		if(mFile.getSize() <= 0) {
+		if (mFile.getSize() <= 0) {
 			throw new RuntimeException("File Size is 0");
 		}
 		
@@ -184,12 +184,12 @@ public class ApiFileServiceImpl implements ApiFileService {
 		// originalFileName에 경로가 포함되어 있는 경우 처리
 		log.debug("File upload OriginalFileName : " + originalFileName);
 		
-		if(originalFileName.indexOf("/") > -1) {
+		if (originalFileName.indexOf("/") > -1) {
 			originalFileName = originalFileName.substring(originalFileName.lastIndexOf("/") + 1);
 			
 			log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
 		}
-		if(originalFileName.indexOf("\\") > -1) {
+		if (originalFileName.indexOf("\\") > -1) {
 			originalFileName = originalFileName.substring(originalFileName.lastIndexOf("\\") + 1);
 			
 			log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
@@ -197,11 +197,11 @@ public class ApiFileServiceImpl implements ApiFileService {
 		
 		String fileExt = FilenameUtils.getExtension(originalFileName);
 		
-		if(originalFileName.toLowerCase().endsWith(".tgz.gz")) {
+		if (originalFileName.toLowerCase().endsWith(".tgz.gz")) {
 			fileExt = "tgz.gz";
-		} else if(originalFileName.toLowerCase().endsWith(".tar.bz2")) {
+		} else if (originalFileName.toLowerCase().endsWith(".tar.bz2")) {
 			fileExt = "tar.bz2";
-		} else if(originalFileName.toLowerCase().endsWith(".tar.gz")) {
+		} else if (originalFileName.toLowerCase().endsWith(".tar.gz")) {
 			fileExt = "tar.gz";
 		}
 		
@@ -249,12 +249,12 @@ public class ApiFileServiceImpl implements ApiFileService {
 		upFile.setRegistSeq(registFile(registFile));
 		upFile.setCreatedDate(CommonFunction.getCurrentDateTime(CoConstDef.DATABASE_FORMAT_DATE_ALL));
 		
-		if(mFile.getSize()!=0){ //File Null Check
-			if(! file.exists()){ //경로상에 파일이 존재하지 않을 경우
+		if (mFile.getSize()!=0){ //File Null Check
+			if (! file.exists()){ //경로상에 파일이 존재하지 않을 경우
 				try {
-					if(file.getParentFile() != null && file.getParentFile().mkdirs()){ //경로에 해당하는 디렉토리들을 생성
+					if (file.getParentFile() != null && file.getParentFile().mkdirs()){ //경로에 해당하는 디렉토리들을 생성
 							boolean upSucc = file.createNewFile(); //이후 파일 생성
-							if(!upSucc){
+							if (!upSucc){
 								uploadSucc=false;
 							}
 						}
@@ -276,20 +276,20 @@ public class ApiFileServiceImpl implements ApiFileService {
 		try {
 			File convertHTMLFile = null;
 			
-			if("XML".equals(fileExt.toUpperCase())) {
+			if ("XML".equals(fileExt.toUpperCase())) {
 				convertHTMLFile = CommonFunction.convertXMLToHTML(file, false);
-			} else if("ZIP".equals(fileExt.toUpperCase())) {
+			} else if ("ZIP".equals(fileExt.toUpperCase())) {
 				FileUtil.decompress(uploadFilePath + "/" + file.getName(), uploadFilePath + "/" + randomUUID);
 				convertHTMLFile = CommonFunction.convertXMLToHTML(new File(uploadFilePath + "/" + randomUUID), true);
-			} else if("TAR.GZ".equals(fileExt.toUpperCase())) {
+			} else if ("TAR.GZ".equals(fileExt.toUpperCase())) {
 				CompressUtil.decompressTarGZ(file, uploadFilePath + "/" + randomUUID);
 				convertHTMLFile = CommonFunction.convertXMLToHTML(new File(uploadFilePath + "/" + randomUUID), true);
 			}
 			
-			if(convertHTMLFile != null) {
+			if (convertHTMLFile != null) {
 				long convertHTMLFileSize = convertHTMLFile.length();
 				
-				if(convertHTMLFileSize > 0){
+				if (convertHTMLFileSize > 0){
 					UploadFile convertNoticeFile = new UploadFile();
 					String convertFileId = fileMapper.getFileId();
 					String convertNoticeFileName = "Notice-"+prjId+"_"+DateUtil.getCurrentDateTime(DateUtil.DATE_PATTERN)+".html";
@@ -334,7 +334,7 @@ public class ApiFileServiceImpl implements ApiFileService {
 	public String registFile(T2File file) {
 		int result = fileMapper.insertFile(file);
 		
-		if(result<=0){
+		if (result<=0){
 			return null;
 		}
 		

--- a/src/main/java/oss/fosslight/service/impl/ApiOssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiOssServiceImpl.java
@@ -28,7 +28,7 @@ public class ApiOssServiceImpl implements ApiOssService {
 	public List<Map<String, Object>> getOssInfo(Map<String, Object> paramMap) {
 		String rtnOssName = apiOssMapper.getOssName((String) paramMap.get("ossName"));
 		
-		if(!StringUtil.isEmpty(rtnOssName)) {
+		if (!StringUtil.isEmpty(rtnOssName)) {
 			paramMap.replace("ossName", rtnOssName);
 		}
 		
@@ -48,9 +48,9 @@ public class ApiOssServiceImpl implements ApiOssService {
 	
 	public String[] getOssNickNameListByOssName(String ossName) {
 		List<String> nickList = null;
-		if(!StringUtil.isEmpty(ossName)) {
+		if (!StringUtil.isEmpty(ossName)) {
 			nickList =  apiOssMapper.selectOssNicknameList(ossName);
-			if(nickList != null) {
+			if (nickList != null) {
 				nickList = nickList.stream()
 									.filter(CommonFunction.distinctByKey(nick -> nick.trim().toUpperCase()))
 									.collect(Collectors.toList());

--- a/src/main/java/oss/fosslight/service/impl/ApiPartnerServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiPartnerServiceImpl.java
@@ -27,7 +27,7 @@ public class ApiPartnerServiceImpl implements ApiPartnerService {
 		
 		int partnerCnt = apiPartnerMapper.selectPartnerMasterCount(paramMap);
 		
-		if(partnerCnt > 0) {
+		if (partnerCnt > 0) {
 			list = apiPartnerMapper.selectPartnerMaster(paramMap);
 		}
 		

--- a/src/main/java/oss/fosslight/service/impl/ApiProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiProjectServiceImpl.java
@@ -77,10 +77,10 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		
 		int projectCnt = apiProjectMapper.selectProjectTotalCount(paramMap);
 		
-		if(projectCnt > 0) {
+		if (projectCnt > 0) {
 			list = apiProjectMapper.selectProject(paramMap);
 			
-			for(Map<String, Object> map : list) {
+			for (Map<String, Object> map : list) {
 				String prjId = (String) map.get("prjId").toString();
 				String status = (String) map.get("status");
 				String distributionStatus = (String) map.get("distributionStatus");
@@ -114,8 +114,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		String ossReportFlag = (String) paramMap.get("ossReportFlag");
 		List<String> prjIdList = (List<String>) paramMap.get("prjId");
 		
-		if(prjIdList != null) {
-			if(isEmpty(ossReportFlag)) {
+		if (prjIdList != null) {
+			if (isEmpty(ossReportFlag)) {
 				ossReportFlag = CoConstDef.FLAG_NO;
 				
 				paramMap.put("ossReportFlag", ossReportFlag);
@@ -150,12 +150,12 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		
 		try {
 			if (!ExcelUtil.readReport(readType, true, sheet, ufile.getRegistSeq(), reportData, errMsgList)) {
-				for(String s : errMsgList) { // error 처리
-					if(isEmpty(s)) {
+				for (String s : errMsgList) { // error 처리
+					if (isEmpty(s)) {
 						continue;
 					}
 					
-					if(!isEmpty(errMsg)) {
+					if (!isEmpty(errMsg)) {
 						errMsg += "<br/>";
 					}
 					
@@ -167,19 +167,19 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			errMsg = e.getMessage();
 		}
 		
-		for(String s : errMsgList) {
-			if(isEmpty(s)) {
+		for (String s : errMsgList) {
+			if (isEmpty(s)) {
 				continue;
 			}
 			
-			if(!isEmpty(errMsg)) {
+			if (!isEmpty(errMsg)) {
 				errMsg += "<br/>";
 			}
 			
 			errMsg += s;
 		}
 		
-		if(isEmpty(errMsg)) {
+		if (isEmpty(errMsg)) {
 			 // Excel file Data를 duplicate Data에대해 merge하고 reset & Load 함.
 			Map<String, Object> resultMap = CommonFunction.makeGridDataFromReport(null, null, null, reportData, ufile.getRegistSeq(), readType);
 			List<ProjectIdentification> OssComponents = (List<ProjectIdentification>) resultMap.get("mainData");
@@ -209,18 +209,18 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		Map<String, Object> checkHeaderSheetName = new HashMap<String, Object>();
 		
 		try {
-			if(resultTxtBean != null) {
+			if (resultTxtBean != null) {
 				resultFileId = resultTxtBean.getRegistFileId();
 			}
 			
 			// 1) build image를 기준으로 oss data mapping (공통)
 			if (!ExcelUtil.readAndroidBuildImage("BIN (Android)", true, sheet, ossReportfileId, resultFileId, reportData, errMsgList, checkHeaderSheetName)) {
-				for(String s : errMsgList) { // error 처리
-					if(isEmpty(s)) {
+				for (String s : errMsgList) { // error 처리
+					if (isEmpty(s)) {
 						continue;
 					}
 					
-					if(!isEmpty(errMsg)) {
+					if (!isEmpty(errMsg)) {
 						errMsg += "<br/>";
 					}
 					
@@ -231,19 +231,19 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			log.error(e.getMessage(), e);
 		}
 		
-		for(String s : errMsgList) {
-			if(isEmpty(s)) {
+		for (String s : errMsgList) {
+			if (isEmpty(s)) {
 				continue;
 			}
 			
-			if(!isEmpty(errMsg)) {
+			if (!isEmpty(errMsg)) {
 				errMsg += "<br/>";
 			}
 			
 			errMsg += s;
 		}
 		
-		if(isEmpty(errMsg)) {
+		if (isEmpty(errMsg)) {
 			// result.text에 의해 변경된 내용이 있을 경우 사용자 표시
 			// validator에서 session에 격납한다.
 			String resultTextChangeHisStr = "";
@@ -271,7 +271,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			try {
 	            String fullName = noticeHtmlBean.getFilePath() + "/" + noticeHtmlBean.getFileName();
 	            
-	            if("xml".equalsIgnoreCase(FilenameUtils.getExtension(noticeHtmlBean.getFileName()))) {
+	            if ("xml".equalsIgnoreCase(FilenameUtils.getExtension(noticeHtmlBean.getFileName()))) {
 	                noticeBinaryList = CommonFunction.getAndroidNoticeBinaryXmlList(fullName);
 	            } else {
 	                noticeBinaryList = CommonFunction.getAndroidNoticeBinaryList(FileUtils.readFileToString(new File(fullName)));
@@ -280,7 +280,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	            Map<String, Object> convertObj = CommonFunction.convertToProjectIdentificationList(reportData, ossReportfileId);
 				noticeCheckResultMap = projectService.applySrcAndroidModel((List<ProjectIdentification>)convertObj.get("resultList"), noticeBinaryList);
 				
-				if(convertObj.containsKey("versionChangeList")) {
+				if (convertObj.containsKey("versionChangeList")) {
 					versionChangedList = (List<String>) convertObj.get("versionChangeList");
 				}
 			} catch (IOException ioe) {
@@ -298,28 +298,28 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			String systemChangeHisStr = "";
 			
-			if(!isEmpty(resultTextChangeHisStr)) {
+			if (!isEmpty(resultTextChangeHisStr)) {
 				systemChangeHisStr = resultTextChangeHisStr;
 			}
 			
-			if(!isEmpty(licenseNameChangeHisStr)) {
-				if(!isEmpty(systemChangeHisStr)) {
+			if (!isEmpty(licenseNameChangeHisStr)) {
+				if (!isEmpty(systemChangeHisStr)) {
 					systemChangeHisStr += "<br><br>";
 				}
 				
 				systemChangeHisStr += licenseNameChangeHisStr;
 			}
 			
-			if(versionChangedList != null) {
+			if (versionChangedList != null) {
 				String versionChangedStr = "<b>The following open source version below has been changed to a registered version</b><br><br>";
 				
-				for(String s : versionChangedList) {
+				for (String s : versionChangedList) {
 					versionChangedStr += "<br>" + s;
 				}
 				
 				putSessionObject(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_OSS_VERSION_CHANGED, ossReportfileId), versionChangedStr);
 				
-				if(!isEmpty(systemChangeHisStr)) {
+				if (!isEmpty(systemChangeHisStr)) {
 					systemChangeHisStr += "<br><br>";
 				}
 				
@@ -347,7 +347,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		Map<String, Object> result = new HashMap<String, Object>();
 		int duplicateCnt = apiProjectMapper.checkProject(paramMap);
 		
-		if(duplicateCnt == 0) {
+		if (duplicateCnt == 0) {
 			apiProjectMapper.createProject(paramMap);
 			
 			result.put("prjId", (String) paramMap.get("prjId").toString());
@@ -374,7 +374,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		paramMap.put("prjId", prjId);
 		paramMap.put("roleOutLicense", CoCodeManager.CD_ROLE_OUT_LICENSE);
 		
-		if(CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST != null && !CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST.isEmpty()) {
+		if (CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST != null && !CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST.isEmpty()) {
 			paramMap.put("roleOutLicenseIdList", CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST);
 		}
 		
@@ -382,7 +382,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		
 		List<Map<String, Object>> list = apiProjectMapper.selectBomList(paramMap);
 		
-		for(Map<String, Object> li : list) {
+		for (Map<String, Object> li : list) {
 			String licenseId = CommonFunction.removeDuplicateStringToken(avoidNull((String) li.get("licenseId")).toString(), ",");
 			String licenseName = CommonFunction.removeDuplicateStringToken((String) li.get("licenseName"), ",");
 			String componentId = String.valueOf(li.get("componentId"));
@@ -404,13 +404,13 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		String groupColumn = "";
 		boolean ossNameEmptyFlag = false;
 		
-		for(Map<String, Object> li : list) {
-			if(isEmpty(groupColumn)) {
+		for (Map<String, Object> li : list) {
+			if (isEmpty(groupColumn)) {
 				groupColumn = (String) li.get("ossName") + "-" + avoidNull((String) li.get("ossVersion"));
 			}
 			
-			if("-".equals(groupColumn)) {
-				if("NA".equals((String) li.get("licenseType"))) {
+			if ("-".equals(groupColumn)) {
+				if ("NA".equals((String) li.get("licenseType"))) {
 					ossNameEmptyFlag = true;
 				}
 			}
@@ -418,7 +418,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			String ossVersion = avoidNull((String) li.get("ossVersion"));
 			String licenseType = avoidNull((String) li.get("licenseType"));
 			
-			if(groupColumn.equals((String) li.get("ossName") + "-" + ossVersion) // 같은 groupColumn이면 데이터를 쌓음
+			if (groupColumn.equals((String) li.get("ossName") + "-" + ossVersion) // 같은 groupColumn이면 데이터를 쌓음
 					&& !("-".equals((String) li.get("ossName")) 
 					&& !"NA".equals(licenseType))
 					&& !ossNameEmptyFlag) { // 단, OSS Name: - 이면서, License Type: Proprietary이 아닌 경우 Row를 합치지 않음.
@@ -438,11 +438,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	
 	@SuppressWarnings("unchecked")
 	public static void setMergeData(List<Map<String, Object>> tempData, List<Map<String, Object>> resultGridData){
-		if(tempData.size() > 0) {
+		if (tempData.size() > 0) {
 			Collections.sort(tempData, new Comparator<Map<String, Object>>() {
 				@Override
 				public int compare(Map<String, Object> o1, Map<String, Object> o2) {
-					if(((String) o1.get("licenseName")).length() >= ((String) o2.get("licenseName")).length()) { // license name이 같으면 bomList조회해온 순서 그대로 유지함. license name이 다르면 순서변경
+					if (((String) o1.get("licenseName")).length() >= ((String) o2.get("licenseName")).length()) { // license name이 같으면 bomList조회해온 순서 그대로 유지함. license name이 다르면 순서변경
 						return 1;
 					}else {
 						return -1;
@@ -451,8 +451,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			});
 			
 			Map<String, Object> rtnBean = null;
-			for(Map<String, Object> temp : tempData) {
-				if(rtnBean == null) {
+			for (Map<String, Object> temp : tempData) {
+				if (rtnBean == null) {
 					rtnBean = temp;
 					
 					continue;
@@ -462,8 +462,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				String rtnLicenseName = (String) rtnBean.get("licenseName");
 				String key = (String) temp.get("ossName") + "-" + (String) temp.get("licenseType");
 				
-				if("--NA".equals(key)) {
-					if(!rtnLicenseName.contains(tempLicenseName)) {
+				if ("--NA".equals(key)) {
+					if (!rtnLicenseName.contains(tempLicenseName)) {
 						resultGridData.add(rtnBean);
 						rtnBean = temp;
 						
@@ -472,18 +472,18 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				}
 				
 				// 동일한 oss name과 version일 경우 license 정보를 중복제거하여 merge 함.
-				for(String tempStr : tempLicenseName.split(",")) {
+				for (String tempStr : tempLicenseName.split(",")) {
 					boolean equalFlag = false;
 					
-					for(String rtnStr : rtnLicenseName.split(",")) {
-						if(rtnStr.equals(tempStr)) {
+					for (String rtnStr : rtnLicenseName.split(",")) {
+						if (rtnStr.equals(tempStr)) {
 							equalFlag = true;
 							
 							break;
 						}
 					}
 					
-					if(!equalFlag) {
+					if (!equalFlag) {
 						rtnBean.replace("LICENSE_NAME", rtnLicenseName + "," + tempStr);
 					}
 				}
@@ -492,14 +492,14 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				List<Map<String, Object>> tempOssComponentsLicenseList = (List<Map<String, Object>>) temp.get("ossComponentsLicenseList");
 				List<Map<String, Object>> rtnOssComponentsLicenseList = (List<Map<String, Object>>) rtnBean.get("ossComponentsLicenseList");
 				
-				for(Map<String, Object> list : tempOssComponentsLicenseList) {
+				for (Map<String, Object> list : tempOssComponentsLicenseList) {
 					int equalsItemList = (int) rtnOssComponentsLicenseList
 														.stream()
 														.filter(e -> ((String) list.get("licenseName")).equals((String) e.get("licenseName"))) // 동일한 licenseName을 filter
 														.collect(Collectors.toList()) // return을 list로변환
 														.size(); // 해당 list의 size
 					
-					if(equalsItemList == 0) {
+					if (equalsItemList == 0) {
 						rtnComponentLicenseList.add(list);
 					}
 				}
@@ -544,9 +544,9 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		Map<String, Object> resultMap = new HashMap<String, Object>();
 
 		// Integrate Yaml Format, Vulnerability
-		for(String resultYamlFormatKey: resultYamlFormat.keySet()){
+		for (String resultYamlFormatKey: resultYamlFormat.keySet()){
 			List<Map<String, Object>> yamlFormatList = resultYamlFormat.get(resultYamlFormatKey);
-			for(Map<String, Object> yamlFormatMap: yamlFormatList) {
+			for (Map<String, Object> yamlFormatMap: yamlFormatList) {
 				String version = (String) yamlFormatMap.get("version");
 				List<Map<String, Object>> maxScoreNvdInfoList = apiVulnerabilityService.selectMaxScoreNvdInfo(resultYamlFormatKey, version);
 
@@ -589,11 +589,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				).collect(Collectors.toList());
 		
 		// status > add
-		for(Map<String, Object> after : filteredAfterBomList) {
+		for (Map<String, Object> after : filteredAfterBomList) {
 			String ossName = (String) after.get("ossName");
 			int addTargetCnt = filteredBeforeBomList.stream().filter(before -> ((String)before.get("ossName")).equals(ossName)).collect(Collectors.toList()).size();
 			
-			if(addTargetCnt == 0) {
+			if (addTargetCnt == 0) {
 				Map<String, Object> addMap = new LinkedHashMap<String, Object>();
 				
 				addMap.put("name", (String) after.get("ossName"));
@@ -605,11 +605,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		}
 		
 		// status > delete
-		for(Map<String, Object> before : filteredBeforeBomList) {
+		for (Map<String, Object> before : filteredBeforeBomList) {
 			String ossName = (String) before.get("ossName");
 			List<Map<String, Object>> afterList = filteredAfterBomList.stream().filter(after -> ((String)after.get("ossName")).equals(ossName)).collect(Collectors.toList());
 			
-			if(afterList.size() == 0) {
+			if (afterList.size() == 0) {
 				Map<String, Object> deleteMap = new LinkedHashMap<String, Object>();
 				
 				deleteMap.put("name", (String) before.get("ossName"));
@@ -620,19 +620,19 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		}
 		
 		// status > change
-		if(!filteredBeforeBomList.isEmpty() && !filteredAfterBomList.isEmpty()) {
+		if (!filteredBeforeBomList.isEmpty() && !filteredAfterBomList.isEmpty()) {
 			List<Map<String, Object>> deduplicatedBeforeBomList = new ArrayList<>();
 			List<Map<String, Object>> deduplicatedAfterBomList = new ArrayList<>();
 			
 			boolean firstFlag = true;
 			boolean deduplicateFlag = false;
 			
-			for(Map<String, Object> filteredBeforeBom : filteredBeforeBomList) {
+			for (Map<String, Object> filteredBeforeBom : filteredBeforeBomList) {
 				String ossName = (String) filteredBeforeBom.get("ossName");
 				String ossVersion = (String) filteredBeforeBom.get("ossVersion");
 				String licenseName = (String) filteredBeforeBom.get("licenseName");
 				
-				if(firstFlag) {
+				if (firstFlag) {
 					List<Map<String, Object>> addBeforeBomList = new ArrayList<>();
 					Map<String, Object> addBeforeBom = new LinkedHashMap<>();
 					Map<String, Object> addBeforeBom2 = new HashMap<>();
@@ -645,8 +645,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 					
 					firstFlag = false;
 				} else {
-					for(Map<String, Object> deduplicatedBeforeBom : deduplicatedBeforeBomList) {
-						if(deduplicatedBeforeBom.containsKey(ossName)) {
+					for (Map<String, Object> deduplicatedBeforeBom : deduplicatedBeforeBomList) {
+						if (deduplicatedBeforeBom.containsKey(ossName)) {
 							@SuppressWarnings("unchecked")
 							List<Map<String, Object>> orgValues = (List<Map<String, Object>>) deduplicatedBeforeBom.get(ossName);
 							
@@ -659,7 +659,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 						}
 					}
 					
-					if(!deduplicateFlag) {
+					if (!deduplicateFlag) {
 						List<Map<String, Object>> addBeforeBomList = new ArrayList<>();
 						Map<String, Object> addBeforeBom = new LinkedHashMap<>();
 						Map<String, Object> addBeforeBom2 = new HashMap<>();
@@ -674,12 +674,12 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				}
 			}
 			
-			for(Map<String, Object> filteredAfterBom : filteredAfterBomList) {
+			for (Map<String, Object> filteredAfterBom : filteredAfterBomList) {
 				String ossName = (String) filteredAfterBom.get("ossName");
 				String ossVersion = (String) filteredAfterBom.get("ossVersion");
 				String licenseName = (String) filteredAfterBom.get("licenseName");
 				
-				if(firstFlag) {
+				if (firstFlag) {
 					List<Map<String, Object>> addAfterBomList = new ArrayList<>();
 					Map<String, Object> addAfterBom = new LinkedHashMap<>();
 					Map<String, Object> addAfterBom2 = new HashMap<>();
@@ -692,8 +692,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 					
 					firstFlag = false;
 				} else {
-					for(Map<String, Object> deduplicatedAfterBom : deduplicatedAfterBomList) {
-						if(deduplicatedAfterBom.containsKey(ossName)) {
+					for (Map<String, Object> deduplicatedAfterBom : deduplicatedAfterBomList) {
+						if (deduplicatedAfterBom.containsKey(ossName)) {
 							@SuppressWarnings("unchecked")
 							List<Map<String, Object>> orgValues = (List<Map<String, Object>>) deduplicatedAfterBom.get(ossName);
 							
@@ -706,7 +706,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 						} 
 					}
 					
-					if(!deduplicateFlag) {
+					if (!deduplicateFlag) {
 						List<Map<String, Object>> addAfterBomList = new ArrayList<>();
 						Map<String, Object> addAfterBom = new LinkedHashMap<>();
 						Map<String, Object> addAfterBom2 = new HashMap<>();
@@ -721,11 +721,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				}
 			}
 			
-			for(Map<String, Object> deduplicatedBeforeBom : deduplicatedBeforeBomList) {
-				for(String beforeKey : deduplicatedBeforeBom.keySet()) {
-					for(Map<String, Object> deduplicatedAfterBom : deduplicatedAfterBomList) {
-						for(String afterKey : deduplicatedAfterBom.keySet()) {
-							if(beforeKey.equalsIgnoreCase(afterKey)) {
+			for (Map<String, Object> deduplicatedBeforeBom : deduplicatedBeforeBomList) {
+				for (String beforeKey : deduplicatedBeforeBom.keySet()) {
+					for (Map<String, Object> deduplicatedAfterBom : deduplicatedAfterBomList) {
+						for (String afterKey : deduplicatedAfterBom.keySet()) {
+							if (beforeKey.equalsIgnoreCase(afterKey)) {
 								Map<String, Object> changeMap = new LinkedHashMap<String, Object>();
 								
 								changeMap.put("name", afterKey);
@@ -771,7 +771,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		List<Map<String, Object>> list = apiProjectMapper.selectProject(paramMap);
 		List<Map<String, Object>> contents = new ArrayList<Map<String, Object>>();
 		
-		for(Map<String, Object> map : list) {
+		for (Map<String, Object> map : list) {
 			Map<String, Object> modelMap = new HashMap<String, Object>();
 			String prjId = (String) map.get("prjId").toString();
 			List<Map<String, Object>> modelList = apiProjectMapper.selectModelList(prjId);
@@ -795,7 +795,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	public List<Map<String, Object>> getVerifyOssList(Map<String, Object> project) {
 		List<Map<String, Object>> verifyFilePathList = apiProjectMapper.selectVerifyOssList(project);
 		
-		if(verifyFilePathList != null && !verifyFilePathList.isEmpty() && verifyFilePathList.get(0) == null) {
+		if (verifyFilePathList != null && !verifyFilePathList.isEmpty() && verifyFilePathList.get(0) == null) {
 			verifyFilePathList = new ArrayList<>();
 		}
 		
@@ -812,12 +812,12 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		final Comparator<Map<String, Object>> comp = Comparator.comparing((Map<String, Object> o) -> o.get("ossName")+"|"+ o.get("ossVersion"));
 		gridData = gridData.stream().sorted(comp).collect(Collectors.toList());
 		
-		for(Map<String, Object> info : gridData) {
-			if(isEmpty(groupColumn)) {
+		for (Map<String, Object> info : gridData) {
+			if (isEmpty(groupColumn)) {
 				groupColumn = (String) info.get("ossName") + "-" + (String) info.get("ossVersion");
 			}
 						
-			if(groupColumn.equals((String) info.get("ossName") + "-" + (String) info.get("ossVersion")) // 같은 groupColumn이면 데이터를 쌓음
+			if (groupColumn.equals((String) info.get("ossName") + "-" + (String) info.get("ossVersion")) // 같은 groupColumn이면 데이터를 쌓음
 					&& !("-".equals((String) info.get("ossName")) 
 					&& !"NA".equals((String) info.get("licenseType")))) { // 단, OSS Name: - 이면서, License Type: Proprietary이 아닌 경우 Row를 합치지 않음.
 				tempData.add(info);
@@ -836,11 +836,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	}
 
 	private void setVerifyMergeData(List<Map<String, Object>> tempData, List<Map<String, Object>> resultGridData) {
-		if(tempData.size() > 0) {
+		if (tempData.size() > 0) {
 			Collections.sort(tempData, new Comparator<Map<String, Object>>() {
 				@Override
 				public int compare(Map<String, Object> o1, Map<String, Object> o2) {
-					if(((String) o1.get("licenseName")).length() >= ((String) o2.get("licenseName")).length()) {
+					if (((String) o1.get("licenseName")).length() >= ((String) o2.get("licenseName")).length()) {
 						return 1;
 					}else {
 						return -1;
@@ -850,8 +850,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			Map<String, Object> rtnBean = null;
 			
-			for(Map<String, Object> temp : tempData) {
-				if(rtnBean == null) {
+			for (Map<String, Object> temp : tempData) {
+				if (rtnBean == null) {
 					rtnBean = temp;
 					
 					continue;
@@ -859,8 +859,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				
 				String key = (String) temp.get("ossName") + "-" + (String) temp.get("licenseType");
 				
-				if("--NA".equals(key)) {
-					if(!((String) rtnBean.get("licenseName")).contains((String) temp.get("licenseName"))) {
+				if ("--NA".equals(key)) {
+					if (!((String) rtnBean.get("licenseName")).contains((String) temp.get("licenseName"))) {
 						resultGridData.add(rtnBean);
 						rtnBean = temp;
 						
@@ -868,18 +868,18 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 					}
 				}
 				
-				for(String licenseName : ((String) temp.get("licenseName")).split(",")) {
+				for (String licenseName : ((String) temp.get("licenseName")).split(",")) {
 					boolean equalFlag = false;
 					
-					for(String rtnLicenseName : ((String) rtnBean.get("licenseName")).split(",")) {
-						if(rtnLicenseName.equals(licenseName)) {
+					for (String rtnLicenseName : ((String) rtnBean.get("licenseName")).split(",")) {
+						if (rtnLicenseName.equals(licenseName)) {
 							equalFlag = true;
 							
 							break;
 						}
 					}
 					
-					if(!equalFlag) {
+					if (!equalFlag) {
 						rtnBean.put("licenseName", (String) rtnBean.get("licenseName") + "," + licenseName);
 					}
 				}
@@ -909,7 +909,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		prjParam.put("packageFileId2", newPackagingFileIdList.get(1));
 		prjParam.put("packageFileId3", newPackagingFileIdList.get(2));
 		
-		for(String fileSeq : fileSeqs){
+		for (String fileSeq : fileSeqs){
 			Map<String, Object> paramT2File = new HashMap<>();
 			
 			paramT2File.put("fileSeq", fileSeq);
@@ -920,26 +920,26 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		String packagingUrl = appEnv.getProperty("packaging.path", "/upload/packaging") + "/" + prjId;
 		List<Map<String, Object>> result = apiFileMapper.selectPackagingFileInfo(prjId); // verify한 file을 select함.
 
-		if(result.size() > 0){
-			for(Map<String, Object> res : result){
+		if (result.size() > 0){
+			for (Map<String, Object> res : result){
 				String rtnFilePath = (String) res.get("logiPath");
 				String rtnFileName = (String) res.get("logiNm");
 				String rtnFileSeq = Integer.toString((int) res.get("fileSeq"));
 				
-				if(publicUrl.equals(rtnFilePath)){
+				if (publicUrl.equals(rtnFilePath)){
 					// select한 filePath가 upload Dir 일 경우 해당 파일만 삭제함.
 					file = new File(rtnFilePath + "/" + rtnFileName);
 					
 					int reuseCnt = apiFileMapper.getPackgingReuseCnt(rtnFileName);
 					
-					if(reuseCnt == 0){
+					if (reuseCnt == 0){
 						Map<String, Object> delFile = new HashMap<>();
 						delFile.put("fileSeq", rtnFileSeq);
 						delFile.put("gubn", "A");
 						int returnSuccess = apiFileMapper.updateFileDelYnKessan(delFile);
 						
-						if(returnSuccess > 0) {
-							if(file.delete()){
+						if (returnSuccess > 0) {
+							if (file.delete()){
 								log.debug(rtnFilePath + "/" + rtnFileName + " is delete success.");
 							} else {
 								log.debug(rtnFilePath + "/" + rtnFileName + " is delete failed.");
@@ -958,39 +958,39 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		try {
 			Map<String, Object> project = apiProjectMapper.selectProjectMaster(prjParam);
 			ArrayList<String> origPackagingFileIdList = new ArrayList<String>();
-			if(project.containsKey("packageFileId")) {
-				if(project.get("packageFileId") != null && !("").equals(Integer.toString((int) project.get("packageFileId")))){
+			if (project.containsKey("packageFileId")) {
+				if (project.get("packageFileId") != null && !("").equals(Integer.toString((int) project.get("packageFileId")))){
 					origPackagingFileIdList.add(Integer.toString((int) project.get("packageFileId")));
 				}
 			}
-			if(project.containsKey("packageFileId2")) {
-				if(project.get("packageFileId2") != null && !("").equals(Integer.toString((int) project.get("packageFileId2")))){
+			if (project.containsKey("packageFileId2")) {
+				if (project.get("packageFileId2") != null && !("").equals(Integer.toString((int) project.get("packageFileId2")))){
 					origPackagingFileIdList.add(Integer.toString((int) project.get("packageFileId2")));
 				}
 			}
-			if(project.containsKey("packageFileId3")) {
-				if(project.get("packageFileId3") != null && !("").equals(Integer.toString((int) project.get("packageFileId3")))){
+			if (project.containsKey("packageFileId3")) {
+				if (project.get("packageFileId3") != null && !("").equals(Integer.toString((int) project.get("packageFileId3")))){
 					origPackagingFileIdList.add(Integer.toString((int) project.get("packageFileId3")));
 				}
 			}
 						
 			int idx = 0;
 			
-			for(String fileId : origPackagingFileIdList){
+			for (String fileId : origPackagingFileIdList){
 				Map<String, Object> fileInfo = new HashMap<>();
 				
-				if(!isEmpty(fileId) && !fileId.equals(newPackagingFileIdList.get(idx))){
+				if (!isEmpty(fileId) && !fileId.equals(newPackagingFileIdList.get(idx))){
 					//fileInfo.setFileSeq(fileId);
 					fileInfo = apiFileMapper.selectFileInfo(fileId);
 					deleteComment += "Packaging file, "+ (String) fileInfo.get("origNm") +", was deleted by "+loginUserName()+". <br>";
 				}
 				
-				if(!isEmpty(newPackagingFileIdList.get(idx)) && !newPackagingFileIdList.get(idx).equals(fileId)){
+				if (!isEmpty(newPackagingFileIdList.get(idx)) && !newPackagingFileIdList.get(idx).equals(fileId)){
 					//fileInfo.setFileSeq(newPackagingFileIdList.get(idx));
 					fileInfo = apiFileMapper.selectFileInfo(newPackagingFileIdList.get(idx));
 					oss.fosslight.domain.File resultFile = (oss.fosslight.domain.File) apiProjectMapper.selectVerificationFile(newPackagingFileIdList.get(idx));
 					
-					if(CoConstDef.FLAG_YES.equals(resultFile.getReuseFlag())){
+					if (CoConstDef.FLAG_YES.equals(resultFile.getReuseFlag())){
 						uploadComment += "Packaging file, "+ (String) fileInfo.get("origNm")+", was loaded from Project ID: "+resultFile.getRefPrjId()+" by "+loginUserName()+". <br>";
 					} else {
 						uploadComment += "Packaging file, "+ (String) fileInfo.get("origNm")+", was uploaded by "+loginUserName()+". <br>";
@@ -1013,30 +1013,30 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		ArrayList<String> LogiNms = new ArrayList<String>();
 		ArrayList<String> reuseNms = new ArrayList<String>();
 		
-		for(Map<String, Object> uploadFileInfo : uploadFileInfos){
+		for (Map<String, Object> uploadFileInfo : uploadFileInfos){
 			LogiNms.add((String) uploadFileInfo.get("logiNm"));
 		}
 		
 		// 현재 proejct Packaging File 중 재사용중인 packaging File 이 있다면 제거 불가
 		List<Map<String, Object>> reusePackaging = apiFileMapper.getReusePackagingInfo();
 		
-		for(Map<String, Object> reuse : reusePackaging){
+		for (Map<String, Object> reuse : reusePackaging){
 			reuseNms.add((String) reuse.get("logiNm"));
 		}
 		
-		if(file.exists()){
-			for(File f : file.listFiles()){
+		if (file.exists()){
+			for (File f : file.listFiles()){
 				String fileNm = f.getName();
 				
-				if(!LogiNms.contains(fileNm)){
+				if (!LogiNms.contains(fileNm)){
 					Map<String, Object> delFile = new HashMap<String, Object>();
 					delFile.put("logiPath", url);
 					delFile.put("logiNm", f.getName());
 					
 					int returnSuccess = apiFileMapper.updateReuseChkFileDelYnByFilePathNm(delFile);
 					
-					if(returnSuccess > 0 && !reuseNms.contains(fileNm)){
-						if(f.delete()){
+					if (returnSuccess > 0 && !reuseNms.contains(fileNm)){
+						if (f.delete()){
 							log.debug(url + "/" + f.getName() + " is delete success.");
 						}else{
 							log.debug(url + "/" + f.getName() + " is delete failed.");
@@ -1049,12 +1049,12 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		// 재사용을 했었던 file중 다른 project에서도 재사용을 하지 않은 file 있는지 확인하고 재사용을 안한다면 file 삭제 / 추후 reuse하는 다른 project에서도 reuseFlag가 N이 되면 지우는 case이므로 log는 남기지 않음.
 		List<Map<String, Object>> reusePackagingFileList = apiFileMapper.getPackgingReuseCntToList(prjId);
 		
-		for(Map<String, Object> reusePackagingFile : reusePackagingFileList){ // reuseCnt가 0인 값만 불러오고 삭제처리 후 hidden flag를 Y로 변경 그리고 재검색시 조회 불가상태로 만듦.
+		for (Map<String, Object> reusePackagingFile : reusePackagingFileList){ // reuseCnt가 0인 값만 불러오고 삭제처리 후 hidden flag를 Y로 변경 그리고 재검색시 조회 불가상태로 만듦.
 			File reuseFile = new File((String) reusePackagingFile.get("logiPath"));
 			
-			if(reuseFile.exists()){
-				for(File f : reuseFile.listFiles()){
-					if(((String) reusePackagingFile.get("logiNm")).equals(f.getName())){
+			if (reuseFile.exists()){
+				for (File f : reuseFile.listFiles()){
+					if (((String) reusePackagingFile.get("logiNm")).equals(f.getName())){
 						Map<String, Object> delFile = new HashMap<>();
 						delFile.put("logiPath", reusePackagingFile.get("logiPath"));
 						delFile.put("logiNm", f.getName());
@@ -1067,8 +1067,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 						
 						apiFileMapper.setReusePackagingFileHidden(refPrjId, logiPath, logiNm);
 						
-						if(returnSuccess > 0){
-							if(f.delete()){
+						if (returnSuccess > 0){
+							if (f.delete()){
 								log.debug(url + "/" + f.getName() + " is delete success.");
 							}else{
 								log.debug(url + "/" + f.getName() + " is delete failed.");
@@ -1088,7 +1088,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		
 		int result = apiProjectMapper.checkPackagingFileId(prjId, packageFileId, packageFileId2, packageFileId3);
 		
-		if(result > 0){
+		if (result > 0){
 			return false;
 		}else{
 			return true;
@@ -1134,14 +1134,14 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			{
 				prjInfo = getProjectBasicInfo(prjId);
 				
-				if(prjInfo != null && CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals((String) prjInfo.get("verificationStatus"))) {
+				if (prjInfo != null && CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals((String) prjInfo.get("verificationStatus"))) {
 					doUpdate = false;
 				}
 			}
 			
 			File chk_list_file = new File(VERIFY_PATH_OUTPUT+"/"+prjId+"/verify_chk_list_"+packagingFileIdx);
 			
-			if(!chk_list_file.exists()) {
+			if (!chk_list_file.exists()) {
 				isChangedPackageFile = true;
 			}
 			
@@ -1151,16 +1151,16 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			log.debug("[API] VERIFY TARGET FILE : " + filePath);
 			
-			if(packagingFileIdx == 1 && isChangedPackageFile) {
+			if (packagingFileIdx == 1 && isChangedPackageFile) {
 				ShellCommander.shellCommandWaitFor(new String[]{"/bin/bash", "-c", "find " + VERIFY_PATH_OUTPUT + " -maxdepth 1 -name "+prjId+" -type d -exec rm -rf {} \\;"});
 			}
 			
 			String exceptionWordsPatten = "proprietary\\|commercial";
-			if(checkExceptionWordsList != null && !checkExceptionWordsList.isEmpty()) {
+			if (checkExceptionWordsList != null && !checkExceptionWordsList.isEmpty()) {
 				exceptionWordsPatten = "";
 				
-				for(String s : checkExceptionWordsList) {
-					if(!isEmpty(exceptionWordsPatten)) {
+				for (String s : checkExceptionWordsList) {
+					if (!isEmpty(exceptionWordsPatten)) {
 						exceptionWordsPatten += "\\|";
 					}
 					
@@ -1172,7 +1172,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			log.info("[API] VERIFY OrigNm : " + file.get("origNm"));
 			String projectNm = ((String) prjInfo.get("prjName")).replace(" ", "@@");
 			
-			if(prjInfo.containsKey("prjVersion") && prjInfo.get("prjVersion") != null && !("").equals((String) prjInfo.get("prjVersion"))){
+			if (prjInfo.containsKey("prjVersion") && prjInfo.get("prjVersion") != null && !("").equals((String) prjInfo.get("prjVersion"))){
 				projectNm +="_"+((String) prjInfo.get("prjVersion")).replace(" ", "@@");
 			}
 			
@@ -1183,7 +1183,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 
 			log.info("[API] VERIFY START : " + prjId);
 			
-			if(isChangedPackageFile){ // packageFile을 변경하지 않고 다시 verify할 경우 아래 shellCommander는 중복 동작 하지 않음.
+			if (isChangedPackageFile){ // packageFile을 변경하지 않고 다시 verify할 경우 아래 shellCommander는 중복 동작 하지 않음.
 				ShellCommander.shellCommandWaitFor(commandStr);
 			}
 			
@@ -1193,7 +1193,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			//STEP 3 : 결과 문자열 리스트값을 배열로 변환 		
 			String chk_list_file_path = null;
 			
-			if(packagingFileIdx == 1) {
+			if (packagingFileIdx == 1) {
 				chk_list_file_path = VERIFY_PATH_OUTPUT+"/"+prjId+"/verify_chk_list_1";
 			} else {
 				chk_list_file_path = VERIFY_PATH_OUTPUT+"/"+prjId+"/verify_chk_list";
@@ -1220,7 +1220,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			log.debug("[API] rePath : " + rePath);
 			
-			if(rePath.indexOf(".tar") > -1){
+			if (rePath.indexOf(".tar") > -1){
 				rePath = rePath.substring(0, rePath.lastIndexOf(".tar"));
 			}
 			
@@ -1233,30 +1233,30 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			// 분석 결과를 격납 (dir or file n	ame : count)
 			Map<String, Integer> deCompResultMap = new HashMap<>();
 			List<String> readmePathList = new ArrayList<String>();
-			if(result != null) {
+			if (result != null) {
 				boolean isFirst = true;
 				
-				for(String s : result) {
-					if(!isEmpty(s) && !(s.contains("(") && s.contains(")"))) {
+				for (String s : result) {
+					if (!isEmpty(s) && !(s.contains("(") && s.contains(")"))) {
 						// packaging file name의 경우 Path로 인식하지 못하도록 처리함.
 
 						boolean isFile = s.endsWith("*");
 						s = s.replace(VERIFY_PATH_DECOMP +"/" + prjId + "/", "");
 						s = s.replaceAll("//", "/");
 						
-						if(s.startsWith("/")) {
+						if (s.startsWith("/")) {
 							s = s.substring(1);
 						}
 						
-						if(s.endsWith("*")) {
+						if (s.endsWith("*")) {
 							s = s.substring(0, s.length()-1);
 						}
 						
-						if(s.endsWith("/")) {
+						if (s.endsWith("/")) {
 							s = s.substring(0, s.length() -1);
 						}
 						
-						if(isFirst) {
+						if (isFirst) {
 							// 첫번째 path를 압축을 푼 처번째 dir로 사용
 							decompressionRootPath = s;
 							
@@ -1266,18 +1266,18 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 						int cnt = 0;
 						
 						//파일 path인 경우, 상위 dir의 파일 count를 +1 한다.
-						if(isFile){
+						if (isFile){
 							String _dir = s;
 							
-							if(s.toUpperCase().indexOf("README") > -1) {
+							if (s.toUpperCase().indexOf("README") > -1) {
 								readmePathList.add(s);
 							}
 							
-							if(s.indexOf("/") > -1) {
+							if (s.indexOf("/") > -1) {
 								_dir = s.substring(0, s.lastIndexOf("/"));
 							}
 							
-							if(deCompResultMap.containsKey(_dir)) {
+							if (deCompResultMap.containsKey(_dir)) {
 								cnt = deCompResultMap.get(_dir);
 							}
 							
@@ -1293,8 +1293,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			List<String> paths = sortByValue(deCompResultMap);
 			
-			for(String path : paths){
-				if(deCompResultMap.get(path) != null){
+			for (String path : paths){
+				if (deCompResultMap.get(path) != null){
 					deCompResultMap = setAddFileCount(deCompResultMap, path, (int)deCompResultMap.get(path));
 				}
 			}
@@ -1344,11 +1344,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 
 				String replaceFilePath = path.substring(0, path.endsWith("*") ? path.length()-1 : path.length());
 				
-				if(replaceFilePath.startsWith("/")) {
+				if (replaceFilePath.startsWith("/")) {
 					replaceFilePath = replaceFilePath.substring(1);
 				}
 				
-				if(replaceFilePath.endsWith("/")) {
+				if (replaceFilePath.endsWith("/")) {
 					replaceFilePath = replaceFilePath.substring(0, replaceFilePath.length()-1);
 				}
 				
@@ -1359,11 +1359,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				
 				String addRootDir = decompressionDirName + "/" + path;
 				
-				if(addRootDir.startsWith("/")) {
+				if (addRootDir.startsWith("/")) {
 					addRootDir = addRootDir.substring(1);
 				}
 				
-				if(addRootDir.endsWith("/")) {
+				if (addRootDir.endsWith("/")) {
 					addRootDir = addRootDir.substring(0, addRootDir.length()-1);
 				}
 				
@@ -1374,11 +1374,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				
 				String addRootDirReplaceFilePath = decompressionDirName + "/" + path.substring(0, path.endsWith("*") ? path.length()-1 : path.length());
 				
-				if(addRootDirReplaceFilePath.startsWith("/")) {
+				if (addRootDirReplaceFilePath.startsWith("/")) {
 					addRootDirReplaceFilePath = addRootDirReplaceFilePath.substring(1);
 				}
 				
-				if(addRootDirReplaceFilePath.endsWith("/")) {
+				if (addRootDirReplaceFilePath.endsWith("/")) {
 					addRootDirReplaceFilePath = addRootDirReplaceFilePath.substring(0, addRootDirReplaceFilePath.length());
 				}
 				
@@ -1388,11 +1388,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				pathCheckList43.add("/"+addRootDirReplaceFilePath + "/");
 
 				String replaceRootDir = path.replaceFirst(packageFileName, "").replaceAll("//", "/");
-				if(replaceRootDir.startsWith("/")) {
+				if (replaceRootDir.startsWith("/")) {
 					replaceRootDir = replaceRootDir.substring(1);
 				}
 				
-				if(replaceRootDir.endsWith("/")) {
+				if (replaceRootDir.endsWith("/")) {
 					replaceRootDir = replaceRootDir.substring(0, replaceRootDir.length()-1);
 				}
 				
@@ -1403,11 +1403,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				
 				String replaceRootDirReplaceFilePath = replaceRootDir;
 				
-				if(replaceRootDirReplaceFilePath.endsWith("*")) {
+				if (replaceRootDirReplaceFilePath.endsWith("*")) {
 					replaceRootDirReplaceFilePath = replaceRootDirReplaceFilePath.substring(0, replaceRootDirReplaceFilePath.length()-1);
 				}
 				
-				if(replaceRootDirReplaceFilePath.endsWith("/")) {
+				if (replaceRootDirReplaceFilePath.endsWith("/")) {
 					replaceRootDirReplaceFilePath = replaceRootDirReplaceFilePath.substring(0, replaceRootDirReplaceFilePath.length()-1);
 				}
 				
@@ -1418,11 +1418,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				
 				String replaceDecomFileRootDir = path.replaceFirst(decompressionRootPath, "").replaceAll("//", "/");
 				
-				if(replaceDecomFileRootDir.startsWith("/")) {
+				if (replaceDecomFileRootDir.startsWith("/")) {
 					replaceDecomFileRootDir = replaceDecomFileRootDir.substring(1);
 				}
 				
-				if(replaceDecomFileRootDir.endsWith("/")) {
+				if (replaceDecomFileRootDir.endsWith("/")) {
 					replaceDecomFileRootDir = replaceDecomFileRootDir.substring(0, replaceDecomFileRootDir.length()-1);
 				}
 				
@@ -1435,7 +1435,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			// 통합 Map 에 모든 허용 패턴을 저장
 			int idx = 0;
 			
-			for(String s : pathCheckList1) {
+			for (String s : pathCheckList1) {
 				checkResultMap.put(s, deCompResultMap.containsKey(s) ? deCompResultMap.get(s) : 0);
 				checkResultMap.put(pathCheckList2.get(idx), deCompResultMap.containsKey(pathCheckList2.get(idx)) ? deCompResultMap.get(pathCheckList2.get(idx)) : 0);
 				checkResultMap.put(pathCheckList3.get(idx), deCompResultMap.containsKey(pathCheckList3.get(idx)) ? deCompResultMap.get(pathCheckList3.get(idx)) : 0);
@@ -1486,24 +1486,24 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			log.info("[API] VERIFY Path Check START -----------------");
 			
-			for(String gridPath : gridFilePaths){
-				if(!separatorErrFlag) {
+			for (String gridPath : gridFilePaths){
+				if (!separatorErrFlag) {
 					separatorErrFlag = gridPath.contains("\\") ? true : false;
 				}
 				
 				//사용자가 * 입력했을때
-				if(!gridPath.trim().equals("/*") && !gridPath.trim().equals("/")){
-					if(gridPath.endsWith("*")) {
+				if (!gridPath.trim().equals("/*") && !gridPath.trim().equals("/")){
+					if (gridPath.endsWith("*")) {
 						gridPath = gridPath.substring(0, gridPath.length()-1);
 					}
-					if(gridPath.startsWith(".")) {
+					if (gridPath.startsWith(".")) {
 						gridPath = gridPath.substring(1, gridPath.length());
 					}
 					// 앞뒤 path구분 제거
-					if(gridPath.endsWith("/")) {
+					if (gridPath.endsWith("/")) {
 						gridPath = gridPath.substring(0, gridPath.length()-1);
 					}
-					if(gridPath.startsWith("/")) {
+					if (gridPath.startsWith("/")) {
 						gridPath = gridPath.substring(1);
 					}
 					
@@ -1515,17 +1515,17 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 					 */
 					boolean resultFlag = false;
 					
-					if(checkResultMap.containsKey(gridPath)) {
+					if (checkResultMap.containsKey(gridPath)) {
 						resultFlag = true;
 						gFileCount = checkResultMap.get(gridPath);
 					}
 					
-					if(!resultFlag) {//path가 존재하지않을 때
+					if (!resultFlag) {//path가 존재하지않을 때
 						gValidIdxlist.add(gridComponentIds.get(gridIdx));
 					} else {//path가 존재할 때
 						// file을 직접 비교하는 경우 count되지 않기 때문에, 1로 고정
 						// resultFlag == true 인경우는 존재하기 해당 path or file 대상이 존재한다는 의미이기 때문에 0이 될 수 없다.
-						if(gFileCount == 0) {
+						if (gFileCount == 0) {
 							gFileCount = 1;
 						}
 						gFileCountMap.put(gridComponentIds.get(gridIdx), Integer.toString(gFileCount));
@@ -1542,15 +1542,15 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			//STEP 4 : README 파일 존재 유무 확인(README 여러개 일경우도 생각해야함 ---차후)
 			
 			// depth가 낮은 readme 파일을 구하기 위해 sort
-			if(packagingFileIdx == 1){ // packageFile에서 readMe File은 첫번째 file에서만 찾음.
+			if (packagingFileIdx == 1){ // packageFile에서 readMe File은 첫번째 file에서만 찾음.
 //				List<String> sortList = new ArrayList<>(deCompResultMap.keySet());
 				Collections.sort(readmePathList, new Comparator<String>() {
 
 					@Override
 					public int compare(String arg1, String arg2) {
-						if(arg1.split("\\/").length > arg2.split("\\/").length) {
+						if (arg1.split("\\/").length > arg2.split("\\/").length) {
 							return 1;
-						} else if(arg1.split("\\/").length < arg2.split("\\/").length) {
+						} else if (arg1.split("\\/").length < arg2.split("\\/").length) {
 							return -1;
 						} else {
 							return arg1.compareTo(arg2);
@@ -1559,33 +1559,33 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				});
 				
 //				String lastReadmeFilePath = "";
-				for(String r : readmePathList) {
+				for (String r : readmePathList) {
 					String _upperPath = avoidNull(r).toUpperCase();
 					
-					if(_upperPath.endsWith("/")) {
+					if (_upperPath.endsWith("/")) {
 						continue;
 					}
 					
 //					String _currentReadmeFilePath = _upperPath.indexOf("/") < 0 ? _upperPath : _upperPath.substring(0,_upperPath.lastIndexOf("/"));
 //					
-//					if(!lastReadmeFilePath.equals(_currentReadmeFilePath)) {
-//						if(!isEmpty(readmePath)) {
+//					if (!lastReadmeFilePath.equals(_currentReadmeFilePath)) {
+//						if (!isEmpty(readmePath)) {
 //							break;
 //						}
 //						
 //						lastReadmeFilePath = _currentReadmeFilePath;
 //					}
 					
-					if(_upperPath.indexOf("/") > -1) {
+					if (_upperPath.indexOf("/") > -1) {
 						_upperPath = _upperPath.substring(_upperPath.lastIndexOf("/"), _upperPath.length());
 					}
 					
-					if(_upperPath.indexOf("README") > -1){
+					if (_upperPath.indexOf("README") > -1){
 						String _readmePath = r.replaceAll("\\n", "");
 						
 						int afterDepthCnt = StringUtils.countMatches(_readmePath, "/");
 						int beforeDepthCnt = StringUtils.countMatches(readmePath, "/");
-						if(isEmpty(readmePath) || beforeDepthCnt > afterDepthCnt) {
+						if (isEmpty(readmePath) || beforeDepthCnt > afterDepthCnt) {
 							readmePath = _readmePath;
 						}
 					}
@@ -1595,18 +1595,18 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			String readmeFileName = "";
 			//STEP 6 : README 파일 내용 출력
-			if(!StringUtil.isEmpty(readmePath)){
-				if(readmePath.indexOf("*") > -1){
+			if (!StringUtil.isEmpty(readmePath)){
+				if (readmePath.indexOf("*") > -1){
 					readmePath = readmePath.substring(0, readmePath.length()-1);
 				}
 				
 				readmeFileName = readmePath;
 				
-				if(readmeFileName.indexOf("/") > -1) {
+				if (readmeFileName.indexOf("/") > -1) {
 					readmeFileName = readmeFileName.substring(readmeFileName.lastIndexOf("/") + 1);
 				}
 				
-				if(readmePath.indexOf(" ") > -1) {
+				if (readmePath.indexOf(" ") > -1) {
 					log.info("do space replase ok");
 					
 					readmePath = readmePath.replaceAll(" ", "*");
@@ -1617,7 +1617,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				log.info("[API] VERIFY Copy Readme file START -----------------");
 				log.info("[API] VERIFY README MV PATH : " + VERIFY_PATH_DECOMP +"/" + prjId +"/" + readmePath);
 				
-				if(isChangedPackageFile){
+				if (isChangedPackageFile){
 					ShellCommander.shellCommandWaitFor(new String[]{"/bin/bash", "-c", "cp "+VERIFY_PATH_DECOMP +"/" + prjId +"/" + readmePath+ " " + VERIFY_PATH_OUTPUT +"/" + prjId +"/"});
 				}
 				
@@ -1625,7 +1625,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			}
 			
 			//STEP 7 : README 파일 내용 DB 에 저장
-			if(doUpdate && packagingFileIdx == 1) {
+			if (doUpdate && packagingFileIdx == 1) {
 				log.debug("[API] VERIFY readme 등록");
 				
 				project.put("prjId", prjId);
@@ -1648,14 +1648,14 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			project.put("exceptFileContent", !isEmpty(exceptFileContent) ? CoConstDef.FLAG_YES : "");
 			project.put("verifyFileContent", !isEmpty(verify_chk_list) ? CoConstDef.FLAG_YES : "");
 			
-			if(doUpdate) {
+			if (doUpdate) {
 				registVerifyContents(project);
 			}
 			
 			log.debug("[API] VERIFY 파일내용 등록 완료");
 			
 			// 서버 디렉토리를 replace한 내용으로 새로운 파일로 다시 쓴다.
-			if(!isEmpty(exceptFileContent)) {
+			if (!isEmpty(exceptFileContent)) {
 				log.info("[API] VERIFY writhFile exceptFileContent file START -----------------");
 				
 				FileUtil.writeFile(VERIFY_PATH_OUTPUT +"/" + prjId, CoConstDef.PACKAGING_VERIFY_FILENAME_PROPRIETARY, exceptFileContent.replaceAll(VERIFY_PATH_DECOMP +"/" + prjId +"/", ""));
@@ -1663,7 +1663,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				log.info("[API] VERIFY writhFile exceptFileContent file END -----------------");
 			}
 			
-			if(!isEmpty(verify_chk_list)) {
+			if (!isEmpty(verify_chk_list)) {
 				log.info("[API] VERIFY writhFile verify_chk_list file START -----------------");
 				
 				FileUtil.writeFile(VERIFY_PATH_OUTPUT +"/" + prjId, CoConstDef.PACKAGING_VERIFY_FILENAME_FILE_LIST, verify_chk_list.replaceAll(VERIFY_PATH_DECOMP +"/" + prjId +"/", ""));
@@ -1672,7 +1672,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			}
 			
 			resCd="10";
-			if(separatorErrFlag) {
+			if (separatorErrFlag) {
 				resMsg = getMessage("verify.path.error");
 			} else {
 				resMsg= getMessage(gValidIdxlist.isEmpty() ? "msg.common.success" : "msg.common.valid");
@@ -1687,12 +1687,12 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			//path not found.가 1건이라도 있으면 status_verify_yn의 flag는 N으로 저장함.
 			// packagingFileId, filePath는 1번만 저장하며, gValidIdxlist의 값때문에 마지막 fileSeq일때 저장함.
-			if(doUpdate && packagingFileIdx == fileSeqs.size()) {
+			if (doUpdate && packagingFileIdx == fileSeqs.size()) {
 				// verify 버튼 클릭시 file path를 저장한다.
-				if(gridComponentIds != null && !gridComponentIds.isEmpty()) {
+				if (gridComponentIds != null && !gridComponentIds.isEmpty()) {
 					int seq = 0;
 					
-					for(String s : gridComponentIds){
+					for (String s : gridComponentIds){
 						Map<String, Object> param = new HashMap<>();
 						param.put("componentId", s);
 						param.put("filePath", gridFilePaths.get(seq++));
@@ -1706,7 +1706,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 					prjParam.put("prjId", prjId);
 					prjParam.put("packageFileId", fileSeqs.get(0));
 					
-					if(prjInfo.containsKey("destributionStatus") && prjInfo.get("destributionStatus") != null && !("").equals(prjInfo.get("destributionStatus"))){
+					if (prjInfo.containsKey("destributionStatus") && prjInfo.get("destributionStatus") != null && !("").equals(prjInfo.get("destributionStatus"))){
 						prjParam.put("statusVerifyYn", "C");
 					} else {
 						prjParam.put("statusVerifyYn", CoConstDef.FLAG_YES);
@@ -1729,7 +1729,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			resMsg="process failed. (server error)";
 		} finally {
 			try {
-				if(isChangedPackageFile){
+				if (isChangedPackageFile){
 					ShellCommander.shellCommandWaitFor(new String[]{"/bin/bash", "-c", "find " + VERIFY_PATH_DECOMP + " -maxdepth 1 -name "+prjId+" -type d -exec rm -rf {} \\;"});
 				}
 				
@@ -1765,7 +1765,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 
 	@Override
 	public void updateVerifyFileCount(ArrayList<String> fileCounts) {
-		for(String componentId : fileCounts){
+		for (String componentId : fileCounts){
 			Map<String, Object> param = new HashMap<>();
 			param.put("componentId", componentId);
 			param.put("verifyFileCount", " ");
@@ -1776,7 +1776,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 
 	@Override
 	public void updateVerifyFileCount(HashMap<String, Object> fileCounts) {
-		for(String componentId : fileCounts.keySet()){
+		for (String componentId : fileCounts.keySet()){
 			Map<String, Object> param = new HashMap<>();
 			param.put("componentId", componentId);
 			param.put("verifyFileCount", (String) fileCounts.get(componentId));
@@ -1796,7 +1796,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			int pFileCnt = deCompResultMap.get(url);
 			deCompResultMap.put(url, fileCnt + pFileCnt);
 			
-			if(deCompResultMap.get(url.substring(0, url.lastIndexOf("/"))) != null){
+			if (deCompResultMap.get(url.substring(0, url.lastIndexOf("/"))) != null){
 				setAddFileCount(deCompResultMap, url, fileCnt);
 			}
 			
@@ -1828,19 +1828,19 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		List<String> packageFileList = new ArrayList<>();
 		
 		if (packageFile.containsKey("packageFileId")) {
-			if(packageFile.get("packageFileId") != null && !("").equals(Integer.toString((int) packageFile.get("packageFileId")))) {
+			if (packageFile.get("packageFileId") != null && !("").equals(Integer.toString((int) packageFile.get("packageFileId")))) {
 				packageFileList.add(Integer.toString((int) packageFile.get("packageFileId")));
 			}
 		}
 		
 		if (packageFile.containsKey("packageFileId2")) {
-			if(packageFile.get("packageFileId2") != null && !("").equals(Integer.toString((int) packageFile.get("packageFileId2")))) {
+			if (packageFile.get("packageFileId2") != null && !("").equals(Integer.toString((int) packageFile.get("packageFileId2")))) {
 				packageFileList.add(Integer.toString((int) packageFile.get("packageFileId2")));
 			}
 		}
 		
 		if (packageFile.containsKey("packageFileId3")) {
-			if(packageFile.get("packageFileId3") != null && !("").equals(Integer.toString((int) packageFile.get("packageFileId3")))) {
+			if (packageFile.get("packageFileId3") != null && !("").equals(Integer.toString((int) packageFile.get("packageFileId3")))) {
 				packageFileList.add(Integer.toString((int) packageFile.get("packageFileId3")));
 			}
 		}
@@ -1865,7 +1865,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		List<String> componentId = apiProjectMapper.selectComponentId(paramMap);
 		
 		// 기존 bom 정보를 모두 물리삭제하고 다시 등록한다.
-		if(componentId.size() > 0){
+		if (componentId.size() > 0){
 			for (int i = 0; i < componentId.size(); i++) {
 				apiProjectMapper.deleteOssComponentsLicense(componentId.get(i));
 			}
@@ -1875,10 +1875,10 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		
 		HashMap<String, Object> mergeListMap = getIdentificationGridList(paramMap);
 		
-		if(mergeListMap != null && mergeListMap.get("rows") != null) {
-			for(HashMap<String, Object> bean : (List<HashMap<String, Object>>) mergeListMap.get("rows")) {
+		if (mergeListMap != null && mergeListMap.get("rows") != null) {
+			for (HashMap<String, Object> bean : (List<HashMap<String, Object>>) mergeListMap.get("rows")) {
 				
-				if((bean.get("ossName") == null || "-".equals((String) bean.get("ossName")))) {
+				if ((bean.get("ossName") == null || "-".equals((String) bean.get("ossName")))) {
 					List<HashMap<String, Object>> ocll = (List<HashMap<String, Object>>) bean.get("ossComponentsLicenseList");
 					if (ocll.size() > 1) {
 						continue;
@@ -1891,7 +1891,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				bean.put("adminCheckYn", CoConstDef.FLAG_NO);
 				bean.put("preObligationType", bean.get("obligationType"));
 				if (bean.containsKey("licenseName")) {
-					if(((String) bean.get("licenseName")).contains("Other")) {
+					if (((String) bean.get("licenseName")).contains("Other")) {
 						String licenseNm = (String) bean.get("licenseName");
 					}
 				}
@@ -1903,7 +1903,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				List<HashMap<String, Object>> licenseList = findOssLicenseIdAndName(bean);
 				
 				if (licenseList.size() > 0) {
-					for(HashMap<String, Object> licenseBean : licenseList) {
+					for (HashMap<String, Object> licenseBean : licenseList) {
 						licenseBean.put("componentId", bean.get("componentId"));
 						
 						apiProjectMapper.registComponentLicense(licenseBean);
@@ -1933,30 +1933,30 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			HashMap<String, HashMap<String, Object>> _ossMap = new HashMap<>();
 			HashMap<String, String> _ossNamesMap = new HashMap<>();
 			
-			if(nickNameList != null) {
-				for(Map<String, Object> bean : nickNameList) {
-					if(bean.get("ossNickname") != null) {
+			if (nickNameList != null) {
+				for (Map<String, Object> bean : nickNameList) {
+					if (bean.get("ossNickname") != null) {
 						nickNameMap.put((String) bean.get("ossName"), ((String) bean.get("ossNickname")).split(","));
 					}
 				}
 			}
 			
-			if(list != null) {
+			if (list != null) {
 				List<HashMap<String, Object>> licenseBeanList = new ArrayList<>();
 				
-				for(HashMap<String, Object> bean : list) {
+				for (HashMap<String, Object> bean : list) {
 					
 					HashMap<String, Object> licenseBean = new HashMap<>();
 					HashMap<String, Object> targetBean = null;
 					String key = (String) bean.get("ossName") +"_"+ avoidNull((String) bean.get("ossVersion")); // oss name을 nick name으로 가져온다.
 					key = key.toUpperCase();
 					
-					if(_ossMap.containsKey(key)) {
+					if (_ossMap.containsKey(key)) {
 						targetBean = _ossMap.get(key);
 					} else {
 						targetBean = bean;
 						
-						if(nickNameMap.containsKey(targetBean.get("ossNameTemp"))) {
+						if (nickNameMap.containsKey(targetBean.get("ossNameTemp"))) {
 							targetBean.put("ossNicknames", nickNameMap.get(targetBean.get("ossNameTemp")));
 						}
 					}
@@ -1978,34 +1978,34 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 					
 					targetBean.put("ossLicenses", makeOssLicense(key, licenseBeanList));
 									
-					if(_ossMap.containsKey(key)) {
+					if (_ossMap.containsKey(key)) {
 						_ossMap.replace(key, targetBean);
 					} else {
 						_ossMap.put(key, targetBean);
 					}
 					
-					if(!_ossNamesMap.containsKey(((String) bean.get("ossName")).toUpperCase())) {
+					if (!_ossNamesMap.containsKey(((String) bean.get("ossName")).toUpperCase())) {
 						_ossNamesMap.put(((String) bean.get("ossName")).toUpperCase(), (String) bean.get("ossName"));
 					}
 				}
 			}
 			
 			HashMap<String, HashMap<String, Object>> _idMasterMap = new HashMap<>();
-			for(HashMap<String, Object> bean : _ossMap.values()) {
-				if(!_idMasterMap.containsKey(bean.get("ossId"))) {
+			for (HashMap<String, Object> bean : _ossMap.values()) {
+				if (!_idMasterMap.containsKey(bean.get("ossId"))) {
 					_idMasterMap.put(Integer.toString((int) bean.get("ossId")), bean);
 				}
 			}
 			
 			OSS_INFO_BY_ID = _idMasterMap;
 			
-			if(listNick != null) {
+			if (listNick != null) {
 
-				for(HashMap<String, Object> bean : listNick) {
+				for (HashMap<String, Object> bean : listNick) {
 					String key = (String) bean.get("ossName") +"_"+ avoidNull((String) bean.get("ossVersion")); // oss name을 nick name으로 가져온다.
 					String ossNickNameKey = ((String) bean.get("ossName")).toUpperCase();
 
-					if(!_ossNamesMap.containsKey(ossNickNameKey)) {
+					if (!_ossNamesMap.containsKey(ossNickNameKey)) {
 						_ossNamesMap.put(ossNickNameKey, (String) bean.get("ossNameTemp"));
 					}
 					
@@ -2036,7 +2036,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			}
 			
-			if(!_ossMap.isEmpty()) {
+			if (!_ossMap.isEmpty()) {
 				OSS_INFO_UPPER = _ossMap;
 			}
 		} catch(Exception e) {
@@ -2071,7 +2071,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
             List<HashMap<String, Object>> list = apiProjectMapper.getLicenseInfoInit();
             List<HashMap<String, Object>> nickList = apiProjectMapper.getLicenseInfoInitNick();
             
-            if(list == null) {
+            if (list == null) {
                 throw new RuntimeException("SYSTEM ERR GET CODE LICENSE MASTER INFO");
             }
             
@@ -2079,17 +2079,17 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
             HashMap<String, HashMap<String, Object>> license_info_upper_map = new HashMap<>();
             HashMap<String, HashMap<String, Object>> license_info_by_id_map = new HashMap<>();
             
-            for(HashMap<String, Object> vo : list) {
-            	if(vo.containsKey("licenseNicknameStr")) {
+            for (HashMap<String, Object> vo : list) {
+            	if (vo.containsKey("licenseNicknameStr")) {
             		List<String> licenseNicknameList = new ArrayList<String>();
-            		for(String nick : ((String) vo.get("licenseNicknameStr")).split("\\|")) {
+            		for (String nick : ((String) vo.get("licenseNicknameStr")).split("\\|")) {
             			licenseNicknameList.add(nick);
             		}
             		vo.put("licenseNicknameList", licenseNicknameList);
             	}
             	
-            	if(vo.containsKey("restriction")) {
-            		if(!("").equals((String) vo.get("restriction"))) {
+            	if (vo.containsKey("restriction")) {
+            		if (!("").equals((String) vo.get("restriction"))) {
                 		vo.put("restrictionStr", licenseRestrictionList((String) vo.get("restriction")));
             		}
             	}
@@ -2098,13 +2098,13 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
             	license_info_upper_map.put(((String) vo.get("licenseName")).toUpperCase(),vo);
             	
             	//SHORT_IDENTIFIER
-            	if(vo.containsKey("shortIdentifier")) {
-            		if(!("").equals(vo.get("shortIdentifier"))) {
-            			if(!license_info_map.containsKey(vo.get("shortIdentifier"))) {
+            	if (vo.containsKey("shortIdentifier")) {
+            		if (!("").equals(vo.get("shortIdentifier"))) {
+            			if (!license_info_map.containsKey(vo.get("shortIdentifier"))) {
                         	license_info_map.put((String) vo.get("shortIdentifier"), vo);
                 		}
                 		
-                		if(!license_info_upper_map.containsKey(((String) vo.get("shortIdentifier")).toUpperCase())) {
+                		if (!license_info_upper_map.containsKey(((String) vo.get("shortIdentifier")).toUpperCase())) {
                 			license_info_upper_map.put(((String) vo.get("shortIdentifier")).toUpperCase(), vo);
                 		}
             		}
@@ -2113,15 +2113,15 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
             	license_info_by_id_map.put(Integer.toString((int) vo.get("licenseId")), vo);
             }
             
-            for(HashMap<String, Object> vo : nickList) {
+            for (HashMap<String, Object> vo : nickList) {
             	
             	HashMap<String, Object> sourceBean = license_info_by_id_map.get(Integer.toString((int) vo.get("licenseId")));
             	
-            	if(vo.containsKey("licenseNicknameList")) {
+            	if (vo.containsKey("licenseNicknameList")) {
             		vo.put("licenseNicknameList", sourceBean.get("licenseNicknameList"));
             	}
             	
-            	if(vo.containsKey("restrictionStr")) {
+            	if (vo.containsKey("restrictionStr")) {
             		vo.put("restrictionStr", sourceBean.get("restrictionStr"));
             	}
             	            	
@@ -2129,15 +2129,15 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
             	license_info_upper_map.put(((String) vo.get("licenseName")).toUpperCase(),vo);
             }
             
-            if(!license_info_map.isEmpty()) {
+            if (!license_info_map.isEmpty()) {
             	LICENSE_INFO = license_info_map;
             }
             
-            if(!license_info_upper_map.isEmpty()) {
+            if (!license_info_upper_map.isEmpty()) {
             	LICENSE_INFO_UPPER = license_info_upper_map;
             }
             
-            if(!license_info_by_id_map.isEmpty()) {
+            if (!license_info_by_id_map.isEmpty()) {
             	LICENSE_INFO_BY_ID = license_info_by_id_map;
             }
         } catch (Exception e) {
@@ -2148,15 +2148,15 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	private String licenseRestrictionList(String restrictionStr) {
 		String returnStr = "";
 		
-		if(!isEmpty(restrictionStr)) {
+		if (!isEmpty(restrictionStr)) {
 			String restrictionArr[] = restrictionStr.split(",");
 			List<String> restrictionList = new ArrayList<>();
 			
-			for(int i = 0 ; i < restrictionArr.length ; i++){
+			for (int i = 0 ; i < restrictionArr.length ; i++){
 				restrictionList.add(restrictionArr[i]);
 			}
 			
-            for(String str : restrictionList){
+            for (String str : restrictionList){
             	returnStr += (isEmpty(returnStr)?"":"\n") + CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, str.trim().toUpperCase());
             }
 		}
@@ -2176,7 +2176,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		
 		paramMap.put("roleOutLicense", CoCodeManager.CD_ROLE_OUT_LICENSE);
 		
-		if(CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST != null && !CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST.isEmpty()) {
+		if (CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST != null && !CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST.isEmpty()) {
 			paramMap.put("roleOutLicenseIdList", CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST);
 		}
 		
@@ -2188,12 +2188,12 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			// bom merge 버튼을 클릭하고, 표시대상이 있을 경우, 기존에 저장되어 있는 내용을 취득한다.
 			// need check의 저장값을 유지하기 위함
-			if(CoConstDef.FLAG_YES.equals(reqMergeFlag) && list != null && !list.isEmpty()) {
+			if (CoConstDef.FLAG_YES.equals(reqMergeFlag) && list != null && !list.isEmpty()) {
 				paramMap.put("merge", CoConstDef.FLAG_NO);
 				List<HashMap<String, Object>> bomBeforeList = apiProjectMapper.selectMergeBomList(paramMap);
 				
-				if(bomBeforeList != null) {
-					for(Map<String, Object> _orgIdentificationBean : bomBeforeList) {
+				if (bomBeforeList != null) {
+					for (Map<String, Object> _orgIdentificationBean : bomBeforeList) {
 						obligationTypeMergeMap.put((String) _orgIdentificationBean.get("refComponentId"), (String) _orgIdentificationBean.get("obligationType"));
 					}
 				}
@@ -2212,8 +2212,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				ll.put("ossComponentsLicenseList", listLicense);
 				ll.put("obligationLicense", CoConstDef.FLAG_YES.equals(ll.get("adminCheckYn")) ? CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK : checkObligationSelectedLicense(listLicense));
 				
-				if(CoConstDef.FLAG_YES.equals(reqMergeFlag)) {
-					if(obligationTypeMergeMap.containsKey(Integer.toString((int) ll.get("componentId")))) {
+				if (CoConstDef.FLAG_YES.equals(reqMergeFlag)) {
+					if (obligationTypeMergeMap.containsKey(Integer.toString((int) ll.get("componentId")))) {
 						ll.put("obligationType", obligationTypeMergeMap.get(Integer.toString((int) ll.get("componentId"))));
 					} else {
 						ll.put("obligationType", ll.get("obligationLicense"));
@@ -2223,14 +2223,14 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				// grouping 된 file path를 br tag로 변경
 				ll.put("filePath", lineReplaceToBR((String) ll.get("filePath")));
 				
-				if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals((String) ll.get("referenceDiv"))) {
-					if(!batMergeSrcMap.containsKey(((String) ll.get("ossName")).toUpperCase())) {
+				if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals((String) ll.get("referenceDiv"))) {
+					if (!batMergeSrcMap.containsKey(((String) ll.get("ossName")).toUpperCase())) {
 						batMergeSrcMap.put(((String) ll.get("ossName")).toUpperCase(), ll);
-					} else if(StringUtil.compareTo(((String) ll.get("ossVersion")), (String) batMergeSrcMap.get(((String) ll.get("ossName")).toUpperCase()).get("ossVersion")) > 0) {
+					} else if (StringUtil.compareTo(((String) ll.get("ossVersion")), (String) batMergeSrcMap.get(((String) ll.get("ossName")).toUpperCase()).get("ossVersion")) > 0) {
 						batMergeSrcMap.replace(((String) ll.get("ossName")).toUpperCase(), ll);
 					}
-				} else if(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(((String) ll.get("referenceDiv")))) {
-					if(!batMergePartnerMap.containsKey(((String) ll.get("ossName")).toUpperCase())) {
+				} else if (CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(((String) ll.get("referenceDiv")))) {
+					if (!batMergePartnerMap.containsKey(((String) ll.get("ossName")).toUpperCase())) {
 						batMergePartnerMap.put(((String) ll.get("ossName")).toUpperCase(), ll);
 					} else if (StringUtil.compareTo(((String) ll.get("ossVersion")), (String) batMergePartnerMap.get(((String) ll.get("ossName")).toUpperCase()).get("ossVersion")) > 0) {
 						batMergePartnerMap.replace(((String) ll.get("ossName").toString()), ll);
@@ -2238,7 +2238,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				}
 				
 				// oss Name은 작성하고, oss Version은 작성하지 않은 case경우 해당 분기문에서 처리
-				if(ll.get("cveId") == null 
+				if (ll.get("cveId") == null 
 						&& isEmpty((String) ll.get("ossVersion")) 
 						&& !isEmpty((String) ll.get("cvssScoreMax"))
 						&& !("-".equals((String) ll.get("ossName")))){ 
@@ -2259,32 +2259,32 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			
 			for (Map<String, Object> ll : list) {
 				// 이미 추가된 oss의 경우
-				if(egnoreList.contains((Integer.toString((int) ll.get("componentId"))))) {
+				if (egnoreList.contains((Integer.toString((int) ll.get("componentId"))))) {
 					continue;
 				}
 				
 				int addIdx = -1;
 				
-				if((String) ll.get("ossName") != null && !("").equals((String) ll.get("ossName"))) {
+				if ((String) ll.get("ossName") != null && !("").equals((String) ll.get("ossName"))) {
 					String mergeKey = ((String) ll.get("ossName")).toUpperCase();
 					// main oss로 표시되는 bat oss의 version이 명시되어 있지 않은 경우
-					if(CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(((String) ll.get("referenceDiv"))) && (ll.get("mergePreDiv") == null && ("").equals((String) ll.get("mergePreDiv"))) 
+					if (CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(((String) ll.get("referenceDiv"))) && (ll.get("mergePreDiv") == null && ("").equals((String) ll.get("mergePreDiv"))) 
 							&& (ll.get("ossVersion") == null && ("").equals((String) ll.get("ossVersion")))) {
 						Map<String, Object> refBean = null;
 						
-						if( batMergeSrcMap.containsKey(mergeKey)) {
+						if ( batMergeSrcMap.containsKey(mergeKey)) {
 							// bat => src
 							refBean = batMergeSrcMap.get(mergeKey);
 							
 							// 설정된 license가 상이하고, bat와 동일한 license가 src에 존재한다면 (최상위 버전이 아닌경우)
 							// continue하고 다음 loop에서 merge
-							if(!isSameLicense( (List<Map<String, Object>>) refBean.get("ossComponentsLicenseList"), (List<Map<String, Object>>) ll.get("ossComponentsLicenseList"))) {
+							if (!isSameLicense( (List<Map<String, Object>>) refBean.get("ossComponentsLicenseList"), (List<Map<String, Object>>) ll.get("ossComponentsLicenseList"))) {
 								String ossNameAndVersion = findBatOssOtherVersionWithLicense(ll, refBean, list);
 								
-								if(!isEmpty(ossNameAndVersion)) {
+								if (!isEmpty(ossNameAndVersion)) {
 									List<Map<String, Object>> _batList = null;
 									
-									if(srcSameLicenseMap.containsKey(ossNameAndVersion)) {
+									if (srcSameLicenseMap.containsKey(ossNameAndVersion)) {
 										_batList = srcSameLicenseMap.get(ossNameAndVersion);
 										_batList.add(ll);
 										srcSameLicenseMap.replace(ossNameAndVersion, _batList);
@@ -2306,11 +2306,11 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 							// 순서 정렬
 							addIdx = findOssAppendIndex(CoConstDef.CD_DTL_COMPONENT_ID_SRC, refBean.get("componentId"), list);
 							
-							if(addIdx > -1) {
+							if (addIdx > -1) {
 								addIdx = addIdx +1;
 								ll.put("groupingColumn", (String) refBean.get("ossName") + (String) refBean.get("ossVersion"));
 							}					
-						} else if( batMergePartnerMap.containsKey(mergeKey)) {
+						} else if ( batMergePartnerMap.containsKey(mergeKey)) {
 							// 3rd => bat
 							refBean = batMergePartnerMap.get(mergeKey);
 							
@@ -2322,12 +2322,12 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 							
 							// bin 에 누락된 정보를 3rd의 첫번재 row에서 채워 넣는다.
 							// DOWNLOAD_LOCATION
-							if(ll.get("downloadLocation") == null) {
+							if (ll.get("downloadLocation") == null) {
 								ll.put("downloadLocation", refBean.get("downloadLocation"));
 							}
 							
 							// HOMEPAGE
-							if(ll.get("homepage") == null) {
+							if (ll.get("homepage") == null) {
 								ll.put("homepage", refBean.get("homepage"));
 							}
 							
@@ -2342,16 +2342,16 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 							// 3rd party의 우선순위가 가장 낮기 때문에, 복수건을 취득하는 경우는 없지만, 기능 확장을 고려해서 list 형으로 반환
 							groupList = findOssGroupList(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER, (String) batMergePartnerMap.get(mergeKey).get("ossName"), (String) batMergePartnerMap.get(mergeKey).get("ossVersion"), list);
 							
-							if(groupList != null && !groupList.isEmpty()) {
-								for(Map<String, Object> _groupBean : groupList) {
+							if (groupList != null && !groupList.isEmpty()) {
+								for (Map<String, Object> _groupBean : groupList) {
 									egnoreList.add((String) _groupBean.get("componentId"));
 								}
 							}
 						}
 					} 
 					// 3rd party의 경우, bat에 동일한 oss가 없을 경우만 추가 (정렬)
-					else if(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals((String) ll.get("referenceDiv")) && isEmpty((String) ll.get("mergePreDiv")) ) {
-						if(existsBatOSS((String) ll.get("ossName"), list)) {
+					else if (CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals((String) ll.get("referenceDiv")) && isEmpty((String) ll.get("mergePreDiv")) ) {
+						if (existsBatOSS((String) ll.get("ossName"), list)) {
 							continue;
 						}
 					}
@@ -2359,8 +2359,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				// License Restriction 저장
 				ll.put("restriction", licenseRestrictionListById((String) ll.get("licenseId")));
 
-				if(addIdx > -1) {
-					if(addIdx > _list.size() -1) {
+				if (addIdx > -1) {
+					if (addIdx > _list.size() -1) {
 						_list.add(ll);
 					} else {
 						_list.add(addIdx, ll);
@@ -2368,26 +2368,26 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 				} else {
 					_list.add(ll);
 					
-					if(groupList != null && !groupList.isEmpty()) {
+					if (groupList != null && !groupList.isEmpty()) {
 						_list.addAll(groupList);
 					}
 				}
 				
-				if(CoConstDef.FLAG_YES.equals((String) ll.get("adminCheckYn"))) {
+				if (CoConstDef.FLAG_YES.equals((String) ll.get("adminCheckYn"))) {
 					adminCheckList.add((String) ll.get("componentId"));
 				}
 			}
 			
 			// src oss중에서 bat와 merge할 수 있는 동일한 oss에 최신 version 외 라이선스까지 동일한 bat가 존재하는 경우
-			if(!srcSameLicenseMap.isEmpty()) {
+			if (!srcSameLicenseMap.isEmpty()) {
 				List<Map<String, Object>> _tmp = new ArrayList<>();
 				
-				for(Map<String, Object> bean : _list) {
+				for (Map<String, Object> bean : _list) {
 					_tmp.add(bean);
 					String _key = (String) bean.get("ossName") + "-" + avoidNull((String) bean.get("ossVersion"));
 					
-					if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals((String) bean.get("referenceDiv")) && srcSameLicenseMap.containsKey(_key)) {
-						for(Map<String, Object> _mergeBean : srcSameLicenseMap.get(_key)) {
+					if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals((String) bean.get("referenceDiv")) && srcSameLicenseMap.containsKey(_key)) {
+						for (Map<String, Object> _mergeBean : srcSameLicenseMap.get(_key)) {
 							_mergeBean.put("ossId", bean.get("ossId"));
 							_mergeBean.put("ossName", bean.get("ossName"));
 							_mergeBean.put("ossVersion", bean.get("ossVersion"));
@@ -2404,7 +2404,7 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 
 			map.put("rows", _list);
 			
-			if(adminCheckList.size() > 0) {
+			if (adminCheckList.size() > 0) {
 				map.put("adminCheckList", adminCheckList);
 			}
 		}
@@ -2415,19 +2415,19 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	private String checkObligationSelectedLicense(List<HashMap<String, Object>> listLicense) {
 		String rtnVal = "";
 		
-		if(listLicense != null) {
-			for(Map<String, Object> bean : listLicense) {
-				if(!CoConstDef.FLAG_YES.equals(bean.get("excludeYn"))) {
+		if (listLicense != null) {
+			for (Map<String, Object> bean : listLicense) {
+				if (!CoConstDef.FLAG_YES.equals(bean.get("excludeYn"))) {
 					// 확인 가능한 라이선스 중에서만 obligation 대상으로 한다.
-					if(bean.containsKey("licenseName")) {
-						if(LICENSE_INFO_UPPER.containsKey(((String) bean.get("licenseName")).toUpperCase())) {
+					if (bean.containsKey("licenseName")) {
+						if (LICENSE_INFO_UPPER.containsKey(((String) bean.get("licenseName")).toUpperCase())) {
 							Map<String, Object> license = LICENSE_INFO_UPPER.get(((String) bean.get("licenseName")).toUpperCase());
 							
-							if(CoConstDef.FLAG_YES.equals(license.get("obligationNeedsCheckYn"))) {
+							if (CoConstDef.FLAG_YES.equals(license.get("obligationNeedsCheckYn"))) {
 								return CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK;
-							} else if(CoConstDef.FLAG_YES.equals(license.get("obligationDisclosingSrcYn"))) {
+							} else if (CoConstDef.FLAG_YES.equals(license.get("obligationDisclosingSrcYn"))) {
 								rtnVal = CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE;
-							} else if(isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(license.get("obligationNotificationYn"))) {
+							} else if (isEmpty(rtnVal) && CoConstDef.FLAG_YES.equals(license.get("obligationNotificationYn"))) {
 								rtnVal = CoConstDef.CD_DTL_OBLIGATION_NOTICE;
 							}
 						}
@@ -2445,12 +2445,12 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	
 	@SuppressWarnings("unchecked")
 	private String findBatOssOtherVersionWithLicense(Map<String, Object> ll, Map<String, Object> refBean, List<HashMap<String, Object>> list) {
-		for(Map<String, Object> bean : list) {
-			if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals((String) bean.get("referenceDiv")) 
+		for (Map<String, Object> bean : list) {
+			if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals((String) bean.get("referenceDiv")) 
 					&& ((String) bean.get("ossName")).equals((String) refBean.get("ossName"))
 					&& !((String) bean.get("ossVersion")).equals((String) refBean.get("ossVersion"))
 					&& ((String) bean.get("ossName")).equals((String) ll.get("ossName"))) {
-				if(isSameLicense((List<Map<String, Object>>) bean.get("ossComponentsLicenseList"), (List<Map<String, Object>>) ll.get("ossComponentsLicenseList"))) {
+				if (isSameLicense((List<Map<String, Object>>) bean.get("ossComponentsLicenseList"), (List<Map<String, Object>>) ll.get("ossComponentsLicenseList"))) {
 					return (String) bean.get("ossName") + "-" + avoidNull((String) bean.get("ossVersion"));
 				}
 			}
@@ -2461,31 +2461,31 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	
 	@SuppressWarnings("unchecked")
 	private boolean isSameLicense(List<Map<String, Object>> list1, List<Map<String, Object>> list2) {
-		if(list1 == null && list2 == null) {
+		if (list1 == null && list2 == null) {
 			return false;
 		}
 		
-		if((list1 == null && list2 != null) || (list1 != null && list2 == null)) {
+		if ((list1 == null && list2 != null) || (list1 != null && list2 == null)) {
 			return false;
 		}
 		
-		if(list1.size() != list2.size()) {
+		if (list1.size() != list2.size()) {
 			return false;
 		}
 		
 		List<String> licenseNames = new ArrayList<>();
 		
-		for(Map<String, Object> bean : list1) {
+		for (Map<String, Object> bean : list1) {
 			Map<String, Object> liMaster = LICENSE_INFO.get(bean.get("licenseName"));
 			
-			if(liMaster == null) {
+			if (liMaster == null) {
 				licenseNames.add(avoidNull((String) bean.get("licenseName")));
 			} else {
 				licenseNames.add((String) liMaster.get("licenseName"));
-				if(liMaster.containsKey("shortIdentifier")) {
+				if (liMaster.containsKey("shortIdentifier")) {
 					licenseNames.add((String) liMaster.get("shortIdentifier"));
 				}
-				if(liMaster.containsKey("licenseNicknameList")) {
+				if (liMaster.containsKey("licenseNicknameList")) {
 					List<String> licenseNicknameList = (List<String>) liMaster.get("licenseNicknameList");
 					for (String ln : licenseNicknameList) {
 						licenseNames.add(ln);
@@ -2494,9 +2494,9 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			}
 		}
 		
-		for(Map<String, Object> bean : list2) {
-			if(bean.containsKey("licenseName")) {
-				if(!licenseNames.contains((String) bean.get("licenseName"))) {
+		for (Map<String, Object> bean : list2) {
+			if (bean.containsKey("licenseName")) {
+				if (!licenseNames.contains((String) bean.get("licenseName"))) {
 					return false;
 				}
 			}
@@ -2508,8 +2508,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	private int findOssAppendIndex(String type, Object object, List<HashMap<String, Object>> list) {
 		int idx = 0;
 		
-		for(Map<String, Object> bean : list) {
-			if(type.equals((String) bean.get("referenceDiv")) && ((String) object).equals(bean.get("componentId"))) {
+		for (Map<String, Object> bean : list) {
+			if (type.equals((String) bean.get("referenceDiv")) && ((String) object).equals(bean.get("componentId"))) {
 				return idx;
 			}
 			
@@ -2523,8 +2523,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		String targetGroup = avoidNull(ossName) + avoidNull(ossVersion);
 		List<Map<String, Object>> groupList = new ArrayList<>();
 		
-		for(Map<String, Object> bean : list) {
-			if(type.equals((String) bean.get("referenceDiv")) && targetGroup.equalsIgnoreCase((String) bean.get("groupingColumn"))) {
+		for (Map<String, Object> bean : list) {
+			if (type.equals((String) bean.get("referenceDiv")) && targetGroup.equalsIgnoreCase((String) bean.get("groupingColumn"))) {
 				groupList.add(bean);
 			}
 		}
@@ -2533,8 +2533,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	}
 	
 	private boolean existsBatOSS(String ossName, List<HashMap<String, Object>> list) {
-		for(Map<String, Object> bean : list) {
-			if(CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals((String) bean.get("referenceDiv")) && isEmpty((String) bean.get("mergePreDiv")) && isEmpty((String) bean.get("ossVersion"))
+		for (Map<String, Object> bean : list) {
+			if (CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals((String) bean.get("referenceDiv")) && isEmpty((String) bean.get("mergePreDiv")) && isEmpty((String) bean.get("ossVersion"))
 					&& ossName.equalsIgnoreCase((String) bean.get("ossName"))) {
 				return true;
 			}
@@ -2546,13 +2546,13 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	private String licenseRestrictionListById(String licenseIdStr) {
 		String returnStr = "";
 		
-		if(licenseIdStr != null) {
+		if (licenseIdStr != null) {
 			String restrictionStr = "";
 			String licenseIdArr[] = licenseIdStr.split(",");
 			
-			for(int i = 0 ; i < licenseIdArr.length ; i++) {
+			for (int i = 0 ; i < licenseIdArr.length ; i++) {
 				Map<String, Object> license = LICENSE_INFO_BY_ID.get(licenseIdArr[i]);
-				if(license != null && license.containsKey("restriction") && !("").equals(license.get("restriction"))) {
+				if (license != null && license.containsKey("restriction") && !("").equals(license.get("restriction"))) {
 					restrictionStr += (isEmpty(restrictionStr)?"":",") + (String) license.get("restriction"); 
 				}
 			}
@@ -2562,19 +2562,19 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 			List<String> distinctList = new ArrayList<String>();
 			
 			// String 배열 -> String 리스트
-			for(int i = 0 ; i < restrictionArr.length ; i++){
+			for (int i = 0 ; i < restrictionArr.length ; i++){
 				restrictionList.add(restrictionArr[i]);
 			}
 			
 			// 중복 제거
-            for(String str : restrictionList){
+            for (String str : restrictionList){
                 if (!distinctList.contains(str)) {
                 	distinctList.add(str);
                 }
             }
             
-            for(String str : distinctList){
-            	if(!("").equals(str)) {
+            for (String str : distinctList){
+            	if (!("").equals(str)) {
                 	returnStr += (isEmpty(returnStr)?"":"\n") + CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, str.trim().toUpperCase());
             	}
             }
@@ -2584,19 +2584,19 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 	}
 	
 	private HashMap<String, Object> findOssIdAndName(HashMap<String, Object> bean) {
-		if(bean != null && bean.containsKey("ossName")) {
-			if("N/A".equals((String) bean.get("ossVersion"))) {
+		if (bean != null && bean.containsKey("ossName")) {
+			if ("N/A".equals((String) bean.get("ossVersion"))) {
 				bean.put("ossVersion", "");
 			}
 			
 			String findKey = ((String) bean.get("ossName")).trim() +"_";
-			if(bean.containsKey("ossVersion")) {
+			if (bean.containsKey("ossVersion")) {
 				findKey = ((String) bean.get("ossVersion")).trim();
 			}
 			findKey = findKey.toUpperCase();
 			Map<String, Object> masterBean = OSS_INFO_UPPER.get(findKey);
 			
-			if(masterBean != null) {
+			if (masterBean != null) {
 				bean.put("ossId", masterBean.get("ossId"));
 				bean.put("ossName", masterBean.get("ossName"));
 			}
@@ -2610,16 +2610,16 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		List<HashMap<String, Object>> ossComponentsLicenseList = null;
 		List<HashMap<String, Object>> returnOssComponentsLicenseList = new ArrayList<>();
 		// 먼저 license Id는 찾을수 있으면 모두 설정한다.
-		if(bean.containsKey("ossComponentsLicenseList")) {
+		if (bean.containsKey("ossComponentsLicenseList")) {
 			ossComponentsLicenseList = (List<HashMap<String, Object>>) bean.get("ossComponentsLicenseList");
-			for(HashMap<String, Object> licenseBean : ossComponentsLicenseList) {
+			for (HashMap<String, Object> licenseBean : ossComponentsLicenseList) {
 				if (licenseBean.containsKey("licenseName")) {
 					HashMap<String, Object> licenseMaster = (HashMap<String, Object>) LICENSE_INFO_UPPER.get(avoidNull(((String) licenseBean.get("licenseName")), "").trim().toUpperCase());
 					
-					if(licenseMaster != null) {
+					if (licenseMaster != null) {
 						licenseBean.put("licenseId", licenseMaster.get("licenseId"));
 						
-						if(licenseMaster.containsKey("shortIdentifier") && !("").equals(licenseMaster.get("shortIdentifier"))) {
+						if (licenseMaster.containsKey("shortIdentifier") && !("").equals(licenseMaster.get("shortIdentifier"))) {
 							licenseBean.put("licenseName", licenseMaster.get("shortIdentifier"));
 						}else {
 							licenseBean.put("licenseName", licenseMaster.get("licenseName"));
@@ -2635,28 +2635,28 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		}
 		
 		// oss에서 추가설정한 license text 및 oss copyright 설정
-		if(bean.containsKey("ossId")) {
+		if (bean.containsKey("ossId")) {
 			HashMap<String, Object> ossMaster = (HashMap<String, Object>) OSS_INFO_BY_ID.get(Integer.toString((int) bean.get("ossId")));
 			
-			if(ossMaster != null) {
+			if (ossMaster != null) {
 				// oss master에 등록된 licnese순서 기준으로 찾는다 (기본적으로 size가 일치 해야함, multi dual license의 경우)
 				if (ossMaster.containsKey("ossLicenses")) {
 					List<HashMap<String, Object>> ossLicensesList = (List<HashMap<String, Object>>) ossMaster.get("ossLicenses");
 					
 					if (ossLicensesList != null && ossLicensesList.size() > 0) {
 						
-						for(int i=0; i<ossLicensesList.size(); i++) {
+						for (int i=0; i<ossLicensesList.size(); i++) {
 							HashMap<String, Object> ossLicense = ossLicensesList.get(i);
-							if(returnOssComponentsLicenseList.size() >= i+1 
+							if (returnOssComponentsLicenseList.size() >= i+1 
 									&& ossLicense.get("licenseId").equals(returnOssComponentsLicenseList.get(i).get("licenseId"))) {
 								// license text
 								// oss_license에 존재하는 경우만 설정
-								if(ossLicense.containsKey("ossLicenseText") && ossLicense.get("ossLicenseText") != null && ((String) ossLicense.get("ossLicenseText")).length() > 0) {
+								if (ossLicense.containsKey("ossLicenseText") && ossLicense.get("ossLicenseText") != null && ((String) ossLicense.get("ossLicenseText")).length() > 0) {
 									returnOssComponentsLicenseList.get(i).put("licenseText", ossLicense.get("ossLicenseText"));
 								}
 								
 								// oss copyright
-								if(ossLicense.containsKey("ossCopyright") && ossLicense.get("ossCopyright") != null && ((String) ossLicense.get("ossCopyright")).length() > 0) {
+								if (ossLicense.containsKey("ossCopyright") && ossLicense.get("ossCopyright") != null && ((String) ossLicense.get("ossCopyright")).length() > 0) {
 									returnOssComponentsLicenseList.get(i).put("copyrightText", ossLicense.get("ossCopyright"));
 								}
 							}
@@ -2675,8 +2675,8 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		@SuppressWarnings("unchecked")
 		List<String> prjIdList = (List<String>) paramMap.get("prjId");
 		
-		if(prjIdList != null) {
-			if(isEmpty(ossReportFlag)) {
+		if (prjIdList != null) {
+			if (isEmpty(ossReportFlag)) {
 				ossReportFlag = CoConstDef.FLAG_NO;
 				
 				paramMap.put("ossReportFlag", ossReportFlag);

--- a/src/main/java/oss/fosslight/service/impl/ApiVulnerabilityServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiVulnerabilityServiceImpl.java
@@ -34,7 +34,7 @@ public class ApiVulnerabilityServiceImpl implements ApiVulnerabilityService {
 		paramMap.put("cveId", id);
 		paramMap.put("ossNicknames", nicknameList);
 		
-		if(product.contains(" ")) {
+		if (product.contains(" ")) {
 			paramMap.put("underbarOssName", product.replaceAll(" ", "_"));
 		}
 		
@@ -42,9 +42,9 @@ public class ApiVulnerabilityServiceImpl implements ApiVulnerabilityService {
 		List<String> duplicatedStr = new ArrayList<String>();
 		List<Map<String, Object>> duplicatedNvdList = new ArrayList<Map<String, Object>>();
 		
-		for(Map<String, Object> nvd : nvdList) {
+		for (Map<String, Object> nvd : nvdList) {
 			String s = (String) nvd.get("cveId");
-			if(!duplicatedStr.contains(s)) {
+			if (!duplicatedStr.contains(s)) {
 				duplicatedStr.add(s);
 				duplicatedNvdList.add(nvd);
 			}
@@ -59,7 +59,7 @@ public class ApiVulnerabilityServiceImpl implements ApiVulnerabilityService {
 		paramMap.put("ossVersion", version);
 		paramMap.put("host", env.getProperty("server.domain"));
 		
-		if(product.contains(" ")) {
+		if (product.contains(" ")) {
 			paramMap.put("underbarOssName", product.replaceAll(" ", "_"));
 		}
 		

--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -66,9 +66,9 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 		List<ProjectIdentification> resultData = new ArrayList<ProjectIdentification>();
 		Map<String, Object> ruleMap = T2CoValidationConfig.getInstance().getRuleAllMap();
 
-		if(validMap != null) {
-			for(String key : validMap.keySet()) {
-				if(key.toUpperCase().startsWith("LICENSENAME")
+		if (validMap != null) {
+			for (String key : validMap.keySet()) {
+				if (key.toUpperCase().startsWith("LICENSENAME")
 						&& (validMap.get(key).equals(ruleMap.get("LICENSE_NAME.UNCONFIRMED.MSG"))
 						|| validMap.get(key).equals(ruleMap.get("LICENSE_NAME.REQUIRED.MSG"))
 						|| validMap.get(key).equals(ruleMap.get("LICENSE_NAME.NOLICENSE.MSG"))
@@ -79,14 +79,14 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 							.collect(Collectors.toList()));
 				}
 
-				if(key.toUpperCase().startsWith("OSSVERSION") && validMap.get(key).equals(ruleMap.get("OSS_VERSION.UNCONFIRMED.MSG"))) {
+				if (key.toUpperCase().startsWith("OSSVERSION") && validMap.get(key).equals(ruleMap.get("OSS_VERSION.UNCONFIRMED.MSG"))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
 							.stream()
 							.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
 							.collect(Collectors.toList()));
 				}
 
-				if(key.toUpperCase().startsWith("OSSNAME") && validMap.get(key).equals(ruleMap.get("OSS_NAME.UNCONFIRMED.MSG"))) {
+				if (key.toUpperCase().startsWith("OSSNAME") && validMap.get(key).equals(ruleMap.get("OSS_NAME.UNCONFIRMED.MSG"))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
 							.stream()
 							.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
@@ -95,9 +95,9 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			}
 		}
 
-		if(diffMap != null) {
-			for(String key : diffMap.keySet()) {
-				if(key.toUpperCase().startsWith("LICENSENAME") && 
+		if (diffMap != null) {
+			for (String key : diffMap.keySet()) {
+				if (key.toUpperCase().startsWith("LICENSENAME") && 
 						(diffMap.get(key).equals(ruleMap.get("LICENSE_NAME.UNCONFIRMED.MSG"))
 								|| diffMap.get(key).startsWith("Declared"))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
@@ -106,21 +106,21 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 							.collect(Collectors.toList()));
 				}
 
-				if(key.toUpperCase().startsWith("OSSVERSION") && diffMap.get(key).equals(ruleMap.get("OSS_VERSION.UNCONFIRMED.MSG"))) {
+				if (key.toUpperCase().startsWith("OSSVERSION") && diffMap.get(key).equals(ruleMap.get("OSS_VERSION.UNCONFIRMED.MSG"))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
 							.stream()
 							.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
 							.collect(Collectors.toList()));
 				}
 
-				if(key.toUpperCase().startsWith("DOWNLOADLOCATION") && diffMap.get(key).equals(ruleMap.get("DOWNLOAD_LOCATION.DIFFERENT.MSG"))) {
+				if (key.toUpperCase().startsWith("DOWNLOADLOCATION") && diffMap.get(key).equals(ruleMap.get("DOWNLOAD_LOCATION.DIFFERENT.MSG"))) {
 					int duplicateRow = (int) resultData
 							.stream()
 							.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
 							.collect(Collectors.toList())
 							.size();
 
-					if(duplicateRow == 0) {
+					if (duplicateRow == 0) {
 						resultData.addAll((List<ProjectIdentification>) componentData
 								.stream()
 								.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
@@ -167,7 +167,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			errors.add(e.getStatusText());
 		}
 
-		for(ProjectIdentification oss : ossList) {
+		for (ProjectIdentification oss : ossList) {
 			List<ProjectIdentification> prjOssLicenses;
 			String downloadLocation = oss.getDownloadLocation();
 			String ossVersion = oss.getOssVersion();
@@ -179,7 +179,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			checkedLicense = combineOssLicenses(prjOssLicenses, currentLicense);
 
 			if (!checkedLicense.isEmpty()) {
-				if(!currentLicense.equals(checkedLicense)) {
+				if (!currentLicense.equals(checkedLicense)) {
 					String evidence = getMessage("check.evidence.exist.nameAndVersion");
 					oss.setCheckOssList("Y");
 					oss.setCheckLicense(checkedLicense);
@@ -190,19 +190,19 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				continue;
 			}
 
-			if(downloadLocation.isEmpty()) {
+			if (downloadLocation.isEmpty()) {
 				continue;
 			}
 
-			if(oss.getDownloadLocation().contains(";")) {
+			if (oss.getDownloadLocation().contains(";")) {
 				oss.setDownloadLocation(oss.getDownloadLocation().split(";")[0]);
 			}
 			
-			if(oss.getDownloadLocation().startsWith("git@")){
+			if (oss.getDownloadLocation().startsWith("git@")){
 				oss.setDownloadLocation(oss.getDownloadLocation().split("@")[1]);
 			}
 			
-			if(oss.getDownloadLocation().startsWith("http://") 
+			if (oss.getDownloadLocation().startsWith("http://") 
 					|| oss.getDownloadLocation().startsWith("https://")
 					|| oss.getDownloadLocation().startsWith("git://")
 					|| oss.getDownloadLocation().startsWith("ftp://")
@@ -210,15 +210,15 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				oss.setDownloadLocation(oss.getDownloadLocation().split("//")[1]);
 			}
 			
-			if(oss.getDownloadLocation().startsWith("www.")) {
+			if (oss.getDownloadLocation().startsWith("www.")) {
 				oss.setDownloadLocation(oss.getDownloadLocation().substring(5, oss.getDownloadLocation().length()));
 			}
 			
-			if(oss.getDownloadLocation().contains(".git")) {
-				if(oss.getDownloadLocation().endsWith(".git")) {
+			if (oss.getDownloadLocation().contains(".git")) {
+				if (oss.getDownloadLocation().endsWith(".git")) {
 					oss.setDownloadLocation(oss.getDownloadLocation().substring(0, oss.getDownloadLocation().length()-4));
 				} else {
-					if(oss.getDownloadLocation().contains("#")) {
+					if (oss.getDownloadLocation().contains("#")) {
 						oss.setDownloadLocation(oss.getDownloadLocation().substring(0, oss.getDownloadLocation().indexOf("#")));
 						oss.setDownloadLocation(oss.getDownloadLocation().substring(0, oss.getDownloadLocation().length()-4));
 					}
@@ -226,7 +226,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			}
 			
 			String[] downloadlocationUrlSplit = oss.getDownloadLocation().split("/");
-			if(downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
+			if (downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
 				oss.setDownloadLocation(oss.getDownloadLocation().substring(0, oss.getDownloadLocation().indexOf("#")));
 			}
 			
@@ -235,7 +235,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			checkedLicense = combineOssLicenses(prjOssLicenses, currentLicense);
 
 			if (!checkedLicense.isEmpty()) {
-				if(!currentLicense.equals(checkedLicense)) {
+				if (!currentLicense.equals(checkedLicense)) {
 					String evidence = getMessage("check.evidence.exist.downloadLocationAndVersion");
 					oss.setCheckOssList("Y");
 					oss.setCheckLicense(checkedLicense);
@@ -257,7 +257,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			checkedLicense = combineOssLicenses(prjOssLicenses, currentLicense);
 
 			if (!checkedLicense.isEmpty() && !isEachOssVersionDiff(prjOssLicenses)) {
-				if(!currentLicense.equals(checkedLicense)) {
+				if (!currentLicense.equals(checkedLicense)) {
 					String evidence = getMessage("check.evidence.exist.downloadLocation");
 					oss.setCheckOssList("Y");
 					oss.setCheckLicense(checkedLicense);
@@ -274,16 +274,16 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			// Search Priority 4. find by Clearly Defined And Github API
 			DependencyType dependencyType = DependencyType.downloadLocationToType(downloadLocation);
 
-			if(dependencyType.equals(DependencyType.UNSUPPORTED) || !isExternalServiceEnable()) {
+			if (dependencyType.equals(DependencyType.UNSUPPORTED) || !isExternalServiceEnable()) {
 				continue;
 			}
 
 			// Search Priority 4-1. Github API : empty oss version and download location
-			if(ossVersion.isEmpty() && ExternalLicenseServiceType.GITHUB.hasDependencyType(dependencyType) && isGitHubApiHealth) {
+			if (ossVersion.isEmpty() && ExternalLicenseServiceType.GITHUB.hasDependencyType(dependencyType) && isGitHubApiHealth) {
 				Matcher matcher = dependencyType.getPattern().matcher(downloadLocation);
 				String owner = "", repo = "";
 
-				while(matcher.find()) {
+				while (matcher.find()) {
 					owner = matcher.group(3);
 					repo = matcher.group(4);
 				}
@@ -291,7 +291,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				String requestUri = ExternalLicenseServiceType.githubLicenseRequestUri(owner, repo);
 				checkedLicense = avoidNull(requestGithubLicenseApi(requestUri));
 
-				if(!currentLicense.equals(checkedLicense) && !checkedLicense.equals("NOASSERTION") && !checkedLicense.equals("NONE") && !checkedLicense.isEmpty()) {
+				if (!currentLicense.equals(checkedLicense) && !checkedLicense.equals("NOASSERTION") && !checkedLicense.equals("NONE") && !checkedLicense.isEmpty()) {
 					String evidence = getMessage("check.evidence.github.downloadLocation");
 					oss.setCheckOssList("Y");
 					oss.setCheckLicense(checkedLicense);
@@ -303,15 +303,15 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			}
 
 			// Search Priority 4-2. Clearly Defined : oss version and download location
-			if(!ossVersion.isEmpty() && ExternalLicenseServiceType.CLEARLY_DEFINED.hasDependencyType(dependencyType) && isClearlyDefinedApiHealth) {
+			if (!ossVersion.isEmpty() && ExternalLicenseServiceType.CLEARLY_DEFINED.hasDependencyType(dependencyType) && isClearlyDefinedApiHealth) {
 				Matcher matcher = dependencyType.getPattern().matcher(downloadLocation);
 				String type = dependencyType.getType();
 				String provider = dependencyType.getProvider();
 				String revision = ossVersion;
 				String namespace = "", name = "";
 
-				while(matcher.find()) {
-					if(dependencyType.equals(DependencyType.MAVEN_CENTRAL) || dependencyType.equals(DependencyType.MAVEN_GOOGLE)) {
+				while (matcher.find()) {
+					if (dependencyType.equals(DependencyType.MAVEN_CENTRAL) || dependencyType.equals(DependencyType.MAVEN_GOOGLE)) {
 						namespace = matcher.group(3);
 						name = matcher.group(4);
 					} else {
@@ -323,7 +323,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				String requestUri = ExternalLicenseServiceType.clearlyDefinedLicenseRequestUri(type, provider, namespace, name, revision);
 				checkedLicense = avoidNull(requestClearlyDefinedLicenseApi(requestUri));
 
-				if(!currentLicense.equals(checkedLicense) && !checkedLicense.equals("NOASSERTION") && !checkedLicense.equals("NONE") && !checkedLicense.isEmpty()) {
+				if (!currentLicense.equals(checkedLicense) && !checkedLicense.equals("NOASSERTION") && !checkedLicense.equals("NONE") && !checkedLicense.isEmpty()) {
 					String evidence = getMessage("check.evidence.clearlyDefined.downloadLocationAndVersion");
 					oss.setCheckOssList("Y");
 					oss.setCheckLicense(checkedLicense);
@@ -354,7 +354,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				.collect(Collectors.toList());
 		
 		// oss name, oss version, oss license와 checked license가 unique하지 않다면 중복된 data의 downloadlocation을 전부 합쳐서 출력함. 
-		for(ProjectIdentification p : sortedData) {
+		for (ProjectIdentification p : sortedData) {
 			String downloadLocation = result.stream()
 					.filter(e -> e.getOssName().equals(p.getOssName()))
 					.filter(e -> e.getOssVersion().equals(p.getOssVersion()))
@@ -378,7 +378,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 
 		resMap.put("checkedData", sortedData);
 
-		if(errors.size() > 0) {
+		if (errors.size() > 0) {
 			resMap.put("error", getMessage("external.service.connect.fail", new Object[]{errors}));
 		}
 
@@ -442,7 +442,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			requestGithubLicense("https://api.github.com/").block();
 		} catch(HttpServerErrorException e) {
 			String message = "GitHub ";
-			if(e.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
+			if (e.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
 				message += getMessage("api.token.invalid");
 				throw new HttpServerErrorException(e.getStatusCode(), message);
 			}
@@ -481,9 +481,9 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 		String checkLicense = "";
 		List<ProjectIdentification> licenses;
 
-		for(ProjectIdentification prjOssMaster : prjOssMasters) {
+		for (ProjectIdentification prjOssMaster : prjOssMasters) {
 
-			if(!isEmpty(checkLicense)) {
+			if (!isEmpty(checkLicense)) {
 				checkLicense += "|";
 			}
 
@@ -496,7 +496,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 	private String makeLicenseExpression(List<ProjectIdentification> licenses, String currentLicense) {
 		String license = "";
 
-		if(licenses.size() != 0){
+		if (licenses.size() != 0){
 			licenses = CommonFunction.makeLicensePermissiveList(licenses, currentLicense);
 			licenses = CommonFunction.makeLicenseExcludeYn(licenses);
 			licenses.sort(Comparator.comparing(ProjectIdentification::getLicenseName));
@@ -524,14 +524,14 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 			.exchange()
 			.flatMap(response -> {
 				HttpStatus statusCode = response.statusCode();
-				if(statusCode.is4xxClientError()) {
+				if (statusCode.is4xxClientError()) {
 					return Mono.error(new HttpServerErrorException(statusCode));
 				}else if (statusCode.is5xxServerError()) {
 					return Mono.error(new HttpServerErrorException(statusCode));
 				}
 				return Mono.just(response);
 			})
-			.retry(1)
+			.retry (1)
 			.flatMap(response -> response.bodyToMono(Object.class));
 	}
 
@@ -557,7 +557,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 					}
 					return Mono.just(response);
 				})
-				.retry(1)
+				.retry (1)
 				.flatMap(response -> response.bodyToMono(Object.class));
 	}
 
@@ -570,7 +570,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 
 			List<String> componentIds = paramBean.getComponentIdList();
 
-			for(String componentId : componentIds) {
+			for (String componentId : componentIds) {
 				OssComponents oc = new OssComponents();
 				oc.setComponentId(componentId);
 				switch(targetName.toUpperCase()) {
@@ -588,7 +588,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				String[] checkLicense = paramBean.getCheckLicense().split(",");
 				String licenseDev = checkLicense.length > 1 ? CoConstDef.LICENSE_DIV_MULTI : CoConstDef.LICENSE_DIV_SINGLE;
 				
-				for(String licenseName : checkLicense) {
+				for (String licenseName : checkLicense) {
 					ProjectIdentification comLicense = new ProjectIdentification();
 					comLicense.setComponentId(componentId);
 					comLicense.setLicenseName(licenseName);
@@ -609,14 +609,14 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				}
 			}
 			
-			if(CoConstDef.CD_CHECK_OSS_PARTNER.equals(targetName.toUpperCase())
+			if (CoConstDef.CD_CHECK_OSS_PARTNER.equals(targetName.toUpperCase())
 					|| CoConstDef.CD_CHECK_OSS_IDENTIFICATION.equals(targetName.toUpperCase())) {
-				if(updateCnt >= 1) {
+				if (updateCnt >= 1) {
 					String commentId = CoConstDef.CD_CHECK_OSS_PARTNER.equals(targetName.toUpperCase()) ? paramBean.getRefPrjId() : paramBean.getReferenceId();
 					String checkOssLicenseComment = "";
 					String changeOssLicenseInfo = "<p>" + paramBean.getOssName();
 
-					if(!paramBean.getOssVersion().isEmpty()) {
+					if (!paramBean.getOssVersion().isEmpty()) {
 						changeOssLicenseInfo += " (" + paramBean.getOssVersion() + ") ";
 					} else {
 						changeOssLicenseInfo += " ";
@@ -626,12 +626,12 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 							+ paramBean.getLicenseName() + " => " + paramBean.getCheckLicense() + "</p>";
 					CommentsHistory commentInfo = null;
 
-					if(isEmpty(commentId)) {
+					if (isEmpty(commentId)) {
 						checkOssLicenseComment  = "<p><b>The following Licenses were modified by \"Check License\"</b></p>";
 						checkOssLicenseComment += changeOssLicenseInfo;
 						CommentsHistory commHisBean = new CommentsHistory();
 						
-						if(CoConstDef.CD_CHECK_OSS_PARTNER.equals(targetName.toUpperCase())) {
+						if (CoConstDef.CD_CHECK_OSS_PARTNER.equals(targetName.toUpperCase())) {
 							commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PARTNER_HIS);
 							commHisBean.setReferenceId(paramBean.getReferenceId());
 						}else {
@@ -644,8 +644,8 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 					} else {
 						commentInfo = (CommentsHistory) commentService.getCommnetInfo(commentId).get("info");
 
-						if(commentInfo != null) {
-							if(!isEmpty(commentInfo.getContents())) {
+						if (commentInfo != null) {
+							if (!isEmpty(commentInfo.getContents())) {
 								checkOssLicenseComment  = commentInfo.getContents();
 								checkOssLicenseComment += changeOssLicenseInfo;
 								commentInfo.setContents(checkOssLicenseComment);
@@ -655,13 +655,13 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 						}
 					}
 
-					if(commentInfo != null) {
+					if (commentInfo != null) {
 						map.put("commentId", commentInfo.getCommId());
 					}
 				}
 			}
 			
-			if(updateCnt >= 1) {
+			if (updateCnt >= 1) {
 				map.put("isValid", true);
 				map.put("returnType", "Success");
 			} else {

--- a/src/main/java/oss/fosslight/service/impl/BinaryDataHistoryServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/BinaryDataHistoryServiceImpl.java
@@ -37,13 +37,13 @@ public class BinaryDataHistoryServiceImpl extends CoTopComponent implements Bina
 		
 		String filterCondition = CommonFunction.getFilterToString(bean.getFilters(), null, exceptionMap);
 		
-		if(!isEmpty(filterCondition)) {
+		if (!isEmpty(filterCondition)) {
 			bean.setFilterCondition(filterCondition);
 		}
 		
 		int records = binaryDataHistoryMapper.selectBinaryDataHistoryTotalCount(bean);
 		
-		if(records > 0) {
+		if (records > 0) {
 			bean.setTotListSize(records);
 			
 			map = getGridPagerMap(bean);

--- a/src/main/java/oss/fosslight/service/impl/CacheServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/CacheServiceImpl.java
@@ -40,7 +40,7 @@ public class CacheServiceImpl implements CacheService {
 	@Cacheable(value="licenseInfoCache")
 	public Set<String> getLicenseUpperNames() {
 		Set<String> list = new HashSet<>();
-		for(String s : getLicenseNames()) {
+		for (String s : getLicenseNames()) {
 			list.add(s.toUpperCase());
 		}
 		return list;

--- a/src/main/java/oss/fosslight/service/impl/CodeServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/CodeServiceImpl.java
@@ -36,7 +36,7 @@ public class CodeServiceImpl extends CoTopComponent implements CodeService {
 		Map<String, Object> map = null;
 		int records = codeMapper.selectCodeTotalCount(vo);
 		
-		if(records > 0) {
+		if (records > 0) {
 			vo.setTotListSize(records);
 			map = getGridPagerMap(vo);
 			map.put("rows", codeMapper.selectCodeList(vo));
@@ -52,7 +52,7 @@ public class CodeServiceImpl extends CoTopComponent implements CodeService {
 	public ArrayList<T2CodeDtl> getCodeDetailList(T2CodeDtl vo) throws Exception {
 		ArrayList<T2CodeDtl> codeDetailList = codeMapper.selectCodeDetailList(vo);
 		
-		if(codeDetailList.size() > 0){
+		if (codeDetailList.size() > 0){
 			for (T2CodeDtl t2CodeDtl : codeDetailList) {
 				if (isGithubTokenCodeDtl(t2CodeDtl)) {
 					t2CodeDtl.setCdDtlExp("");
@@ -76,9 +76,9 @@ public class CodeServiceImpl extends CoTopComponent implements CodeService {
 	@Override
 	public void setCode(T2Code vo) throws Exception {
 		// 추가
-		if(CoConstDef.GRID_OPERATION_ADD.equals(vo.getOper())) {
+		if (CoConstDef.GRID_OPERATION_ADD.equals(vo.getOper())) {
 			codeMapper.insertCode(vo);
-		} else if(CoConstDef.GRID_OPERATION_EDIT.equals(vo.getOper())) { // 수정
+		} else if (CoConstDef.GRID_OPERATION_EDIT.equals(vo.getOper())) { // 수정
 			codeMapper.updateCode(vo);
 		} else { // 삭제
 			codeMapper.deleteCodeDetailAll(vo);
@@ -132,7 +132,7 @@ public class CodeServiceImpl extends CoTopComponent implements CodeService {
 			}
 		}
 
-		if(isExternalServiceCodeNo(cdNo) && hasGithubTokenCodeDtl(dtlList)) {
+		if (isExternalServiceCodeNo(cdNo) && hasGithubTokenCodeDtl(dtlList)) {
 			// 1. 기존 github token값 보관
 			T2CodeDtl githubTokenDtl = codeMapper.getCodeDetail(cdNo, CoConstDef.CD_DTL_GITHUB_TOKEN);
 
@@ -144,7 +144,7 @@ public class CodeServiceImpl extends CoTopComponent implements CodeService {
 
 			// 3. 전체 상세 코드 재등록(추가 / 변경 / 삭제)
 			for (T2CodeDtl codeDtl : dtlList) {
-				if(isGithubTokenCodeDtlNo(codeDtl.getCdDtlNo()) && codeDtl.getCdDtlExp().isEmpty()) {
+				if (isGithubTokenCodeDtlNo(codeDtl.getCdDtlNo()) && codeDtl.getCdDtlExp().isEmpty()) {
 					codeMapper.insertCodeDetail(githubTokenDtl);
 				} else {
 					codeMapper.insertCodeDetail(codeDtl);

--- a/src/main/java/oss/fosslight/service/impl/CommentServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/CommentServiceImpl.java
@@ -29,7 +29,7 @@ public class CommentServiceImpl implements CommentService {
 	public List<CommentsHistory> getCommentListHis(CommentsHistory bean) {
 		List<CommentsHistory> commentsHistoryList = commentMapper.getCommentListHis(bean);
 		
-		for(CommentsHistory commentsHistory : commentsHistoryList) {
+		for (CommentsHistory commentsHistory : commentsHistoryList) {
 			commentMapper.updateHistoryReadYn(commentsHistory);
 		}
 		
@@ -52,13 +52,13 @@ public class CommentServiceImpl implements CommentService {
 	public CommentsHistory registComment(CommentsHistory bean, boolean deleteUserComment) {
 		boolean isNew = StringUtil.isEmpty(bean.getCommId());
 		
-		if(!StringUtil.isEmpty(bean.getContents()) || !StringUtil.isEmpty(bean.getStatus())){
+		if (!StringUtil.isEmpty(bean.getContents()) || !StringUtil.isEmpty(bean.getStatus())){
 			commentMapper.registComment(bean);
 		}
 		
 		boolean isPartner = CoConstDef.CD_DTL_COMMENT_PARTNER_HIS.equals(bean.getReferenceDiv());
 		
-		if(deleteUserComment && isNew && (CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS.equals(bean.getReferenceDiv())
+		if (deleteUserComment && isNew && (CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS.equals(bean.getReferenceDiv())
 				|| CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS.equals(bean.getReferenceDiv())
 				|| CoConstDef.CD_DTL_COMMENT_PARTNER_HIS.equals(bean.getReferenceDiv()) 
 				|| CoConstDef.CD_DTL_COMMENT_PROJECT_HIS.equals(bean.getReferenceDiv()))) {
@@ -87,12 +87,12 @@ public class CommentServiceImpl implements CommentService {
 					break;
 			}
 			
-			if(!StringUtil.isEmpty(bean.getReferenceDiv())) {
+			if (!StringUtil.isEmpty(bean.getReferenceDiv())) {
 				commentMapper.deleteCommentUserTemp(bean);
 			}
 		}
 		
-		if(CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_ADDED_COMMENT.equals(bean.getMailType()) 
+		if (CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_ADDED_COMMENT.equals(bean.getMailType()) 
 			|| CoConstDef.CD_MAIL_TYPE_PROJECT_PACKAGING_ADDED_COMMENT.equals(bean.getMailType())
 			|| CoConstDef.CD_MAIL_TYPE_PROJECT_DISTRIBUTE_ADDED_COMMENT.equals(bean.getMailType())
 			|| CoConstDef.CD_MAIL_TYPE_PARTER_ADDED_COMMENT.equals(bean.getMailType())
@@ -100,7 +100,7 @@ public class CommentServiceImpl implements CommentService {
 			|| CoConstDef.CD_MAIL_TYPE_PROJECT_REQUESTTOOPEN_COMMENT.equals(bean.getMailType())) {
 			CoMail mailBean = new CoMail(bean.getMailType());
 			
-			if(isPartner) {
+			if (isPartner) {
 				mailBean.setParamPartnerId(bean.getReferenceId());
 			} else {
 				mailBean.setParamPrjId(bean.getReferenceId());
@@ -108,17 +108,17 @@ public class CommentServiceImpl implements CommentService {
 			
 			mailBean.setComment(bean.getContents());
 			
-			if(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS.equals(bean.getReferenceDiv())) {
+			if (CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS.equals(bean.getReferenceDiv())) {
 				mailBean.setStage("Identificaiton");
-			} else if(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS.equals(bean.getReferenceDiv())) {
+			} else if (CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS.equals(bean.getReferenceDiv())) {
 				mailBean.setStage("Packaging");
-			} else if(CoConstDef.CD_DTL_COMMENT_DISTRIBUTION_HIS.equals(bean.getReferenceDiv())) {
+			} else if (CoConstDef.CD_DTL_COMMENT_DISTRIBUTION_HIS.equals(bean.getReferenceDiv())) {
 				mailBean.setStage("Distribution");
 			}
 			
 			mailBean.setReceiveFlag(bean.getMailSendType());
 			
-			if(!StringUtil.isEmpty(bean.getContents())){//comment 내용이 있을시만 메일 발송
+			if (!StringUtil.isEmpty(bean.getContents())){//comment 내용이 있을시만 메일 발송
 				CoMailManager.getInstance().sendMail(mailBean);
 			}
 		}
@@ -153,8 +153,8 @@ public class CommentServiceImpl implements CommentService {
 		CommentsHistory before = commentMapper.getCommentInfo(bean.getCommId());
 		int rtn = commentMapper.updateComment(bean);
 		
-		if(emailSendFlag) {
-			if(rtn > 0 && bean.getReferenceDiv() != null) {
+		if (emailSendFlag) {
+			if (rtn > 0 && bean.getReferenceDiv() != null) {
 				boolean isPartner = false;
 				String paramOssId = null;
 				String paramLicenseId = null;
@@ -205,11 +205,11 @@ public class CommentServiceImpl implements CommentService {
 				mailBean.setComment(bean.getContents());
 				mailBean.setReceiveFlag(bean.getMailSendType());
 				
-				if(isPartner) {
+				if (isPartner) {
 					mailBean.setParamPartnerId(bean.getReferenceId());
-				} else if(!StringUtil.isEmpty(paramLicenseId)) {
+				} else if (!StringUtil.isEmpty(paramLicenseId)) {
 					mailBean.setParamLicenseId(paramLicenseId);
-				} else if(!StringUtil.isEmpty(paramOssId)) {
+				} else if (!StringUtil.isEmpty(paramOssId)) {
 					mailBean.setParamOssId(paramOssId);
 				} else {
 					mailBean.setParamPrjId(bean.getReferenceId());
@@ -231,7 +231,7 @@ public class CommentServiceImpl implements CommentService {
 	public List<CommentsHistory> getMoreCommentListHis(CommentsHistory bean) {
 		List<CommentsHistory> commentsHistoryList = commentMapper.getMoreCommentListHis(bean);
 		
-		for(CommentsHistory commentsHistory : commentsHistoryList) {
+		for (CommentsHistory commentsHistory : commentsHistoryList) {
 			commentMapper.updateHistoryReadYn(commentsHistory);
 		}
 		

--- a/src/main/java/oss/fosslight/service/impl/ComplianceServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ComplianceServiceImpl.java
@@ -38,14 +38,14 @@ public class ComplianceServiceImpl implements ComplianceService {
 			project.setModelFlag(CoConstDef.FLAG_NO);
 			List<Project> projectNameList = projectMapper.selectModelInfoList(project);
 			
-			if(projectNameList != null && projectNameList.size() > 0) {
+			if (projectNameList != null && projectNameList.size() > 0) {
 				list.addAll(projectNameList);
 			}
 			
 			project.setModelFlag(CoConstDef.FLAG_YES);
 			List<Project> modelNameList = projectMapper.selectModelInfoList(project);
 			
-			if(modelNameList != null && modelNameList.size() > 0) {
+			if (modelNameList != null && modelNameList.size() > 0) {
 				list.addAll(modelNameList);
 			}
 			
@@ -53,13 +53,13 @@ public class ComplianceServiceImpl implements ComplianceService {
 						.filter(CommonFunction.distinctByKey(p -> p.getModelName()+"-"+p.getPrjId()))
 						.collect(Collectors.toList());
 			
-			for(String modelName : project.getModelListInfo()) {
+			for (String modelName : project.getModelListInfo()) {
 				int duplicateCnt = list.stream()
 										.filter(p -> modelName.equals(p.getModelName()))
 										.collect(Collectors.toList())
 										.size();
 				
-				if(duplicateCnt == 0) {
+				if (duplicateCnt == 0) {
 					Project prj = new Project();
 					prj.setModelName(modelName);
 					
@@ -68,12 +68,12 @@ public class ComplianceServiceImpl implements ComplianceService {
 			}
 			
 			
-			if(list != null) {
+			if (list != null) {
 				final Comparator<Project> comp = Comparator.comparing((Project p) -> p.getModelName());
 				list = list.stream().sorted(comp).collect(Collectors.toList());
 				
 				// 코드변환처리
-				for(Project bean : list) {
+				for (Project bean : list) {
 					// DISTRIBUTION_TYPE
 					bean.setDistributionType(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, bean.getDistributionType()));
 					// Project Status - delay 기능이 삭제됨. 기존에도 delay를 표시하지 않았으므로 priority도 표시하지 않게 처리함.

--- a/src/main/java/oss/fosslight/service/impl/DashboardServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/DashboardServiceImpl.java
@@ -52,9 +52,9 @@ public class DashboardServiceImpl extends CoTopComponent implements DashboardSer
         List<Project> list = dashboardMapper.selectDashboardJobsList(paramMap);
         // TODO bin 변경  > ???
         
-        if(list != null) {
+        if (list != null) {
 			// 코드변환처리
-			for(Project bean : list) {
+			for (Project bean : list) {
 				bean.setStatus( CoCodeManager.getCodeString(CoConstDef.CD_PROJECT_STATUS, bean.getStatus()));
 				
 				// Project priority 
@@ -74,14 +74,14 @@ public class DashboardServiceImpl extends CoTopComponent implements DashboardSer
         boolean projectFlag = CommonFunction.propertyFlagCheck("menu.project.use.flag", CoConstDef.FLAG_YES);
         boolean partnerFlag = CommonFunction.propertyFlagCheck("menu.partner.use.flag", CoConstDef.FLAG_YES);
         
-        if(projectFlag) {
+        if (projectFlag) {
         	referenceDivList.add(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
         	referenceDivList.add(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS);
         	referenceDivList.add(CoConstDef.CD_DTL_COMMENT_DISTRIBUTION_HIS);
         	referenceDivList.add(CoConstDef.CD_DTL_COMMENT_PROJECT_HIS);
         }
         
-        if(partnerFlag) {
+        if (partnerFlag) {
         	referenceDivList.add(CoConstDef.CD_DTL_COMMENT_PARTNER_HIS);
         }
         
@@ -108,8 +108,8 @@ public class DashboardServiceImpl extends CoTopComponent implements DashboardSer
 
         List<OssMaster> ossList = dashboardMapper.selectDashboardOssList(ossMaster);
         
-		for(OssMaster item : ossList) {
-			if(CoCodeManager.OSS_INFO_BY_ID.containsKey(item.getOssId())) {
+		for (OssMaster item : ossList) {
+			if (CoCodeManager.OSS_INFO_BY_ID.containsKey(item.getOssId())) {
 				item.setLicenseName(CommonFunction.makeLicenseExpression(CoCodeManager.OSS_INFO_BY_ID.get(item.getOssId()).getOssLicenses()));
 			}
 		}

--- a/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
@@ -82,9 +82,9 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		boolean sw = true;
 		String fileId = "";
 		
-		if(oldFileId==null || "0".equals(oldFileId) || "".equals(oldFileId)){
+		if (oldFileId==null || "0".equals(oldFileId) || "".equals(oldFileId)){
 			fileId = fileMapper.getFileId();
-			if(fileId == null){
+			if (fileId == null){
 				fileId = "1";
 			}
 		}else{
@@ -93,12 +93,12 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		
 		int indexNum = 0;
 		
-		while(fileNames.hasNext()){
+		while (fileNames.hasNext()){
 			UploadFile upFile = new UploadFile();					
 			boolean uploadSucc = true;
 			String fileName = fileNames.next();		//input name
 			
-			if(inputFileName != null){
+			if (inputFileName != null){
 				String inputFileNameRe = inputFileName.replace("##]", "");
 				int st = fileName.indexOf("[");
 				int en = fileName.indexOf("]");
@@ -111,7 +111,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 				
 				boolean isInput = fileName.startsWith(inputFileNameRe);
 				
-				if(!isInput || inputFileName == null){
+				if (!isInput || inputFileName == null){
 					continue;
 				}
 			}
@@ -120,11 +120,11 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			
 			MultipartFile mFile = multipartRequest.getFile(fileName);
 			
-			if(isEmpty(mFile.getOriginalFilename())) {
+			if (isEmpty(mFile.getOriginalFilename())) {
 				throw new RuntimeException("File Name is empty");
 			}
 			
-			if(mFile.getSize() <= 0) {
+			if (mFile.getSize() <= 0) {
 				throw new RuntimeException("File Size is 0");
 			}
 			
@@ -133,12 +133,12 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			// originalFileName에 경로가 포함되어 있는 경우 처리
 			log.debug("File upload OriginalFileName : " + originalFileName);
 			
-			if(originalFileName.indexOf("/") > -1) {
+			if (originalFileName.indexOf("/") > -1) {
 				originalFileName = originalFileName.substring(originalFileName.lastIndexOf("/") + 1);
 				
 				log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
 			}
-			if(originalFileName.indexOf("\\") > -1) {
+			if (originalFileName.indexOf("\\") > -1) {
 				originalFileName = originalFileName.substring(originalFileName.lastIndexOf("\\") + 1);
 				
 				log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
@@ -146,11 +146,11 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			
 			String fileExt = FilenameUtils.getExtension(originalFileName);
 			
-			if(originalFileName.toLowerCase().endsWith(".tgz.gz")) {
+			if (originalFileName.toLowerCase().endsWith(".tgz.gz")) {
 				fileExt = "tgz.gz";
-			} else if(originalFileName.toLowerCase().endsWith(".tar.bz2")) {
+			} else if (originalFileName.toLowerCase().endsWith(".tar.bz2")) {
 				fileExt = "tar.bz2";
-			} else if(originalFileName.toLowerCase().endsWith(".tar.gz")) {
+			} else if (originalFileName.toLowerCase().endsWith(".tar.gz")) {
 				fileExt = "tar.gz";
 			}
 			
@@ -198,14 +198,14 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			upFile.setRegistSeq(registFile(registFile));
 			upFile.setCreatedDate(CommonFunction.getCurrentDateTime(CoConstDef.DATABASE_FORMAT_DATE_ALL));
 			
-			if(mFile.getSize()!=0){ //File Null Check
-				if(! file.exists()){ //경로상에 파일이 존재하지 않을 경우
+			if (mFile.getSize()!=0){ //File Null Check
+				if (! file.exists()){ //경로상에 파일이 존재하지 않을 경우
 					try {
-						if(file.getParentFile().mkdirs()){ //경로에 해당하는 디렉토리들을 생성
+						if (file.getParentFile().mkdirs()){ //경로에 해당하는 디렉토리들을 생성
 
 							boolean upSucc = file.createNewFile(); //이후 파일 생성
 							
-							if(!upSucc){
+							if (!upSucc){
 								uploadSucc=false;
 							}
 						}
@@ -223,7 +223,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			result.add(upFile);
 		}
 		
-		if(sw){
+		if (sw){
 			result = null;
 		}
 		
@@ -234,7 +234,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 	public String registFile(T2File file) {
 		int result = fileMapper.insertFile(file);
 		
-		if(result <= 0){
+		if (result <= 0){
 			return null;
 		}
 		
@@ -279,7 +279,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		String fileId = "";
 		
 		//구 fileId가 존제 한다면 구 fileId에 넣어준다
-		if(!isEmpty(oldFileId)){
+		if (!isEmpty(oldFileId)){
 			fileId = oldFileId;
 		} else {
 			fileId = avoidNull(fileMapper.getFileId(), "1");
@@ -289,13 +289,13 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 
 		int indexNum = 0;
 		
-		while(fileNames.hasNext()){
+		while (fileNames.hasNext()){
 			UploadFile upFile = new UploadFile();
 			registFile.setCreator(registFile.getCreator());
 			boolean uploadSucc = true;
 			String fileName = fileNames.next();		//input name
 			
-			if(inputFileName != null){
+			if (inputFileName != null){
 				String inputFileNameRe = inputFileName.replace("##]", "");
 				int st = fileName.indexOf("[");
 				int en = fileName.indexOf("]");
@@ -310,7 +310,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 				
 				boolean isInput = fileName.startsWith(inputFileNameRe);
 				
-				if(!isInput || inputFileName == null){
+				if (!isInput || inputFileName == null){
 					continue;
 				}
 			}
@@ -319,11 +319,11 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			
 			MultipartFile mFile = multipartRequest.getFile(fileName);
 
-			if(isEmpty(mFile.getOriginalFilename())) {
+			if (isEmpty(mFile.getOriginalFilename())) {
 				throw new RuntimeException("File Name is empty");
 			}
 			
-			if(mFile.getSize() <= 0) {
+			if (mFile.getSize() <= 0) {
 				throw new RuntimeException("File Size is 0");
 			}
 			
@@ -332,12 +332,12 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			// originalFileName에 경로가 포함되어 있는 경우 처리
 			log.debug("File upload OriginalFileName : " + originalFileName);
 			
-			if(originalFileName.indexOf("/") > -1) {
+			if (originalFileName.indexOf("/") > -1) {
 				originalFileName = originalFileName.substring(originalFileName.lastIndexOf("/") + 1);
 				
 				log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
 			}
-			if(originalFileName.indexOf("\\") > -1) {
+			if (originalFileName.indexOf("\\") > -1) {
 				originalFileName = originalFileName.substring(originalFileName.lastIndexOf("\\") + 1);
 				
 				log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
@@ -345,11 +345,11 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			
 			String fileExt = FilenameUtils.getExtension(originalFileName);
 			
-			if(originalFileName.toLowerCase().endsWith(".tgz.gz")) {
+			if (originalFileName.toLowerCase().endsWith(".tgz.gz")) {
 				fileExt = "tgz.gz";
-			} else if(originalFileName.toLowerCase().endsWith(".tar.bz2")) {
+			} else if (originalFileName.toLowerCase().endsWith(".tar.bz2")) {
 				fileExt = "tar.bz2";
-			} else if(originalFileName.toLowerCase().endsWith(".tar.gz")) {
+			} else if (originalFileName.toLowerCase().endsWith(".tar.gz")) {
 				fileExt = "tar.gz";
 			}
 			
@@ -359,7 +359,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			try{
 				/* 파일 저장 경로 설정 hk-cho */
 				// 1) parameter로 filePath가 넘어오지 않았을 경우 Property에 있는 경로에 저장
-				if(StringUtil.isEmpty(filePath)) {
+				if (StringUtil.isEmpty(filePath)) {
 					uploadFilePath = appEnv.getProperty("upload.path", "/upload");
 					uploadThumbFilePath = appEnv.getProperty("image.path", "/image");
 				} else { // 2) parameter로 filePath가 넘어왔을 경우 넘어온 filePath에 저장
@@ -376,7 +376,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			String phyFileNm = originalFileName;						// 서버에 저장될 물리 파일명
 			String thumbPhyFileNm = phyFileNm+"_thumb."+fileExt;		// 서버에 저장될 thumb 물리 파일명
 			
-			if(useRandomPath){
+			if (useRandomPath){
 				UUID randomUUID = UUID.randomUUID();
 				phyFileNm = randomUUID+"."+fileExt;
 				thumbPhyFileNm = randomUUID+"_thumb."+fileExt;
@@ -410,16 +410,16 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 				registFile.setContentType(mFile.getContentType());
 			} catch (Exception e) {}
 			
-			if(mFile.getSize()!=0){ //File Null Check
+			if (mFile.getSize()!=0){ //File Null Check
 				new File(filePath).mkdirs();
 				
-				if(isOrigFile) {
+				if (isOrigFile) {
 					uploadSucc = FileUtil.transferTo(mFile, new File(filePath + "/" + originalFileName));
 				} else {
 					uploadSucc = FileUtil.transferTo(mFile, new File(filePath + "/" + phyFileNm));
 				}
 				
-				if(uploadSucc){
+				if (uploadSucc){
 					try {
 						String regiSeq = registFile(registFile);
 						
@@ -438,7 +438,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			result.add(upFile);
 		}
 		
-		if(sw){
+		if (sw){
 			result = null;
 		}
 		
@@ -455,11 +455,11 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		fileInfo.setExt(FilenameUtils.getExtension(fileName));
 		
 		try {
-			if(fileName.toLowerCase().endsWith(".tgz.gz")) {
+			if (fileName.toLowerCase().endsWith(".tgz.gz")) {
 				fileInfo.setExt("tgz.gz");
-			} else if(fileName.toLowerCase().endsWith(".tar.bz2")) {
+			} else if (fileName.toLowerCase().endsWith(".tar.bz2")) {
 				fileInfo.setExt("tar.bz2");
-			} else if(fileName.toLowerCase().endsWith(".tar.gz")) {
+			} else if (fileName.toLowerCase().endsWith(".tar.gz")) {
 				fileInfo.setExt("tar.gz");
 			}
 		} catch (Exception e) {
@@ -483,11 +483,11 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		fileInfo.setExt(FilenameUtils.getExtension(fileName));
 		
 		try {
-			if(avoidNull(fileName.toLowerCase()).endsWith(".tgz.gz")) {
+			if (avoidNull(fileName.toLowerCase()).endsWith(".tgz.gz")) {
 				fileInfo.setExt("tgz.gz");
-			} else if(avoidNull(fileName.toLowerCase()).endsWith(".tar.bz2")) {
+			} else if (avoidNull(fileName.toLowerCase()).endsWith(".tar.bz2")) {
 				fileInfo.setExt("tar.bz2");
-			} else if(avoidNull(fileName.toLowerCase()).endsWith(".tar.gz")) {
+			} else if (avoidNull(fileName.toLowerCase()).endsWith(".tar.gz")) {
 				fileInfo.setExt("tar.gz");
 			}
 		} catch (Exception e) {
@@ -535,14 +535,14 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		boolean uploadSucc = true;
 		UploadFile upFile = new UploadFile();
 		
-		if(StringUtil.isEmpty(filePath)){
+		if (StringUtil.isEmpty(filePath)){
 			try {
 				uploadFilePath = appEnv.getProperty("packaging.path", "/upload/packaging") + "/" + prjId;
 				uploadThumbFilePath = appEnv.getProperty("packaging.path", "/upload/packaging") + "/" + prjId + "/thumb";
 				
 				File dir = new File(uploadFilePath);
 				
-				if(!dir.exists()){
+				if (!dir.exists()){
 					dir.mkdirs();
 				}
 			} catch(Exception e) {
@@ -563,7 +563,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		// Url의 index 다음 문자열 부터 분리후 저장
 		String originalFileName = avoidNull(url).trim();
 		
-		if(originalFileName.indexOf("/") > -1) {
+		if (originalFileName.indexOf("/") > -1) {
 			originalFileName = originalFileName.substring(originalFileName.lastIndexOf('/') + 1);
 		}
 		
@@ -572,11 +572,11 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		String fileName = originalFileName.substring(0,i);		//input name
 		String fileExt = FilenameUtils.getExtension(originalFileName);
 		
-		if(originalFileName.toLowerCase().endsWith(".tgz.gz")) {
+		if (originalFileName.toLowerCase().endsWith(".tgz.gz")) {
 			fileExt = "tgz.gz";
-		} else if(originalFileName.toLowerCase().endsWith(".tar.bz2")) {
+		} else if (originalFileName.toLowerCase().endsWith(".tar.bz2")) {
 			fileExt = "tar.bz2";
-		} else if(originalFileName.toLowerCase().endsWith(".tar.gz")) {
+		} else if (originalFileName.toLowerCase().endsWith(".tar.gz")) {
 			fileExt = "tar.gz";
 		}
 		
@@ -596,7 +596,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		try {
 			readChannel = Channels.newChannel(new URL(url.replaceAll("\\s", "%20")).openStream());
 			
-			if(isOrigFile) {
+			if (isOrigFile) {
 				fileOS = new FileOutputStream(uploadFilePath+"/"+fileName+"."+fileExt);
 			} else {
 				fileOS = new FileOutputStream(uploadFilePath+"/"+randomUUID+"."+fileExt);
@@ -609,7 +609,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			log.error(e.getMessage());
 			ShellCommanderResult = -1;
 		} finally {
-			if(writeChannel != null) {
+			if (writeChannel != null) {
 				try {
 					writeChannel.close();
 				} catch (Exception e) {
@@ -617,7 +617,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 				}
 			}
 			
-			if(fileOS != null) {
+			if (fileOS != null) {
 				try {
 					fileOS.close();
 				} catch (Exception e) {
@@ -625,7 +625,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 				}
 			}
 			
-			if(readChannel != null) {
+			if (readChannel != null) {
 				try {
 					readChannel.close();
 				} catch (Exception e) {
@@ -634,7 +634,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			}
 		}
 		
-		if(ShellCommanderResult == 0){
+		if (ShellCommanderResult == 0){
 			File getfile = new File(uploadFilePath+"/"+randomUUID+"."+fileExt);
 			long fileSize = getfile.length();
 			
@@ -703,7 +703,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		prjParam.setPackageFileId2(newPackagingFileIdList.get(1));
 		prjParam.setPackageFileId3(newPackagingFileIdList.get(2));
 		
-		for(String fileSeq : fileSeqs){
+		for (String fileSeq : fileSeqs){
 			T2File paramT2File = new T2File();
 			
 			paramT2File.setFileSeq(fileSeq);
@@ -714,28 +714,28 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		String packagingUrl = appEnv.getProperty("packaging.path", "/upload/packaging") + "/" + prjId;
 		List<T2File> result = fileMapper.selectPackagingFileInfo(prjId); // verify한 file을 select함.
 
-		if(result.size() > 0){
-			for(T2File res : result){
+		if (result.size() > 0){
+			for (T2File res : result){
 				String rtnFilePath = res.getLogiPath();
 				String rtnFileName = res.getLogiNm();
 				String rtnFileSeq = res.getFileSeq();
 				
-				if(publicUrl.equals(rtnFilePath)){
+				if (publicUrl.equals(rtnFilePath)){
 					// select한 filePath가 upload Dir 일 경우 해당 파일만 삭제함.
 					file = new File(rtnFilePath + "/" + rtnFileName);
 					
 					for (String fileSeq : fileSeqs) {
-						if(file.exists() && !rtnFileSeq.equals(fileSeq)){
+						if (file.exists() && !rtnFileSeq.equals(fileSeq)){
 							int reuseCnt = fileMapper.getPackgingReuseCnt(rtnFileName);
 								
-							if(reuseCnt == 0){
+							if (reuseCnt == 0){
 								T2File delFile = new T2File();
 								delFile.setFileSeq(rtnFileSeq);
 								delFile.setGubn("A");
 								int returnSuccess = fileMapper.updateFileDelYnKessan(delFile);
 								
-								if(returnSuccess > 0) {
-									if(file.delete()){
+								if (returnSuccess > 0) {
+									if (file.delete()){
 										log.debug(rtnFilePath + "/" + rtnFileName + " is delete success.");
 									} else {
 										log.debug(rtnFilePath + "/" + rtnFileName + " is delete failed.");
@@ -762,21 +762,21 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			
 			int idx = 0;
 			
-			for(String fileId : origPackagingFileIdList){
+			for (String fileId : origPackagingFileIdList){
 				T2File fileInfo = new T2File();
 				
-				if(!isEmpty(fileId) && !fileId.equals(newPackagingFileIdList.get(idx))){
+				if (!isEmpty(fileId) && !fileId.equals(newPackagingFileIdList.get(idx))){
 					//fileInfo.setFileSeq(fileId);
 					fileInfo = fileMapper.selectFileInfo(fileId);
 					deleteComment += "Packaging file, "+fileInfo.getOrigNm()+", was deleted by "+loginUserName()+". <br>";
 				}
 				
-				if(!isEmpty(newPackagingFileIdList.get(idx)) && !newPackagingFileIdList.get(idx).equals(fileId)){
+				if (!isEmpty(newPackagingFileIdList.get(idx)) && !newPackagingFileIdList.get(idx).equals(fileId)){
 					//fileInfo.setFileSeq(newPackagingFileIdList.get(idx));
 					fileInfo = fileMapper.selectFileInfo(newPackagingFileIdList.get(idx));
 					oss.fosslight.domain.File resultFile = verificationMapper.selectVerificationFile(newPackagingFileIdList.get(idx));
 					
-					if(CoConstDef.FLAG_YES.equals(resultFile.getReuseFlag())){
+					if (CoConstDef.FLAG_YES.equals(resultFile.getReuseFlag())){
 						uploadComment += "Packaging file, "+fileInfo.getOrigNm()+", was loaded from Project ID: "+resultFile.getRefPrjId()+" by "+loginUserName()+". <br>";
 					} else {
 						uploadComment += "Packaging file, "+fileInfo.getOrigNm()+", was uploaded by "+loginUserName()+". <br>";
@@ -800,30 +800,30 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		ArrayList<String> LogiNms = new ArrayList<String>();
 		ArrayList<String> reuseNms = new ArrayList<String>();
 		
-		for(T2File uploadFileInfo : uploadFileInfos){
+		for (T2File uploadFileInfo : uploadFileInfos){
 			LogiNms.add(uploadFileInfo.getLogiNm());
 		}
 		
 		// 현재 proejct Packaging File 중 재사용중인 packaging File 이 있다면 제거 불가
 		List<T2File> reusePackaging = fileMapper.getReusePackagingInfo();
 		
-		for(T2File reuse : reusePackaging){
+		for (T2File reuse : reusePackaging){
 			reuseNms.add(reuse.getLogiNm());
 		}
 		
-		if(file.exists()){
-			for(File f : file.listFiles()){
+		if (file.exists()){
+			for (File f : file.listFiles()){
 				String fileNm = f.getName();
 				
-				if(!LogiNms.contains(fileNm)){
+				if (!LogiNms.contains(fileNm)){
 					T2File delFile = new T2File();
 					delFile.setLogiPath(url);
 					delFile.setLogiNm(f.getName());
 					
 					int returnSuccess = fileMapper.updateReuseChkFileDelYnByFilePathNm(delFile);
 					
-					if(returnSuccess > 0 && !reuseNms.contains(fileNm)){
-						if(f.delete()){
+					if (returnSuccess > 0 && !reuseNms.contains(fileNm)){
+						if (f.delete()){
 							log.debug(url + "/" + f.getName() + " is delete success.");
 						}else{
 							log.debug(url + "/" + f.getName() + " is delete failed.");
@@ -836,12 +836,12 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		// 재사용을 했었던 file중 다른 project에서도 재사용을 하지 않은 file 있는지 확인하고 재사용을 안한다면 file 삭제 / 추후 reuse하는 다른 project에서도 reuseFlag가 N이 되면 지우는 case이므로 log는 남기지 않음.
 		List<T2File> reusePackagingFileList = fileMapper.getPackgingReuseCntToList(prjId);
 		
-		for(T2File reusePackagingFile : reusePackagingFileList){ // reuseCnt가 0인 값만 불러오고 삭제처리 후 hidden flag를 Y로 변경 그리고 재검색시 조회 불가상태로 만듦.
+		for (T2File reusePackagingFile : reusePackagingFileList){ // reuseCnt가 0인 값만 불러오고 삭제처리 후 hidden flag를 Y로 변경 그리고 재검색시 조회 불가상태로 만듦.
 			File reuseFile = new File(reusePackagingFile.getLogiPath());
 			
-			if(reuseFile.exists()){
-				for(File f : reuseFile.listFiles()){
-					if(reusePackagingFile.getLogiNm().equals(f.getName())){
+			if (reuseFile.exists()){
+				for (File f : reuseFile.listFiles()){
+					if (reusePackagingFile.getLogiNm().equals(f.getName())){
 						T2File delFile = new T2File();
 						delFile.setLogiPath(reusePackagingFile.getLogiPath());
 						delFile.setLogiNm(f.getName());
@@ -850,8 +850,8 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 						
 						fileMapper.setReusePackagingFileHidden(refPrjId[refPrjId.length-1], reusePackagingFile.getLogiPath(), f.getName());
 						
-						if(returnSuccess > 0){
-							if(f.delete()){
+						if (returnSuccess > 0){
+							if (f.delete()){
 								log.debug(url + "/" + f.getName() + " is delete success.");
 							}else{
 								log.debug(url + "/" + f.getName() + " is delete failed.");
@@ -911,9 +911,9 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		String fileId = "";
 		
 		//구 fileId가 존제 한다면 구 fileId에 넣어준다
-		if(oldFileId==null || "0".equals(oldFileId) || "".equals(oldFileId)){
+		if (oldFileId==null || "0".equals(oldFileId) || "".equals(oldFileId)){
 			fileId = fileMapper.getFileId();
-			if(fileId == null){
+			if (fileId == null){
 				fileId = "1";
 			}
 		} else {
@@ -922,7 +922,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		
 		int indexNum = 0;
 		
-		while(fileNames.hasNext()){
+		while (fileNames.hasNext()){
 			UploadFile upFile = new UploadFile();
 					
 			boolean uploadSucc = true;
@@ -932,11 +932,11 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			
 			MultipartFile mFile = multipartRequest.getFile(fileName);
 			
-			if(isEmpty(mFile.getOriginalFilename())) {
+			if (isEmpty(mFile.getOriginalFilename())) {
 				throw new RuntimeException("File Name is empty");
 			}
 			
-			if(mFile.getSize() <= 0) {
+			if (mFile.getSize() <= 0) {
 				throw new RuntimeException("File Size is 0");
 			}
 			
@@ -945,12 +945,12 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			// originalFileName에 경로가 포함되어 있는 경우 처리
 			log.debug("File upload OriginalFileName : " + originalFileName);
 			
-			if(originalFileName.indexOf("/") > -1) {
+			if (originalFileName.indexOf("/") > -1) {
 				originalFileName = originalFileName.substring(originalFileName.lastIndexOf("/") + 1);
 				
 				log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
 			}
-			if(originalFileName.indexOf("\\") > -1) {
+			if (originalFileName.indexOf("\\") > -1) {
 				originalFileName = originalFileName.substring(originalFileName.lastIndexOf("\\") + 1);
 				
 				log.debug("File upload OriginalFileName Substring with File.separator : " + originalFileName);
@@ -958,11 +958,11 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			
 			String fileExt = FilenameUtils.getExtension(originalFileName);
 			
-			if(originalFileName.toLowerCase().endsWith(".tgz.gz")) {
+			if (originalFileName.toLowerCase().endsWith(".tgz.gz")) {
 				fileExt = "tgz.gz";
-			} else if(originalFileName.toLowerCase().endsWith(".tar.bz2")) {
+			} else if (originalFileName.toLowerCase().endsWith(".tar.bz2")) {
 				fileExt = "tar.bz2";
-			} else if(originalFileName.toLowerCase().endsWith(".tar.gz")) {
+			} else if (originalFileName.toLowerCase().endsWith(".tar.gz")) {
 				fileExt = "tar.gz";
 			}
 			
@@ -1010,13 +1010,13 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			upFile.setRegistSeq(registFile(registFile));
 			upFile.setCreatedDate(CommonFunction.getCurrentDateTime(CoConstDef.DATABASE_FORMAT_DATE_ALL));
 			
-			if(mFile.getSize()!=0){ //File Null Check
-				if(! file.exists()){ //경로상에 파일이 존재하지 않을 경우
+			if (mFile.getSize()!=0){ //File Null Check
+				if (! file.exists()){ //경로상에 파일이 존재하지 않을 경우
 					try {
-						if(file.getParentFile().mkdirs()){ //경로에 해당하는 디렉토리들을 생성
+						if (file.getParentFile().mkdirs()){ //경로에 해당하는 디렉토리들을 생성
 								boolean upSucc = file.createNewFile(); //이후 파일 생성
 								
-								if(!upSucc){
+								if (!upSucc){
 									uploadSucc=false;
 								}
 						} 
@@ -1037,20 +1037,20 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			try {
 				File convertHTMLFile = null;
 				
-				if("XML".equals(fileExt.toUpperCase())) {
+				if ("XML".equals(fileExt.toUpperCase())) {
 					convertHTMLFile = CommonFunction.convertXMLToHTML(file, false);
-				} else if("ZIP".equals(fileExt.toUpperCase())) {
+				} else if ("ZIP".equals(fileExt.toUpperCase())) {
 					FileUtil.decompress(uploadFilePath + "/" + file.getName(), uploadFilePath + "/" + randomUUID);
 					convertHTMLFile = CommonFunction.convertXMLToHTML(new File(uploadFilePath + "/" + randomUUID), true);
-				} else if("TAR.GZ".equals(fileExt.toUpperCase())) {
+				} else if ("TAR.GZ".equals(fileExt.toUpperCase())) {
 					CompressUtil.decompressTarGZ(file, uploadFilePath + "/" + randomUUID);
 					convertHTMLFile = CommonFunction.convertXMLToHTML(new File(uploadFilePath + "/" + randomUUID), true);
 				}
 				
-				if(convertHTMLFile != null) {
+				if (convertHTMLFile != null) {
 					long convertHTMLFileSize = convertHTMLFile.length();
 					
-					if(convertHTMLFileSize > 0){
+					if (convertHTMLFileSize > 0){
 						UploadFile convertNoticeFile = new UploadFile();
 						String convertFileId = fileMapper.getFileId();
 						String convertNoticeFileName = "Notice-"+prjId+"_"+DateUtil.getCurrentDateTime(DateUtil.DATE_PATTERN)+".html";
@@ -1087,7 +1087,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 			}
 		}
 		
-		if(sw){
+		if (sw){
 			result = null;
 		}
 		
@@ -1098,7 +1098,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 	public void deletePhysicalFile(T2File file, String flag) {
 		String filePath = "";
 		
-		if(flag.equals("VERIFY")) {
+		if (flag.equals("VERIFY")) {
 			filePath = file.getLogiPath() + "/" + file.getLogiNm();
 		}else {
 			T2File T2file = fileMapper.getFileInfo2(file);
@@ -1111,7 +1111,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
    	 		to.close();
    	 		
    	 		File LogiFile = new File(filePath);	
-   	 		if(LogiFile.exists()){
+   	 		if (LogiFile.exists()){
    	 			LogiFile.delete();
    	 		}
 		} catch(Exception e) {
@@ -1125,14 +1125,14 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		String newFileId = fileMapper.getFileId();
 		List<T2File> orgFileInfoList = fileMapper.getFileInfoList(fileId);
 		
-		for(T2File orgFile : orgFileInfoList) {
+		for (T2File orgFile : orgFileInfoList) {
 			String baseFile = orgFile.getLogiPath() + "/" + orgFile.getLogiNm();
 			
 			UUID randomUUID = UUID.randomUUID();
 			String copyFileName = randomUUID + "." + orgFile.getExt();
 			String newFile = orgFile.getLogiPath();
 			
-			if(FileUtil.copyFile(baseFile, newFile, copyFileName)) {
+			if (FileUtil.copyFile(baseFile, newFile, copyFileName)) {
 				T2File fileInfo = new T2File();
 				fileInfo.setFileId(newFileId);
 				fileInfo.setFileSeq(orgFile.getFileSeq());
@@ -1144,7 +1144,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 				fileCopyFlag = false;
 			}
 			
-			if(!fileCopyFlag) {
+			if (!fileCopyFlag) {
 				newFileId = null;
 				log.error("physical file copy error");
 				break;

--- a/src/main/java/oss/fosslight/service/impl/HistoryServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/HistoryServiceImpl.java
@@ -66,7 +66,7 @@ public class HistoryServiceImpl extends CoTopComponent implements HistoryService
 		int cnt = 1;
 		String cdNm = beData != null ? beData.gethType() : null;
 
-		for(String[] dtlCd : CoCodeManager.getValues(cdNm)){
+		for (String[] dtlCd : CoCodeManager.getValues(cdNm)){
 			Map<String, Object> dataMap = new HashMap<String, Object>();
 
 			// EXP : TYPE(String, Code, Array, Object) | NAME | CD_NO
@@ -78,7 +78,7 @@ public class HistoryServiceImpl extends CoTopComponent implements HistoryService
 			Object beD_ = getDataForType(cdNm, dtlCd, beMap);
 
 			// main data
-			if(asD_.getClass().equals(String.class) && beD_.getClass().equals(String.class)){
+			if (asD_.getClass().equals(String.class) && beD_.getClass().equals(String.class)){
 				dataMap.put("as", asD_);
 				dataMap.put("be", beD_);
 			} else { // sub list data
@@ -114,21 +114,21 @@ public class HistoryServiceImpl extends CoTopComponent implements HistoryService
 		// EXP : TYPE(String, Code, Array, Object) | NAME | CD_NO
 		String[] inf = CoCodeManager.getCodeExpString(cdNm, dtlCd[0]).split("\\|");
 
-		if(inf[0].equals("String")) {
+		if (inf[0].equals("String")) {
 			ret = dMap != null ? escapeSql(nvl((String)dMap.get(dtlCd[1]), "")) : "";
-		} else if(inf[0].equals("Code")) {
-			if((dtlCd[1]).equals("obligation")){
+		} else if (inf[0].equals("Code")) {
+			if ((dtlCd[1]).equals("obligation")){
 				ret = dMap != null ? (String)dMap.get("obligationType"): "";
 			}else{
 				ret = dMap != null ?nvl(CoCodeManager.getCodeString(inf[2], (String)dMap.get(dtlCd[1])), inf[2]) : "";
 			}
-		} else if(inf[0].equals("Array") && "999".equals(dtlCd[2])) {
+		} else if (inf[0].equals("Array") && "999".equals(dtlCd[2])) {
 			List<String> asArr = dMap != null ? (ArrayList<String>)dMap.get(dtlCd[1]) : null;
 			ret = asArr != null && asArr.size() > 0 ? String.join("<br>", asArr) : "";
-		} else if(inf[0].equals("Array") && dtlCd[2] == null) {
+		} else if (inf[0].equals("Array") && dtlCd[2] == null) {
 			List<String> asArr = dMap != null ? (ArrayList<String>)dMap.get(dtlCd[1]) : null;
 			ret = asArr != null && asArr.size() > 0 ? String.join(", ", asArr) : "";
-		} else if(inf[0].equals("Array") && dtlCd[2] != null) {
+		} else if (inf[0].equals("Array") && dtlCd[2] != null) {
 			String sCdNm = dtlCd[2]; // CD_SUB_NO(Ref Entity)
 			HashMap<String, Object> sTblMap = new HashMap<String, Object>();
 
@@ -142,7 +142,7 @@ public class HistoryServiceImpl extends CoTopComponent implements HistoryService
 			colInfo.put("order", "0");
 			colNames.add(colInfo);
 
-			for(String[] v : CoCodeManager.getAllValues(sCdNm)){
+			for (String[] v : CoCodeManager.getAllValues(sCdNm)){
 				colInfo =  new HashMap<String, Object>();
 				colInfo.put("key", v[2]);
 				colInfo.put("name", v[4].split("\\|")[1]);
@@ -157,21 +157,21 @@ public class HistoryServiceImpl extends CoTopComponent implements HistoryService
 			// colModel 생성
 			List<Map<String, Object>> subList = new ArrayList<Map<String, Object>>();
 
-			if(dMap != null && dMap.get(dtlCd[1]) != null){
+			if (dMap != null && dMap.get(dtlCd[1]) != null){
 				// sub list 생성
 				int sCnt = 1;
 
-				for(Map<String, Object> sMap : (List<Map<String, Object>>) dMap.get(dtlCd[1])){
+				for (Map<String, Object> sMap : (List<Map<String, Object>>) dMap.get(dtlCd[1])){
 					Map<String, Object> sDataMap = new HashMap<String, Object>();
 					sDataMap.put("no", sCnt++);
 
 					// row data 생성
-					for(String[] sDtlCd : CoCodeManager.getValues(sCdNm)){
+					for (String[] sDtlCd : CoCodeManager.getValues(sCdNm)){
 						String[] sInf = CoCodeManager.getCodeExpString(sCdNm, sDtlCd[0]).split("\\|");	// EXP : TYPE(String, Code, Array, Object) | NAME | CD_NO
 
-						if(sInf[0].equals("String")){
+						if (sInf[0].equals("String")){
 							sDataMap.put(sDtlCd[1], escapeSql(nvl((String)sMap.get(sDtlCd[1]))) );
-						}else if(sInf[0].equals("Code")){
+						}else if (sInf[0].equals("Code")){
 							sDataMap.put(sDtlCd[1], CoCodeManager.getCodeString(sInf[1], (String)sMap.get(sDtlCd[1])) );
 						}
 					}

--- a/src/main/java/oss/fosslight/service/impl/LicenseServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/LicenseServiceImpl.java
@@ -81,7 +81,7 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 	public Map<String,Object> getLicenseMasterList(LicenseMaster licenseMaster) {
 		
 		// obligation type 검색 조건 추가
-		if(!isEmpty(licenseMaster.getObligationType())) {
+		if (!isEmpty(licenseMaster.getObligationType())) {
 			switch (licenseMaster.getObligationType()) {
 				case CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK:
 					licenseMaster.setObligationNeedsCheckYn(CoConstDef.FLAG_YES);
@@ -103,10 +103,10 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 			}
 		}
 
-		if(licenseMaster.getRestrictions() != null) {
+		if (licenseMaster.getRestrictions() != null) {
 			String restrictions = licenseMaster.getRestrictions();
 						
-			if(!isEmpty(restrictions)){
+			if (!isEmpty(restrictions)){
 				String[] arrRestrictions = restrictions.split(",");
 				
 				licenseMaster.setArrRestriction(arrRestrictions);
@@ -119,8 +119,8 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		
 		List<LicenseMaster> list = licenseMapper.selectLicenseList(licenseMaster);
 		
-		for(LicenseMaster item : list){
-			if(!isEmpty(item.getRestriction())){
+		for (LicenseMaster item : list){
+			if (!isEmpty(item.getRestriction())){
 				item.setRestriction(CommonFunction.setLicenseRestrictionList(item.getRestriction()));
 			}
 		}
@@ -139,20 +139,20 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		List<LicenseMaster> licenseNicknameList = licenseMapper.selectLicenseNicknameList(licenseMaster);
 		List<String> nickNames = new ArrayList<>();
 		
-		for(LicenseMaster bean : licenseNicknameList) {
+		for (LicenseMaster bean : licenseNicknameList) {
 			nickNames.add(bean.getLicenseNickname());
 		}
 		
 		List<LicenseMaster> licenseWebPageList = licenseMapper.selectLicenseWebPageList(licenseMaster);
 		List<String> webPage = new ArrayList<>();
-		for(LicenseMaster bean : licenseWebPageList) {
+		for (LicenseMaster bean : licenseWebPageList) {
 			webPage.add(bean.getWebpage());
 		}
 
 		// 일반 user 화면 일 경우 restriction을 full name으로 화면 출력
 		// admin 화면 일 경우 restriction code를 사용하여 체크박스로 구성
-		if(!"ROLE_ADMIN".equals(loginUserRole())) {
-			if(licenseMaster.getRestriction() != null) {
+		if (!"ROLE_ADMIN".equals(loginUserRole())) {
+			if (licenseMaster.getRestriction() != null) {
 				T2CodeDtl t2CodeDtl = new T2CodeDtl();
 				List<T2CodeDtl> t2CodeDtlList = new ArrayList<>(); 
 				t2CodeDtl.setCdNo(CoConstDef.CD_LICENSE_RESTRICTION);
@@ -164,8 +164,8 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 				List<String> restrictionList = Arrays.asList(licenseMaster.getRestriction().split(","));
 				String restrictionStr = "";
 				
-				for(T2CodeDtl item: t2CodeDtlList){
-					if(restrictionList.contains(item.getCdDtlNo())) {
+				for (T2CodeDtl item: t2CodeDtlList){
+					if (restrictionList.contains(item.getCdDtlNo())) {
 						restrictionStr += (!isEmpty(restrictionStr) ? ", " : "") + item.getCdDtlNm();
 					}
 				}
@@ -189,7 +189,7 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 	public LicenseMaster checkExistsLicense(LicenseMaster param) {
 		LicenseMaster bean = licenseMapper.checkExistsLicense(param);
 		
-		if(bean != null && !isEmpty(bean.getLicenseId())) {
+		if (bean != null && !isEmpty(bean.getLicenseId())) {
 			return bean;
 		}
 		
@@ -200,9 +200,9 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 	public List<LicenseMaster> getLicenseMasterListExcel(LicenseMaster license) {
 		List<LicenseMaster> result = licenseMapper.selectLicenseList(license);
 		
-		if(result != null) {
-			for(LicenseMaster bean : result) {
-				if(CoCodeManager.LICENSE_INFO_BY_ID.containsKey(bean.getLicenseId())) {
+		if (result != null) {
+			for (LicenseMaster bean : result) {
+				if (CoCodeManager.LICENSE_INFO_BY_ID.containsKey(bean.getLicenseId())) {
 					LicenseMaster master = CoCodeManager.LICENSE_INFO_BY_ID.get(bean.getLicenseId());
 					
 					bean.setLicenseNicknameList(master.getLicenseNicknameList());
@@ -225,11 +225,11 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 	
 	@Override
 	public void deleteDistributeLicense(LicenseMaster bean, boolean distributionFlag) {
-		if(bean != null && !isEmpty(bean.getLicenseName())) {
+		if (bean != null && !isEmpty(bean.getLicenseName())) {
 			String fileName = bean.getShortIdentifier();
 			String result = null;
 			
-			if(isEmpty(fileName)) {
+			if (isEmpty(fileName)) {
 				fileName = bean.getLicenseName();
 			}
 			
@@ -238,7 +238,7 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 			log.info("OSDD license update result : " + avoidNull(result));
 		}
 		
-		if(avoidNull(bean.getRestriction()).contains(CoConstDef.CD_LICENSE_NETWORK_RESTRICTION)){
+		if (avoidNull(bean.getRestriction()).contains(CoConstDef.CD_LICENSE_NETWORK_RESTRICTION)){
 			registNetworkServerLicense(bean.getLicenseId(), "DEL");
 		}
 	}
@@ -253,13 +253,13 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 				
 				break;
 			case "INS":
-				if(isEmpty(CD_DTL_NO)){
+				if (isEmpty(CD_DTL_NO)){
 					licenseMapper.insertNetworkServerLicense(licenseId);
 				}
 				
 				break;
 			case "DEL":
-				if(!isEmpty(CD_DTL_NO)){
+				if (!isEmpty(CD_DTL_NO)){
 					licenseMapper.deleteNetworkServerLicense(licenseId);
 				}
 				
@@ -279,8 +279,8 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		List<String> ossList = licenseMapper.getOssListWithLicenseForTypeCheck(licenseId);
 		
 		// 최종적으로 라이선스 타입이 변경된 oss 목록 산출
-		if(ossList != null) {
-			for(String ossId : ossList) {
+		if (ossList != null) {
+			for (String ossId : ossList) {
 				OssMaster ossBean = ossService.getOssInfo(ossId, false);
 				
 				String orgOssLicenseType = ossBean.getLicenseType();
@@ -289,7 +289,7 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 				// license type 변경 여부 체크
 				ossService.checkOssLicenseAndObligation(ossBean);
 				
-				if(!orgOssLicenseType.equals(ossBean.getLicenseType())) {
+				if (!orgOssLicenseType.equals(ossBean.getLicenseType())) {
 					// oss의 license type과 obligation을 변경한다.
 					ossService.updateLicenseTypeAndObligation(ossBean);
 					
@@ -310,7 +310,7 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		String[] licenseNicknames = licenseMaster.getLicenseNicknames();
 		String licenseId = licenseMaster.getLicenseId();
 		
-		if(StringUtil.isEmpty(licenseId)){
+		if (StringUtil.isEmpty(licenseId)){
 			licenseMaster.setCreator(licenseMaster.getLoginUserName());
 		}
 		
@@ -318,7 +318,7 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		// trim 처리
 		licenseMaster.setLicenseName(licenseMaster.getLicenseName().trim());
 		
-		if(StringUtil.isEmpty(licenseId)){
+		if (StringUtil.isEmpty(licenseId)){
 			licenseMapper.insertLicenseMaster(licenseMaster);
 		} else {
 			licenseMapper.updateLicenseMaster(licenseMaster);
@@ -332,9 +332,9 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		 */
 		licenseMapper.deleteLicenseNickname(licenseMaster);
 		
-		if(licenseNicknames != null){
-			for(String nickName : licenseNicknames){
-				if(!isEmpty(nickName)) {
+		if (licenseNicknames != null){
+			for (String nickName : licenseNicknames){
+				if (!isEmpty(nickName)) {
 					licenseMaster.setLicenseNickname(nickName.trim());
 					licenseMapper.insertLicenseNickname(licenseMaster);
 				}
@@ -342,7 +342,7 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		}
 		
 		//코멘트 등록
-		if(!isEmpty(licenseMaster.getComment())) {
+		if (!isEmpty(licenseMaster.getComment())) {
 			CommentsHistory param = new CommentsHistory();
 			param.setReferenceId(licenseMaster.getLicenseId());
 			param.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_LICENSE);
@@ -362,14 +362,14 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		boolean SuccessType = false;
 		LicenseMaster licenseBean = CoCodeManager.LICENSE_INFO_BY_ID.get(licenseId);
 		
-		if(licenseBean == null) {
+		if (licenseBean == null) {
 			log.error("LICENSE INFO IS NULL, LICENSE ID = " + avoidNull(licenseId));
 		} else {
 			String contents = makeLicenseInfoHtml(licenseBean);
 			String fileName = !isEmpty(licenseBean.getShortIdentifier()) ? licenseBean.getShortIdentifier() : licenseBean.getLicenseNameTemp();
 			fileName = fileName.replaceAll(" ", "_").replaceAll("/", "_") + ".html";
 			
-			if(!isEmpty(contents)) {
+			if (!isEmpty(contents)) {
 				String filePath = CommonFunction.appendProperty("root.dir", "internal.url.dir.path");
 				FileUtil.writeFile(filePath, fileName, contents);
 				
@@ -387,11 +387,11 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		Map<String, Object> model = new HashMap<>();
 		model.put("licenseName", bean.getLicenseNameTemp());
 		
-		if(!isEmpty(bean.getShortIdentifier())) {
+		if (!isEmpty(bean.getShortIdentifier())) {
 			model.put("shortIdentifier", bean.getShortIdentifier());
 		}
 		
-		if(!isEmpty(bean.getWebpage())) {
+		if (!isEmpty(bean.getWebpage())) {
 			model.put("webPage", bean.getWebpage());
 		}
 		
@@ -406,13 +406,13 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 	public List<LicenseMaster> getLicenseNameList() {
 		List<LicenseMaster> list = licenseMapper.selectLicenseNameList();
 		
-		if(list != null) {
-			for(LicenseMaster bean : list) {
-				if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNeedsCheckYn()))) {
+		if (list != null) {
+			for (LicenseMaster bean : list) {
+				if (CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNeedsCheckYn()))) {
 					bean.setObligationCode(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK);
-				} else if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationDisclosingSrcYn()))) {
+				} else if (CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationDisclosingSrcYn()))) {
 					bean.setObligationCode(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
-				} else if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNotificationYn()))) {
+				} else if (CoConstDef.FLAG_YES.equals(avoidNull(bean.getObligationNotificationYn()))) {
 					bean.setObligationCode(CoConstDef.CD_DTL_OBLIGATION_NOTICE);
 				}
 			}
@@ -428,55 +428,55 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 		// 관련자들 모두 취득
 		List<Project> prjList = licenseMapper.getLicenseChangeForUserList(licenseId);
 		
-		if(prjList != null) {
+		if (prjList != null) {
 			// 수신자 대상 추출 (프로젝트 정보를 함께 넘긴다)
 			Map<String, Map<String, Project>> sendInfoMap = new HashMap<>();
 			
-			for(Project bean : prjList) {
+			for (Project bean : prjList) {
 				Map<String, Project> _info = null;
 				
-				if(!isEmpty(bean.getCreator())) {
+				if (!isEmpty(bean.getCreator())) {
 					_info = sendInfoMap.get(bean.getCreator());
 					
-					if(_info == null) {
+					if (_info == null) {
 						_info = new HashMap<>();
 					}
 					
-					if(!_info.containsKey(bean.getPrjId())) {
+					if (!_info.containsKey(bean.getPrjId())) {
 						_info.put(bean.getPrjId(), bean);
-						if(sendInfoMap.containsKey(bean.getCreator())) {
+						if (sendInfoMap.containsKey(bean.getCreator())) {
 							sendInfoMap.replace(bean.getCreator(), _info);
 						} else {
 							sendInfoMap.put(bean.getCreator(), _info);
 						}
 					}
 				} 
-				if(!isEmpty(bean.getReviewer())) {
+				if (!isEmpty(bean.getReviewer())) {
 					_info = sendInfoMap.get(bean.getReviewer());
 					
-					if(_info == null) {
+					if (_info == null) {
 						_info = new HashMap<>();
 					}
 					
-					if(!_info.containsKey(bean.getPrjId())) {
+					if (!_info.containsKey(bean.getPrjId())) {
 						_info.put(bean.getPrjId(), bean);
-						if(sendInfoMap.containsKey(bean.getReviewer())) {
+						if (sendInfoMap.containsKey(bean.getReviewer())) {
 							sendInfoMap.replace(bean.getReviewer(), _info);
 						} else {
 							sendInfoMap.put(bean.getReviewer(), _info);
 						}
 					}
 				} 
-				if(!isEmpty(bean.getPrjUserId())) {
+				if (!isEmpty(bean.getPrjUserId())) {
 					_info = sendInfoMap.get(bean.getPrjUserId());
 					
-					if(_info == null) {
+					if (_info == null) {
 						_info = new HashMap<>();
 					}
 					
-					if(!_info.containsKey(bean.getPrjId())) {
+					if (!_info.containsKey(bean.getPrjId())) {
 						_info.put(bean.getPrjId(), bean);
-						if(sendInfoMap.containsKey(bean.getPrjUserId())) {
+						if (sendInfoMap.containsKey(bean.getPrjUserId())) {
 							sendInfoMap.replace(bean.getPrjUserId(), _info);
 						} else {
 							sendInfoMap.put(bean.getPrjUserId(), _info);
@@ -486,13 +486,13 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 			}
 			
 			// sendInfoMap 건수 (사람수) 만큼 발송
-			for(String userId : sendInfoMap.keySet()) {
+			for (String userId : sendInfoMap.keySet()) {
 				CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_LICENSE_UPDATE_TYPE);
 				mailBean.setToIds(new String[]{userId});
 				List<Project> tempList = new ArrayList<>();
 				Map<String, Project> prjInfo = sendInfoMap.get(userId);
 				
-				for(String prjId : prjInfo.keySet()) {
+				for (String prjId : prjInfo.keySet()) {
 					tempList.add(prjInfo.get(prjId));
 				}
 				
@@ -508,7 +508,7 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 
 	@Override
 	public void registLicenseWebPage(LicenseMaster licenseMaster) {
-		if(licenseMapper.existsLicenseWebPages(licenseMaster) > 0){
+		if (licenseMapper.existsLicenseWebPages(licenseMaster) > 0){
 			licenseMapper.deleteLicenseWebPages(licenseMaster);
 		}
 
@@ -516,9 +516,9 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 
 		String[] webPages = licenseMaster.getWebpages();
 
-		if(webPages != null){
-			for(String url : webPages){
-				if(!isEmpty(url)){ // 공백의 downloadLocation은 save하지 않음.
+		if (webPages != null){
+			for (String url : webPages){
+				if (!isEmpty(url)){ // 공백의 downloadLocation은 save하지 않음.
 					LicenseMaster master = new LicenseMaster();
 					master.setLicenseId(licenseMaster.getLicenseId());
 					master.setWebpage(url);
@@ -533,7 +533,7 @@ public class LicenseServiceImpl extends CoTopComponent implements LicenseService
 	@Override
 	public String webPageStringFormat(String[] webpagesList) {
 		String webpages = "";
-		for(String webpage : webpagesList) {
+		for (String webpage : webpagesList) {
 			webpages += webpage+",";
 		}
 		if (!("").equals(webpages)) {

--- a/src/main/java/oss/fosslight/service/impl/MailServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/MailServiceImpl.java
@@ -55,11 +55,11 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 		
 		receiverInfo.setToIds(selectMailAddrFromIds(receiverId));					// 수신인 메일 주소
 		
-		if(ccIds != null && ccIds.length != 0) {
+		if (ccIds != null && ccIds.length != 0) {
 			selectMailAddrFromIds(ccIds);		// 참조 메일 주소
 		}
 		
-		if(bccIds != null && bccIds.length != 0) {
+		if (bccIds != null && bccIds.length != 0) {
 			selectMailAddrFromIds(bccIds);		// 숨은참조 메일 주소
 		}
 		
@@ -81,7 +81,7 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 //		Map<String, Object> mailData = new HashMap<String, Object>();
 //		
 //		// 수정의 경우 비교데이터
-//		if("UPDATE".equals(mailInfo.gethAction())){
+//		if ("UPDATE".equals(mailInfo.gethAction())){
 //			mailData = getAsToBeHistoryData(mailInfo);
 //		} else {
 //			mailData = toMailData(mailInfo);
@@ -116,12 +116,12 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
         // Result : Vector [ String CD_DTL_NO, String CD_DTL_NM(Key), String CD_SUB_NO(Ref Entity) ] 
 		String cdNm = afterData != null ? afterData.gethType() : null; 
 		
-		for(String[] dtlCd : CoCodeManager.getValues(cdNm)){
+		for (String[] dtlCd : CoCodeManager.getValues(cdNm)){
 			Object beforeD_ = getDataForType(cdNm, dtlCd, beforeMap);
 			Object afterD_ = getDataForType(cdNm, dtlCd, afterMap);
 			
 			// main data
-			if(beforeD_ instanceof String && afterD_ instanceof String) {
+			if (beforeD_ instanceof String && afterD_ instanceof String) {
 				log.debug("String value : " + dtlCd[1]);
 				String bStr = beforeD_.toString();
 				String aStr = afterD_.toString();
@@ -149,7 +149,7 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 		dataMap.put("bModifiedDate", beforeData != null ? beforeData.getModifiedDate() : "");
 		dataMap.put("aModifiedDate", afterData != null ? afterData.getModifiedDate() : "");
 		
-		if(!StringUtil.isEmpty(beforeData != null ? beforeData.getModifier() : "")) {
+		if (!StringUtil.isEmpty(beforeData != null ? beforeData.getModifier() : "")) {
 			T2Users param = new T2Users();
 			param.setUserId(beforeData.getModifier());
 			T2Users modifier = userService.getUser(param);
@@ -158,7 +158,7 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 			dataMap.put("bModifierMail", modifier.getEmail());
 		}
 		
-		if(!StringUtil.isEmpty(beforeData != null ? afterData.getModifier() : "")) {
+		if (!StringUtil.isEmpty(beforeData != null ? afterData.getModifier() : "")) {
 			T2Users param = new T2Users();
 			param.setUserId(afterData.getModifier());
 			T2Users modifier = userService.getUser(param);
@@ -191,7 +191,7 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 			Object d = getDataForType(cdNm, dtlCd, hMap);
 			
 			// main data
-			if(d instanceof String) { // d의 Type이 String일 경우
+			if (d instanceof String) { // d의 Type이 String일 경우
 				mTbl.put(dtlCd[1], !StringUtil.isEmpty(d.toString()) ? d : "");
 			} else { // sub list obj
 				mTbl.put(dtlCd[1], "");
@@ -210,7 +210,7 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 		dataMap.put("modifier", history != null ? history.getModifier() : "");
 		dataMap.put("modifiedDate", history != null ? history.getModifiedDate() : "");
 		
-		if(!StringUtil.isEmpty(history != null ? history.getModifier() : "")) {
+		if (!StringUtil.isEmpty(history != null ? history.getModifier() : "")) {
 			T2Users param = new T2Users();
 			param.setUserId(history.getModifier());
 			T2Users modifier = userService.getUser(param);
@@ -230,14 +230,14 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 		// EXP : TYPE(String, Code, Array, Object) | NAME | CD_NO
 		String[] inf = CoCodeManager.getCodeExpString(cdNm, dtlCd[0]).split("\\|");
 		
-		if(inf[0].equals("String")) {
+		if (inf[0].equals("String")) {
 			ret = dMap != null ? escapeSql(nvl((String)dMap.get(dtlCd[1]), "")) : "";
-		} else if(inf[0].equals("Code")) {
+		} else if (inf[0].equals("Code")) {
 			ret = dMap != null ? nvl(CoCodeManager.getCodeString(inf[2], (String)dMap.get(dtlCd[1])), inf[2]) : "";
-		} else if(inf[0].equals("Array") && dtlCd[2] == null) {
+		} else if (inf[0].equals("Array") && dtlCd[2] == null) {
 			List<String> asArr = dMap != null ? (ArrayList<String>)dMap.get(dtlCd[1]) : null;
 			ret = asArr != null && asArr.size() > 0 ? String.join(", ", asArr) : "";
-		} else if(inf[0].equals("Array") && dtlCd[2] != null) {
+		} else if (inf[0].equals("Array") && dtlCd[2] != null) {
 			String sCdNm = dtlCd[2]; // CD_SUB_NO(Ref Entity) 
 			HashMap<String, Object> sTblMap = new HashMap<String, Object>();
 			// colNames 생성
@@ -251,7 +251,7 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 			colInfo.put("order", "0");
 			colNames.add(colInfo);
 			
-			for(String[] v : CoCodeManager.getAllValues(sCdNm)){
+			for (String[] v : CoCodeManager.getAllValues(sCdNm)){
 				 colInfo =  new HashMap<String, Object>();
 				 colInfo.put("key", v[2]);
 				 colInfo.put("name", v[4].split("\\|")[1]);
@@ -266,21 +266,21 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 			// colModel 생성
 			List<Map<String, Object>> subList = new ArrayList<Map<String, Object>>();
 			
-			if(dMap != null && dMap.get(dtlCd[1]) != null){
+			if (dMap != null && dMap.get(dtlCd[1]) != null){
 				// sub list 생성
 				int sCnt = 1;
 				
-				for(Map<String, Object> sMap : (List<Map<String, Object>>) dMap.get(dtlCd[1])){
+				for (Map<String, Object> sMap : (List<Map<String, Object>>) dMap.get(dtlCd[1])){
 					Map<String, Object> sDataMap = new HashMap<String, Object>();
 					sDataMap.put("no", sCnt++);
 					
 					// row data 생성
-					for(String[] sDtlCd : CoCodeManager.getValues(sCdNm)){
+					for (String[] sDtlCd : CoCodeManager.getValues(sCdNm)){
 						String[] sInf = CoCodeManager.getCodeExpString(sCdNm, sDtlCd[0]).split("\\|");	// EXP : TYPE(String, Code, Array, Object) | NAME | CD_NO
 						
-						if(sInf[0].equals("String")) {
+						if (sInf[0].equals("String")) {
 							sDataMap.put(sDtlCd[1], escapeSql(nvl((String)sMap.get(sDtlCd[1]))) );
-						} else if(sInf[0].equals("Code")) {
+						} else if (sInf[0].equals("Code")) {
 							sDataMap.put(sDtlCd[1], CoCodeManager.getCodeString(sInf[1], (String)sMap.get(sDtlCd[1])) );
 						}	
 					}
@@ -332,7 +332,7 @@ public class MailServiceImpl extends CoTopComponent implements MailService {
 	public void sendTempMail() {
 		List<Map<String, Object>> tempMailList = mailManagerMapper.getTempMail();
 		
-		for(Map<String, Object> mailMap : tempMailList) {
+		for (Map<String, Object> mailMap : tempMailList) {
 			String mailType = (String) mailMap.get("mailType");
 			String mailSeq = (String) mailMap.get("mailSeq");
 			CoMail mailBean = new CoMail(mailType);

--- a/src/main/java/oss/fosslight/service/impl/NoticeServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/NoticeServiceImpl.java
@@ -31,15 +31,15 @@ public class NoticeServiceImpl extends CoTopComponent implements NoticeService {
 		Map<String, Object> map = null;
 		int records = noticeMapper.selectNoticeTotalCount(vo);
 		
-		if(records > 0) {
+		if (records > 0) {
 			vo.setTotListSize(records);
 			// Grid paging 처리를 위한 기본 param 설정 Map 생성(반드시 totlistsize를 set 하고 나서 생성해야함)
 			map = getGridPagerMap(vo);
 			List<Notice> noticeList =  noticeMapper.selectNoticeList(vo);
 			
 	        // 테그 치환
-	        if(noticeList != null) {
-				for(Notice item : noticeList) {
+	        if (noticeList != null) {
+				for (Notice item : noticeList) {
 					item.setReplaceNotice(item.getNotice().replaceAll("<br>", "\n\r"));
 					item.setReplaceNotice(item.getNotice().replaceAll("<(/)?([a-zA-Z]*)(\\\\s[a-zA-Z]*=[^>]*)?(\\\\s)*(/)?>", ""));
 				}
@@ -53,9 +53,9 @@ public class NoticeServiceImpl extends CoTopComponent implements NoticeService {
 	
 	@Override
 	public void setNotice(Notice vo) throws Exception {
-		if(CoConstDef.GRID_OPERATION_ADD.equals(vo.getOper())) { // 추가
+		if (CoConstDef.GRID_OPERATION_ADD.equals(vo.getOper())) { // 추가
 			noticeMapper.insertNotice(vo);
-		} else if(CoConstDef.GRID_OPERATION_EDIT.equals(vo.getOper())) { // 수정
+		} else if (CoConstDef.GRID_OPERATION_EDIT.equals(vo.getOper())) { // 수정
 			noticeMapper.updateNotice(vo);
 		} else { // 삭제
 			noticeMapper.deleteNotice(vo);
@@ -68,12 +68,12 @@ public class NoticeServiceImpl extends CoTopComponent implements NoticeService {
 		
 		int records = noticeMapper.selectPublishedNoticeCount(vo);
 		
-		if(records > 0) {
+		if (records > 0) {
 			List<Notice> noticeList = noticeMapper.selectPublishedNotice(vo);
 			
 			map = getGridPagerMap(vo);
 	
-	        if(noticeList != null) {
+	        if (noticeList != null) {
 				map.put("noticeList", noticeList);
 	        }
 		}

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -99,19 +99,19 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	@Override
 	public Map<String,Object> getOssMasterList(OssMaster ossMaster) {
 		// 기간 검색 조건
-		if(!isEmpty(ossMaster.getcEndDate())) {
+		if (!isEmpty(ossMaster.getcEndDate())) {
 			ossMaster.setcEndDate(DateUtil.addDaysYYYYMMDD(ossMaster.getcEndDate(), 1));
 		}
 		
-		if(!isEmpty(ossMaster.getmEndDate())) {
+		if (!isEmpty(ossMaster.getmEndDate())) {
 			ossMaster.setmEndDate(DateUtil.addDaysYYYYMMDD(ossMaster.getmEndDate(), 1));
 		}
 		
-		if(isEmpty(ossMaster.getOssNameAllSearchFlag())) {
+		if (isEmpty(ossMaster.getOssNameAllSearchFlag())) {
 			ossMaster.setOssNameAllSearchFlag(CoConstDef.FLAG_NO);
 		}
 		
-		if(isEmpty(ossMaster.getLicenseNameAllSearchFlag())) {
+		if (isEmpty(ossMaster.getLicenseNameAllSearchFlag())) {
 			ossMaster.setLicenseNameAllSearchFlag(CoConstDef.FLAG_NO);
 		}
 		
@@ -126,8 +126,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		String orgOssName = ossMaster.getOssName();
 		List<String> multiOssList = ossMapper.selectMultiOssList(ossMaster);
 		
-		for(OssMaster oss : list){
-			if(multiOssList.contains(oss.getOssName())) {
+		for (OssMaster oss : list){
+			if (multiOssList.contains(oss.getOssName())) {
 				ossMaster.setOssId(oss.getOssId());
 				ossMaster.setOssName(oss.getOssName());
 				List<OssMaster> subList = ossMapper.selectOssSubList(ossMaster);
@@ -141,26 +141,26 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		ossMaster.setOssName(orgOssName);
 		
 		// license name 처리
-		if(newList != null && !newList.isEmpty()) {
+		if (newList != null && !newList.isEmpty()) {
 			OssMaster param = new OssMaster();
 			
-			for(OssMaster bean : newList) {
+			for (OssMaster bean : newList) {
 				param.addOssIdList(bean.getOssId());
 			}
 
 			List<OssLicense> licenseList = ossMapper.selectOssLicenseList(param);
 			
-			for(OssLicense licenseBean : licenseList) {
-				for(OssMaster bean : newList) {
-					if(licenseBean.getOssId().equals(bean.getOssId())) {
+			for (OssLicense licenseBean : licenseList) {
+				for (OssMaster bean : newList) {
+					if (licenseBean.getOssId().equals(bean.getOssId())) {
 						bean.addOssLicense(licenseBean);
 						break;
 					}
 				}
 			}
 
-			for(OssMaster bean : newList) {
-				if(bean.getOssLicenses() != null && !bean.getOssLicenses().isEmpty()) {
+			for (OssMaster bean : newList) {
+				if (bean.getOssLicenses() != null && !bean.getOssLicenses().isEmpty()) {
 					bean.setLicenseName(CommonFunction.makeLicenseExpression(bean.getOssLicenses()));
 				}
 				
@@ -168,10 +168,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				bean.setGroupKey(bean.getOssName().toUpperCase());
 				
 				// NICK NAME ICON 표시
-				if(CoConstDef.FLAG_YES.equals(ossMaster.getSearchFlag())) {
+				if (CoConstDef.FLAG_YES.equals(ossMaster.getSearchFlag())) {
 					bean.setOssName(StringUtil.replaceHtmlEscape(bean.getOssName()));
 					
-					if(!isEmpty(bean.getOssNickname())) {
+					if (!isEmpty(bean.getOssNickname())) {
 						bean.setOssName("<span class='iconSet nick'>Nick</span>&nbsp;" + bean.getOssName());
 					} else {
 						bean.setOssName("<span class='iconSet nick dummy'></span>&nbsp;" + bean.getOssName());
@@ -198,14 +198,14 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public String[] getOssNickNameListByOssName(String ossName) {
 		List<String> nickList = new ArrayList<>();
 		
-		if(!isEmpty(ossName)) {
+		if (!isEmpty(ossName)) {
 			OssMaster param = new OssMaster();
 			param.setOssName(ossName);
 			List<OssMaster> list =  ossMapper.selectOssNicknameList(param);
 			
-			if(list != null) {
-				for(OssMaster bean : list) {
-					if(!isEmpty(bean.getOssNickname()) && !nickList.contains(bean.getOssNickname())) {
+			if (list != null) {
+				for (OssMaster bean : list) {
+					if (!isEmpty(bean.getOssNickname()) && !nickList.contains(bean.getOssNickname())) {
 						nickList.add(bean.getOssNickname());
 					}
 				}
@@ -220,9 +220,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		HashMap<String, Object> map = new HashMap<String, Object>();
 		List<OssLicense> list = ossMapper.selectOssLicenseList(ossMaster);
 
-		if(!CommonFunction.isAdmin() && list != null) {
-			for(OssLicense license : list) {
-				if(!isEmpty(license.getOssCopyright())) {
+		if (!CommonFunction.isAdmin() && list != null) {
+			for (OssLicense license : list) {
+				if (!isEmpty(license.getOssCopyright())) {
 					license.setOssCopyright(CommonFunction.lineReplaceToBR( StringUtil.replaceHtmlEscape( license.getOssCopyright() )));
 				}
 			}
@@ -252,7 +252,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		StringBuilder sb = new StringBuilder();
 		
-		for(OssMaster ossNickname : ossNicknameList){
+		for (OssMaster ossNickname : ossNicknameList){
 			sb.append(ossNickname.getOssNickname()).append(",");
 		}
 		
@@ -260,8 +260,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		sb = new StringBuilder(); // 초기화
 		
-		if(ossDownloadLocation != null && !ossDownloadLocation.isEmpty()) {
-			for(OssMaster location : ossDownloadLocation) {
+		if (ossDownloadLocation != null && !ossDownloadLocation.isEmpty()) {
+			for (OssMaster location : ossDownloadLocation) {
 				sb.append(location.getDownloadLocation()).append(",");
 			}
 		}else {
@@ -272,7 +272,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		sb = new StringBuilder(); // 초기화
 		
-		for(OssMaster licenseInfo : ossDetectedLicense) {
+		for (OssMaster licenseInfo : ossDetectedLicense) {
 			sb.append(licenseInfo.getLicenseName()).append(",");
 		}
 		
@@ -314,26 +314,26 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		OssMaster param = new OssMaster();
 		Map<String, OssMaster> map = new HashMap<String, OssMaster>();
 		
-		if(!isEmpty(ossId)) {
+		if (!isEmpty(ossId)) {
 			param.addOssIdList(ossId);
 			map = isMailFormat ? getBasicOssInfoListByIdOnTime(param) : getBasicOssInfoListById(param);
 		}
 		
-		if(!isEmpty(ossName)) {
+		if (!isEmpty(ossName)) {
 			param.setOssName(ossName);
 			map = getNewestOssInfoOnTime(param);
 		}
 		
-		if(map != null) {
+		if (map != null) {
 			// nickname 정보 취득 
-			for(OssMaster bean : map.values()) {
+			for (OssMaster bean : map.values()) {
 				param.setOssName(bean.getOssName());
 				List<OssMaster> nickNameList = ossMapper.selectOssNicknameList(param);
-				if(nickNameList != null && !nickNameList.isEmpty()) {
+				if (nickNameList != null && !nickNameList.isEmpty()) {
 					List<String> nickNames = new ArrayList<>();
 					
-					for(OssMaster nickNameBean : nickNameList) {
-						if(!isEmpty(nickNameBean.getOssNickname())) {
+					for (OssMaster nickNameBean : nickNameList) {
+						if (!isEmpty(nickNameBean.getOssNickname())) {
 							nickNames.add(nickNameBean.getOssNickname());
 						}
 					}
@@ -342,10 +342,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				}
 				
 				List<OssMaster> detectedLicenseList = ossMapper.selectOssDetectedLicenseList(bean);
-				if(detectedLicenseList.size() > 0) {
+				if (detectedLicenseList.size() > 0) {
 					String detectedLicense = "";
-					for(OssMaster ossBean : detectedLicenseList) {
-						if(!isEmpty(detectedLicense)) {
+					for (OssMaster ossBean : detectedLicenseList) {
+						if (!isEmpty(detectedLicense)) {
 							detectedLicense += ", ";
 						}
 						
@@ -360,7 +360,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				if (ossDownloadLocation.size() > 0) {
 					StringBuilder sb = new StringBuilder();
 					
-					for(OssMaster location : ossDownloadLocation) {
+					for (OssMaster location : ossDownloadLocation) {
 						sb.append(location.getDownloadLocation()).append(",");
 					}
 					
@@ -368,39 +368,39 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					bean.setDownloadLocations(ossDownloadLocations);
 				}
 				
-				if(isMailFormat) {
+				if (isMailFormat) {
 					bean.setLicenseName(CommonFunction.makeLicenseExpression(bean.getOssLicenses()));
 					bean.setOssLicenses(CommonFunction.changeLicenseNameToShort(bean.getOssLicenses()));
 					
 					// code 변경
-					if(!isEmpty(bean.getLicenseDiv())) {
+					if (!isEmpty(bean.getLicenseDiv())) {
 						// multi license 표시 여부 판단을 위해서 코드표시명 변환 이전의 값이 필요함
 						bean.setMultiLicenseFlag(bean.getLicenseDiv());
 						bean.setLicenseDiv(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_DIV, bean.getLicenseDiv()));
 					}
 					
-					if(!isEmpty(bean.getLicenseType())) {
+					if (!isEmpty(bean.getLicenseType())) {
 						bean.setLicenseType(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_TYPE, bean.getLicenseType()));
 					}
 					
-					if(!isEmpty(bean.getObligationType())) {
+					if (!isEmpty(bean.getObligationType())) {
 						bean.setObligation(CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, bean.getObligationType()));
 					}
 					
 					// 날짜 형식
-					if(!isEmpty(bean.getModifiedDate())) {
+					if (!isEmpty(bean.getModifiedDate())) {
 						bean.setModifiedDate(DateUtil.dateFormatConvert(bean.getModifiedDate(), DateUtil.TIMESTAMP_PATTERN, DateUtil.DATE_PATTERN_DASH));
 					}
 					
-					if(!isEmpty(bean.getModifier())) {
+					if (!isEmpty(bean.getModifier())) {
 						bean.setModifier(CoMailManager.getInstance().makeUserNameFormat(bean.getModifier()));
 					}
 					
-					if(!isEmpty(bean.getCreatedDate())) {
+					if (!isEmpty(bean.getCreatedDate())) {
 						bean.setCreatedDate(DateUtil.dateFormatConvert(bean.getCreatedDate(), DateUtil.TIMESTAMP_PATTERN, DateUtil.DATE_PATTERN_DASH));
 					}
 					
-					if(!isEmpty(bean.getCreator())) {
+					if (!isEmpty(bean.getCreator())) {
 						bean.setCreator(CoMailManager.getInstance().makeUserNameFormat(bean.getCreator()));
 					}
 
@@ -425,15 +425,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	private Map<String, OssMaster> makeBasicOssInfoMap(List<OssMaster> list, boolean useId, boolean useUpperKey) {
 		Map<String, OssMaster> map = new HashMap<>();
 		
-		for(OssMaster bean : list) {
+		for (OssMaster bean : list) {
 			OssMaster targetBean = null;
 			String key = useId ? bean.getOssId() : bean.getOssName() +"_"+ avoidNull(bean.getOssVersion());
 			
-			if(useUpperKey) {
+			if (useUpperKey) {
 				key = key.toUpperCase();
 			}
 			
-			if(map.containsKey(key)) {
+			if (map.containsKey(key)) {
 				targetBean = map.get(key);
 			} else {
 				targetBean = bean;
@@ -454,7 +454,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			
 			targetBean.addOssLicense(subBean);
 			
-			if(map.containsKey(key)) {
+			if (map.containsKey(key)) {
 				map.replace(key, targetBean);
 			} else {
 				map.put(key, targetBean);
@@ -499,10 +499,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<Map<String, OssMaster>> mailBeanList = new ArrayList<>();
 		
 		// 메일 발송을 위한 data 취득( 메일 형식을 위해 다시 DB Select )
-		for(OssMaster bean : rowList) {
-			if(!isEmpty(bean.getMergeStr())) {
+		for (OssMaster bean : rowList) {
+			if (!isEmpty(bean.getMergeStr())) {
 				// 실제로 삭제처리는 중복되는 OSS Version만
-				if("Duplicated".equalsIgnoreCase(bean.getMergeStr())) {
+				if ("Duplicated".equalsIgnoreCase(bean.getMergeStr())) {
 					// mail 발송을 위해 삭제전 data 취득
 					Map<String, OssMaster> mailDiffMap = new HashMap<>();
 					OssMaster ossMailInfo1 = getOssInfo(bean.getDelOssId(), true);
@@ -510,10 +510,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					
 					List<String> ossNickNameList = new ArrayList<String>();
 
-					if(tempBean1.getOssNicknames() != null) {
+					if (tempBean1.getOssNicknames() != null) {
 						tempBean1.setOssNickname(CommonFunction.arrayToString(tempBean1.getOssNicknames(), "<br>"));
 
-						for(String nickName : Arrays.asList(tempBean1.getOssNicknames())) {
+						for (String nickName : Arrays.asList(tempBean1.getOssNicknames())) {
 							ossNickNameList.add(nickName);
 						}
 					}
@@ -524,7 +524,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					OssMaster ossMailInfo2 = getOssInfo(bean.getOssId(), true);
 					OssMaster tempBean2 = (OssMaster) BeanUtils.cloneBean(ossMailInfo2);
 					
-					if(tempBean2.getOssNicknames() != null) {
+					if (tempBean2.getOssNicknames() != null) {
 						for (String nickName : Arrays.asList(tempBean2.getOssNicknames())){
 							ossNickNameList.add(nickName);
 						}
@@ -544,7 +544,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					OssMaster ossMailInfo1 = getOssInfo(bean.getOssId(), true);
 					OssMaster tempBean1 = (OssMaster) BeanUtils.cloneBean(ossMailInfo1);
 					
-					if(tempBean1.getOssNicknames() != null) {
+					if (tempBean1.getOssNicknames() != null) {
 						tempBean1.setOssNickname(CommonFunction.arrayToString(tempBean1.getOssNicknames(), "<br>"));
 					}
 					
@@ -556,13 +556,13 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 					OssMaster ossMailInfo2 = getOssInfo(ossMaster.getNewOssId(), true);
 					OssMaster beforeBean1 = (OssMaster) BeanUtils.cloneBean(ossMailInfo2);
-					if(beforeBean1.getOssNicknames() != null) {
-						for(String nickName : Arrays.asList(beforeBean1.getOssNicknames())) {
+					if (beforeBean1.getOssNicknames() != null) {
+						for (String nickName : Arrays.asList(beforeBean1.getOssNicknames())) {
 							ossNickNameList.add(nickName);
 						}
 					}
 
-					if(tempBean2.getOssNicknames() != null) {
+					if (tempBean2.getOssNicknames() != null) {
 						for (String nickName : Arrays.asList(tempBean2.getOssNicknames())){
 							ossNickNameList.add(nickName);
 						}
@@ -580,15 +580,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		}
 
 		// 삭제 처리
-		for(OssMaster bean : rowList) {
-			if(!isEmpty(bean.getMergeStr())) {
+		for (OssMaster bean : rowList) {
+			if (!isEmpty(bean.getMergeStr())) {
 				boolean isDel = false;
 				
 				OssMaster mergeBean = new OssMaster();
 				History h = null;
 				
 				// 신규 version의 등록이 필요한 경우
-				if("Added".equalsIgnoreCase(bean.getMergeStr())) {
+				if ("Added".equalsIgnoreCase(bean.getMergeStr())) {
 					CommentsHistory historyBean = new CommentsHistory();
 					historyBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_OSS);
 					historyBean.setReferenceId(bean.getOssId());
@@ -631,7 +631,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				}
 				
 				//1. 기존 OssId를 사용중인 프로젝트의 OssId , Version 를 새로운 OssId로 교체				
-				if(isDel && h != null) {
+				if (isDel && h != null) {
 					try{
 						h.sethAction(CoConstDef.ACTION_CODE_DELETE);
 						historyService.storeData(h);
@@ -662,8 +662,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		nickMergeParam.setOssNickname(beforOssName);
 		ossMapper.mergeOssNickname2(nickMergeParam);
 		
-		if(beforeBean.getOssNicknames() != null) {
-			for(String nickName : beforeBean.getOssNicknames()) {
+		if (beforeBean.getOssNicknames() != null) {
+			for (String nickName : beforeBean.getOssNicknames()) {
 				nickMergeParam.setOssNickname(nickName);
 				
 				ossMapper.mergeOssNickname2(nickMergeParam);
@@ -672,13 +672,13 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		CoCodeManager.getInstance().refreshOssInfo();
 
-		for(Map<String, OssMaster> mailInfoMap : mailBeanList) {
+		for (Map<String, OssMaster> mailInfoMap : mailBeanList) {
 			// 삭제대상 OSS를 사용중인 프로젝트의 목록을 코멘트로 남긴다.
 			try {
 				String templateComemnt = makeTemplateComment(ossMaster.getComment(), mailInfoMap.get("before"), mailInfoMap.get("after"));
 				
 				// 사용중인 프로젝트가 없는 경우는 코멘트를 추가작으로 남기지 않는다.
-				if(!isEmpty(templateComemnt)) {
+				if (!isEmpty(templateComemnt)) {
 					CommentsHistory historyBean = new CommentsHistory();
 					historyBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_OSS);
 					historyBean.setReferenceId(mailInfoMap.get("after").getOssId());
@@ -768,8 +768,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		// 메일 발송시 사용사는 쿼리와 동일
 		List<Project> prjList = ossMapper.getOssChangeForUserList(ossMasterBefore);
 		
-		if(prjList != null && !prjList.isEmpty()) {
-			for(Project prjBean : prjList) {
+		if (prjList != null && !prjList.isEmpty()) {
+			for (Project prjBean : prjList) {
 				prjBean.setDistributionType(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, prjBean.getDistributionType()));
 				prjBean.setCreator(makeUserNameFormatWithDivision(prjBean.getCreator()));
 				prjBean.setCreatedDate(CommonFunction.formatDateSimple(prjBean.getCreatedDate()));
@@ -796,11 +796,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		T2Users userInfo = userMapper.getUser(userParam);
 		
-		if(userInfo != null && !isEmpty(userInfo.getUserName())) {
-			if(!isEmpty(userInfo.getDivision())) {
+		if (userInfo != null && !isEmpty(userInfo.getUserName())) {
+			if (!isEmpty(userInfo.getDivision())) {
 				String _division = CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, userInfo.getDivision());
 				
-				if(!isEmpty(_division)) {
+				if (!isEmpty(_division)) {
 					rtnVal += _division + " ";
 				}
 			}
@@ -817,7 +817,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		param.setUserId(userId);
 		T2Users userInfo = userMapper.getUser(param);
 		
-		if(userInfo != null) {
+		if (userInfo != null) {
 			rtn = avoidNull(userInfo.getUserName());
 			rtn += "(" + avoidNull(userInfo.getUserId()) + ")";
 		}
@@ -828,9 +828,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	private String makeOssNameFormat(OssMaster bean) {
 		String rtnVal = "";
 		
-		if(bean != null) {
+		if (bean != null) {
 			rtnVal = avoidNull(bean.getOssName());
-			if(!isEmpty(bean.getOssVersion())) {
+			if (!isEmpty(bean.getOssVersion())) {
 				rtnVal += " (" + bean.getOssVersion() + ")";
 			}
 		}
@@ -843,21 +843,21 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<String> rtnList = new ArrayList<>();
 		List<String> currntList = null;
 		
-		if(ossNicknames != null && ossNicknames.length > 0) {
+		if (ossNicknames != null && ossNicknames.length > 0) {
 			currntList = Arrays.asList(ossNicknames);
 		}
 		
-		if(currntList == null) {
+		if (currntList == null) {
 			currntList = new ArrayList<>();
 		}
 		
-		if(!isEmpty(ossName)) {
+		if (!isEmpty(ossName)) {
 			// oss name으로 등록된 nick name이 있는지 확인
 			List<String> _nickNames = ossMapper.checkNickNameRegOss(ossName);
 			
-			if(_nickNames != null && !_nickNames.isEmpty()) {
-				for(String s : _nickNames) {
-					if(!isEmpty(s) && !currntList.contains(s)) {
+			if (_nickNames != null && !_nickNames.isEmpty()) {
+				for (String s : _nickNames) {
+					if (!isEmpty(s) && !currntList.contains(s)) {
 						rtnList.add(s);
 					}
 				}
@@ -874,11 +874,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		boolean projectFlag = CommonFunction.propertyFlagCheck("menu.project.use.flag", CoConstDef.FLAG_YES);
         boolean partnerFlag = CommonFunction.propertyFlagCheck("menu.partner.use.flag", CoConstDef.FLAG_YES);
         
-		if(projectFlag) {
+		if (projectFlag) {
 			resultCnt += ossMapper.checkExistOssConfProject(CoCodeManager.OSS_INFO_BY_ID.get(ossId));
 		}
 		
-		if(partnerFlag) {
+		if (partnerFlag) {
 			resultCnt += ossMapper.checkExistOssConfPartner(CoCodeManager.OSS_INFO_BY_ID.get(ossId));
 		}
 		
@@ -896,7 +896,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			boolean isNew = StringUtil.isEmpty(ossId);
 			OssMaster orgMasterInfo = null;
 
-			if(StringUtil.isEmpty(ossId)){
+			if (StringUtil.isEmpty(ossId)){
 				ossMaster.setCreator(ossMaster.getLoginUserName());
 			} else {
 				orgMasterInfo = new OssMaster();
@@ -908,21 +908,21 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			boolean vulnRecheck = false;
 			
 			// 변경전 oss name에 해당하는 oss_id 목록을 찾는다.
-			if(!isNew) {
+			if (!isNew) {
 				OssMaster _orgBean = getOssInfo(ossId, false);
 				
-				if(_orgBean != null && !isEmpty(_orgBean.getOssName())) {
-					if(!avoidNull(ossMaster.getOssName()).trim().equalsIgnoreCase(_orgBean.getOssName()) 
+				if (_orgBean != null && !isEmpty(_orgBean.getOssName())) {
+					if (!avoidNull(ossMaster.getOssName()).trim().equalsIgnoreCase(_orgBean.getOssName()) 
 							|| !avoidNull(ossMaster.getOssVersion()).trim().equalsIgnoreCase(avoidNull(_orgBean.getOssVersion()).trim())) {
 						vulnRecheck = true;
 					}
-					if(!avoidNull(ossMaster.getOssName()).trim().equalsIgnoreCase(_orgBean.getOssName())) {
+					if (!avoidNull(ossMaster.getOssName()).trim().equalsIgnoreCase(_orgBean.getOssName())) {
 						// 변경 전 oss name 에 등록된 nickname 삭제
 						_orgBean.setOssId(null);
 						List<OssMaster> beforeOssNameList = ossMapper.getOssListByName(_orgBean);
-						if(beforeOssNameList != null) {
+						if (beforeOssNameList != null) {
 							int ossIdCnt = beforeOssNameList.stream().map(e -> e.getOssId()).distinct().collect(Collectors.toList()).size();
-							if(ossIdCnt == 1) {
+							if (ossIdCnt == 1) {
 								ossMapper.deleteOssNickname(_orgBean);
 							}
 						}
@@ -931,7 +931,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 			}
 			
-			if(vulnRecheck) {
+			if (vulnRecheck) {
 				ossMaster.setVulnRecheck(CoConstDef.FLAG_YES);
 			}
 			
@@ -950,7 +950,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			int ossLicenseDeclaredIdx = 0;
 			String licenseId = ""; 
 			
-			for(OssLicense license : list) {
+			for (OssLicense license : list) {
 				ossLicenseDeclaredIdx++;
 				licenseId = CommonFunction.getLicenseIdByName(license.getLicenseName());
 				
@@ -971,14 +971,14 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			// Detected License Insert / 20210806_Distinct Add
 			List<String> detectedLicenses = ossMaster.getDetectedLicenses().stream().distinct().collect(Collectors.toList());
 			
-			if(detectedLicenses != null) {
+			if (detectedLicenses != null) {
 				int ossLicenseDetectedIdx = 0;
 				
-				for(String detectedLicense : detectedLicenses) {			
-					if(!isEmpty(detectedLicense)) {
+				for (String detectedLicense : detectedLicenses) {			
+					if (!isEmpty(detectedLicense)) {
 						LicenseMaster detectedLicenseInfo = CoCodeManager.LICENSE_INFO_UPPER.get(detectedLicense.toUpperCase().trim());
 						
-						if(detectedLicenseInfo != null) {
+						if (detectedLicenseInfo != null) {
 							OssMaster om = new OssMaster(
 									  ossMaster.getOssId() // ossId
 									, detectedLicenseInfo.getLicenseId() // licenseId
@@ -991,11 +991,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				}
 			}
 			
-			if(ossMaster.getOssLicenses() != null) {
-				for(OssLicense license : ossMaster.getOssLicenses()) {
+			if (ossMaster.getOssLicenses() != null) {
+				for (OssLicense license : ossMaster.getOssLicenses()) {
 					// v-Diff check를 위해 만약 license id가 param Bean에 없는 경우, license id를 등록한다.
-					if(isEmpty(license.getLicenseId())) {
-						if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(license.getLicenseName().toUpperCase())) {
+					if (isEmpty(license.getLicenseId())) {
+						if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(license.getLicenseName().toUpperCase())) {
 							license.setLicenseId(CoCodeManager.LICENSE_INFO_UPPER.get(license.getLicenseName().toUpperCase()).getLicenseId());
 						}
 					}
@@ -1006,15 +1006,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			 * 1. 라이센스 닉네임 삭제 
 			 * 2. 라이센스 닉네임 재등록
 			 */
-			if(CoConstDef.FLAG_YES.equals(ossMaster.getAddNicknameYn())) { //nickname을 clear&insert 하지 않고, 중복제거를 한 나머지 nickname에 대해서는 add함.
-				if(ossNicknames != null){
+			if (CoConstDef.FLAG_YES.equals(ossMaster.getAddNicknameYn())) { //nickname을 clear&insert 하지 않고, 중복제거를 한 나머지 nickname에 대해서는 add함.
+				if (ossNicknames != null){
 					List<OssMaster> ossNicknameList = ossMapper.selectOssNicknameList(ossMaster);
 					
-					for(String nickName : ossNicknames){
-						if(!isEmpty(nickName)) {
+					for (String nickName : ossNicknames){
+						if (!isEmpty(nickName)) {
 							int duplicateCnt = ossNicknameList.stream().filter(o -> nickName.toUpperCase().equals(o.getOssNickname().toUpperCase())).collect(Collectors.toList()).size();
 							
-							if(duplicateCnt == 0) {
+							if (duplicateCnt == 0) {
 								OssMaster ossBean = new OssMaster();
 								ossBean.setOssName(ossMaster.getOssName());
 								ossBean.setOssNickname(nickName.trim());
@@ -1025,11 +1025,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					}
 				}
 			} else { // nickname => clear&insert
-				if(ossNicknames != null) {
+				if (ossNicknames != null) {
 					ossMapper.deleteOssNickname(ossMaster);
 					
-					for(String nickName : ossNicknames){
-						if(!isEmpty(nickName)) {
+					for (String nickName : ossNicknames){
+						if (!isEmpty(nickName)) {
 							ossMaster.setOssNickname(nickName.trim());
 							ossMapper.insertOssNickname(ossMaster);
 						}
@@ -1040,7 +1040,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			}
 			
 			//코멘트 등록
-			if(!isEmpty(avoidNull(ossMaster.getComment()).trim())) {
+			if (!isEmpty(avoidNull(ossMaster.getComment()).trim())) {
 				CommentsHistory param = new CommentsHistory();
 				param.setReferenceId(ossMaster.getOssId());
 				param.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_OSS);
@@ -1049,17 +1049,17 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				commentService.registComment(param);
 			}
 			
-			if(isNew || vulnRecheck) {
+			if (isNew || vulnRecheck) {
 				List<String> ossNameArr = new ArrayList<>();
 				ossNameArr.add(ossMaster.getOssName().trim());
 				
-				if(ossMaster.getOssName().contains(" ")) {
+				if (ossMaster.getOssName().contains(" ")) {
 					ossNameArr.add(ossMaster.getOssName().replaceAll(" ", "_"));
 				}
 				
-				if(ossNicknames != null) {
-					for(String s : ossNicknames) {
-						if(!isEmpty(s)) {
+				if (ossNicknames != null) {
+					for (String s : ossNicknames) {
+						if (!isEmpty(s)) {
 							ossNameArr.add(s.trim());
 						}
 					}
@@ -1069,23 +1069,23 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				nvdParam.setOssNames(ossNameArr.toArray(new String[ossNameArr.size()]));
 				OssMaster nvdData = null;
 				
-				if(!isEmpty(ossMaster.getOssVersion())) {
+				if (!isEmpty(ossMaster.getOssVersion())) {
 					nvdParam.setOssVersion(ossMaster.getOssVersion());
 					nvdData = ossMapper.getNvdDataByOssName(nvdParam);
 				} else {
 					nvdData = ossMapper.getNvdDataByOssNameWithoutVer(nvdParam);
 				}
 				
-				if(nvdData != null) {
+				if (nvdData != null) {
 					ossMaster.setCvssScore(nvdData.getCvssScore());
 					ossMaster.setCveId(nvdData.getCveId());
 					ossMaster.setVulnDate(nvdData.getVulnDate());
 					ossMaster.setVulnYn(CoConstDef.FLAG_YES);
 					
 					ossMapper.updateNvdData(ossMaster);
-				} else if(!isNew) {
+				} else if (!isNew) {
 					OssMaster _orgBean = getOssInfo(ossId, false);
-					if(_orgBean != null && (CoConstDef.FLAG_YES.equals(_orgBean.getVulnYn()) || !isEmpty(_orgBean.getCvssScore()))) {
+					if (_orgBean != null && (CoConstDef.FLAG_YES.equals(_orgBean.getVulnYn()) || !isEmpty(_orgBean.getCvssScore()))) {
 						ossMaster.setVulnYn(CoConstDef.FLAG_NO);
 						
 						ossMapper.updateNvdData(ossMaster);
@@ -1100,7 +1100,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			registOssDownloadLocation(ossMaster);
 			
 			// Deactivate Flag Setting
-			if(isEmpty(ossMaster.getDeactivateFlag())) {
+			if (isEmpty(ossMaster.getDeactivateFlag())) {
 				ossMaster.setDeactivateFlag(CoConstDef.FLAG_NO);
 			}
 
@@ -1130,7 +1130,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 	@Override
 	public void registOssDownloadLocation(OssMaster ossMaster) {
-		if(ossMapper.existsOssDownloadLocation(ossMaster) > 0){
+		if (ossMapper.existsOssDownloadLocation(ossMaster) > 0){
 			ossMapper.deleteOssDownloadLocation(ossMaster);
 		}
 		
@@ -1138,9 +1138,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		String[] downloadLocations = ossMaster.getDownloadLocations();
 		
-		if(downloadLocations != null){
-			for(String url : downloadLocations){
-				if(!isEmpty(url)){ // 공백의 downloadLocation은 save하지 않음.
+		if (downloadLocations != null){
+			for (String url : downloadLocations){
+				if (!isEmpty(url)){ // 공백의 downloadLocation은 save하지 않음.
 					OssMaster master = new OssMaster();
 					master.setOssId(ossMaster.getOssId());
 					master.setDownloadLocation(url);
@@ -1161,7 +1161,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		Map<String, OssMaster> mergeMap = new HashMap<>();
 		
 		// 이관 대상 OSS 정보를 먼저 격납한다.
-		for(OssMaster bean : list2) {
+		for (OssMaster bean : list2) {
 			bean.setLicenseName(CommonFunction.makeLicenseExpression(CoCodeManager.OSS_INFO_BY_ID.get(bean.getOssId()).getOssLicenses()));
 			bean.setLicenseType(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_TYPE, bean.getLicenseType()));
 			bean.setObligation(CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, bean.getObligationType()));
@@ -1169,7 +1169,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		}
 		
 		// 삭제 대상 OSS Version이 이관 대상 OSS 에 존재하는지 확인 
-		for(OssMaster bean : list1) {
+		for (OssMaster bean : list1) {
 			bean.setLicenseName(CommonFunction.makeLicenseExpression(CoCodeManager.OSS_INFO_BY_ID.get(bean.getOssId()).getOssLicenses()));
 			bean.setLicenseType(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_TYPE, bean.getLicenseType()));
 			bean.setObligation(CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, bean.getObligationType()));
@@ -1177,7 +1177,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			String verKey = avoidNull(bean.getOssVersion(), "N/A").toUpperCase();
 			
 			// 이미 존재한다면
-			if(mergeMap.containsKey(verKey)) {
+			if (mergeMap.containsKey(verKey)) {
 				mergeMap.get(verKey).setMergeStr("Duplicated");
 				mergeMap.get(verKey).setDelOssId(bean.getOssId());
 			} else {
@@ -1204,18 +1204,18 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		try {
 			OssMaster beforeBean = getOssInfo(ossMaster.getOssId(), false);
 			
-			if(isEmpty(ossMaster.getOssName())) {
+			if (isEmpty(ossMaster.getOssName())) {
 				ossMaster.setOssName(beforeBean.getOssName());
 			}
 			
 			// 바로 삭제 일 경우( identification 상태가 conf인 프로젝트가 없을시 )
-			if(CoConstDef.FLAG_NO.equals(avoidNull(ossMaster.getNewOssId(), CoConstDef.FLAG_NO))) {
+			if (CoConstDef.FLAG_NO.equals(avoidNull(ossMaster.getNewOssId(), CoConstDef.FLAG_NO))) {
 				//3. 기존의 Oss 삭제		
 				//ossMapper.deleteOssNickname(ossMaster);
 				
 				// 닉네임은 이름으로 매핑되기 때문에, 삭제후에 신규 추가시 자동으로 설정되는 문제가 있음
 				// 삭제하는 oss 이름으로 공유하는 닉네임이 더이상 없을 경우, 닉네임도 삭제하도록 추가
-				if(ossMapper.checkHasAnotherVersion(ossMaster) == 0) {
+				if (ossMapper.checkHasAnotherVersion(ossMaster) == 0) {
 					ossMapper.deleteOssNickname(ossMaster);
 				}
 				
@@ -1229,7 +1229,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				// 동일한 oss에서 이동하는 경우, nick name을 별도로 등록하지 않음
 				OssMaster afterBean = getOssInfo(ossMaster.getNewOssId(), false);
 				
-				if(!beforeBean.getOssName().toUpperCase().equals(afterBean.getOssName().toUpperCase())) {
+				if (!beforeBean.getOssName().toUpperCase().equals(afterBean.getOssName().toUpperCase())) {
 					//2. 기존 Oss 의 Name 과 Nickname을 현재 선택한 Oss의 Nickname 에 병합
 					ArrayList<String> nickNamesArray = new ArrayList<>();
 					Map<String, Object> map = ossMapper.selectOssNameMap(ossMaster);
@@ -1238,17 +1238,17 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					
 					nickNamesArray.add(ossName);
 					
-					for(Map<String, String> nickMap : list){
+					for (Map<String, String> nickMap : list){
 						nickNamesArray.addAll(new ArrayList<String>(nickMap.values()));
 					}
 					
-					for(String nickname : nickNamesArray){
+					for (String nickname : nickNamesArray){
 						ossMaster.setOssNickname(nickname);
 						ossMapper.mergeOssNickname(ossMaster);
 					}
 				}
 				
-				if(ossMapper.checkHasAnotherVersion(ossMaster) == 0) {
+				if (ossMapper.checkHasAnotherVersion(ossMaster) == 0) {
 					ossMapper.deleteOssNickname(ossMaster);
 				}
 				
@@ -1270,7 +1270,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public OssMaster checkExistsOss(OssMaster param) {
 		OssMaster bean = ossMapper.checkExistsOss(param);
 		
-		if(bean != null && !isEmpty(bean.getOssId())) {
+		if (bean != null && !isEmpty(bean.getOssId())) {
 			return bean;
 		}
 		
@@ -1281,20 +1281,20 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public OssMaster checkExistsOssNickname(OssMaster param) {
 		OssMaster bean1 = ossMapper.checkExistsOssname(param);
 		
-		if(bean1 != null && !isEmpty(bean1.getOssId())) {
+		if (bean1 != null && !isEmpty(bean1.getOssId())) {
 			return bean1;
 		}
 		
 		OssMaster bean2 = ossMapper.checkExistsOssNickname(param);
 		
-		if(bean2 != null && !isEmpty(bean2.getOssId())) {
+		if (bean2 != null && !isEmpty(bean2.getOssId())) {
 			return bean2;
 		}
 		
-		if(!isEmpty(param.getOssId())) {
+		if (!isEmpty(param.getOssId())) {
 			OssMaster bean3 = ossMapper.checkExistsOssNickname2(param);
 			
-			if(bean3 != null) {
+			if (bean3 != null) {
 				return bean3;
 			}
 			
@@ -1307,7 +1307,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public OssMaster checkExistsOssNickname2(OssMaster param) {
 		OssMaster bean2 = ossMapper.checkExistsOssNickname(param);
 		
-		if(bean2 != null && !isEmpty(bean2.getOssId())) {
+		if (bean2 != null && !isEmpty(bean2.getOssId())) {
 			return bean2;
 		}
 		
@@ -1318,9 +1318,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public Map<String, OssMaster> getBasicOssInfoListById(OssMaster ossMaster) {
 		Map<String, OssMaster> resultMap = new HashMap<>();
 		
-		if(CoCodeManager.OSS_INFO_BY_ID != null && ossMaster.getOssIdList() != null && !ossMaster.getOssIdList().isEmpty()) {
-			for(String ossId : ossMaster.getOssIdList()) {
-				if(CoCodeManager.OSS_INFO_BY_ID.containsKey(ossId)) {
+		if (CoCodeManager.OSS_INFO_BY_ID != null && ossMaster.getOssIdList() != null && !ossMaster.getOssIdList().isEmpty()) {
+			for (String ossId : ossMaster.getOssIdList()) {
+				if (CoCodeManager.OSS_INFO_BY_ID.containsKey(ossId)) {
 					resultMap.put(ossId, CoCodeManager.OSS_INFO_BY_ID.get(ossId));
 				}
 			}
@@ -1333,7 +1333,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public List<OssMaster> getOssListByName(OssMaster bean) {
 		List<OssMaster> list = ossMapper.getOssListByName(bean);
 		
-		if(list == null) {
+		if (list == null) {
 			list = new ArrayList<>();
 		}
 		
@@ -1341,20 +1341,20 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<OssMaster> newList = new ArrayList<>();
 		Map<String, OssMaster> remakeMap = new HashMap<>();
 		OssMaster currentBean = null;
-		for(OssMaster ossBean : list) {
+		for (OssMaster ossBean : list) {
 			// name + version
-			if(!isEmpty(ossBean.getOssVersion())) {
+			if (!isEmpty(ossBean.getOssVersion())) {
 				ossBean.setOssNameVerStr(ossBean.getOssName() + " (" + ossBean.getOssVersion() + ")");
 			} else {
 				ossBean.setOssNameVerStr(ossBean.getOssName());
 			}
 			
-			if(remakeMap.containsKey(ossBean.getOssId())) {
+			if (remakeMap.containsKey(ossBean.getOssId())) {
 				currentBean = remakeMap.get(ossBean.getOssId());
 			} else {
 				currentBean = ossBean;
 				
-				if(!isEmpty(currentBean.getOssNickname())) {
+				if (!isEmpty(currentBean.getOssNickname())) {
 					currentBean.setOssNickname(currentBean.getOssNickname().replaceAll("\\|", "<br>"));
 				}
 				
@@ -1366,15 +1366,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				String resultDectedLicense = "";
 				String resultLicenseText = "";
 				
-				if(!isEmpty(detectedLicense)) {
-					for(String dl : detectedLicenseList) {
+				if (!isEmpty(detectedLicense)) {
+					for (String dl : detectedLicenseList) {
 						LicenseMaster licenseMaster = null;
 						
-						if(CoCodeManager.LICENSE_INFO.containsKey(dl)) {
+						if (CoCodeManager.LICENSE_INFO.containsKey(dl)) {
 							licenseMaster = CoCodeManager.LICENSE_INFO.get(dl);
 						}
 						
-						if(licenseMaster != null) {
+						if (licenseMaster != null) {
 							resultDectedLicense += "<a href='javascript:void(0);' class='urlLink'  onclick='showLicenseText(" + avoidNull(licenseMaster.getLicenseId()) + ");' >" + dl + "</a>";
 							resultLicenseText += "<div id='license_"+ avoidNull(licenseMaster.getLicenseId())+"' class='classLicenseText' style='display: none;'>"+CommonFunction.lineReplaceToBR(avoidNull(licenseMaster.getLicenseText()))+"</div>";
 						}
@@ -1394,14 +1394,14 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			
 			currentBean.addOssLicense(licenseBean);
 
-			if(remakeMap.containsKey(ossBean.getOssId())) {
+			if (remakeMap.containsKey(ossBean.getOssId())) {
 				remakeMap.replace(ossBean.getOssId(), currentBean);
 			} else {
 				remakeMap.put(ossBean.getOssId(), currentBean);
 			}
 		}
 		
-		for(OssMaster ossBean : remakeMap.values()) {
+		for (OssMaster ossBean : remakeMap.values()) {
 			ossBean.setLicenseName(CommonFunction.makeLicenseExpression(ossBean.getOssLicenses(), !isEmpty(bean.getOssId())));
 			newList.add(ossBean);
 		}
@@ -1411,7 +1411,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	
 	@Override
 	public void updateLicenseDivDetail(OssMaster master) {
-		if(master != null && !isEmpty(master.getOssId())) {
+		if (master != null && !isEmpty(master.getOssId())) {
 			boolean multiLicenseFlag = false;
 			boolean dualLicenseFlag = false;
 			boolean vDiffFlag = false;
@@ -1431,21 +1431,21 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			List<String> ossIdListByName = new ArrayList<>();
 			ossIdListByName.add(master.getOssId());
 			
-			if(ossMap != null && ossMap.size() > 1) {
+			if (ossMap != null && ossMap.size() > 1) {
 				// 비교대상 key룰 먼저 설정
 				List<List<OssLicense>> andCombLicenseListStandard = new ArrayList<>();
 				List<List<OssLicense>> andCombLicenseListCompare = new ArrayList<>();
 				
 				int idx = 0;
 				
-				for(OssMaster _bean : ossMap.values()) {
-					if(!isEmpty(_bean.getOssId())) {
-						for(OssLicense license : _bean.getOssLicenses()) {
-							if("AND".equalsIgnoreCase(license.getOssLicenseComb())) {
+				for (OssMaster _bean : ossMap.values()) {
+					if (!isEmpty(_bean.getOssId())) {
+						for (OssLicense license : _bean.getOssLicenses()) {
+							if ("AND".equalsIgnoreCase(license.getOssLicenseComb())) {
 								multiLicenseFlag = true;
 							}
 							
-							if("OR".equalsIgnoreCase(license.getOssLicenseComb())) {
+							if ("OR".equalsIgnoreCase(license.getOssLicenseComb())) {
 								dualLicenseFlag = true;
 							}
 						}
@@ -1462,16 +1462,16 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						
 						ossIdListByName.add(_bean.getOssId());
 						
-						if(idx == 0) {
+						if (idx == 0) {
 							andCombLicenseListStandard = makeLicenseKeyList(_bean.getOssLicenses());
 						}else {
-							if(!vDiffFlag && _bean.getOssLicenses() != null) {
+							if (!vDiffFlag && _bean.getOssLicenses() != null) {
 								andCombLicenseListCompare = makeLicenseKeyList(_bean.getOssLicenses());
 								
-								if(andCombLicenseListStandard.size() != andCombLicenseListCompare.size()) {
+								if (andCombLicenseListStandard.size() != andCombLicenseListCompare.size()) {
 									vDiffFlag = true;
 								}else {
-									if(!checkLicenseListVersionDiff(andCombLicenseListStandard, andCombLicenseListCompare)) {
+									if (!checkLicenseListVersionDiff(andCombLicenseListStandard, andCombLicenseListCompare)) {
 										vDiffFlag = true;
 									}
 								}
@@ -1486,39 +1486,39 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			} else {
 				String ossId = "";
 				
-				if(ossMap != null) {
-					for(OssMaster _bean : ossMap.values()) {
-						if(!isEmpty(_bean.getOssId())) {
+				if (ossMap != null) {
+					for (OssMaster _bean : ossMap.values()) {
+						if (!isEmpty(_bean.getOssId())) {
 							ossId = _bean.getOssId();
 							
-							for(OssLicense license : _bean.getOssLicenses()) {
-								if("AND".equalsIgnoreCase(license.getOssLicenseComb())) {
+							for (OssLicense license : _bean.getOssLicenses()) {
+								if ("AND".equalsIgnoreCase(license.getOssLicenseComb())) {
 									multiLicenseFlag = true;
 								}
 								
-								if("OR".equalsIgnoreCase(license.getOssLicenseComb())) {
+								if ("OR".equalsIgnoreCase(license.getOssLicenseComb())) {
 									dualLicenseFlag = true;
 								}
 							}
 						}
 					}
 				}else {
-					if(CoConstDef.LICENSE_DIV_MULTI.equals(master.getLicenseDiv())) {
+					if (CoConstDef.LICENSE_DIV_MULTI.equals(master.getLicenseDiv())) {
 						ossId = master.getOssId();
 						
-						for(OssLicense license : master.getOssLicenses()) {
-							if("AND".equalsIgnoreCase(license.getOssLicenseComb())) {
+						for (OssLicense license : master.getOssLicenses()) {
+							if ("AND".equalsIgnoreCase(license.getOssLicenseComb())) {
 								multiLicenseFlag = true;
 							}
 											
-							if("OR".equalsIgnoreCase(license.getOssLicenseComb())) {
+							if ("OR".equalsIgnoreCase(license.getOssLicenseComb())) {
 								dualLicenseFlag = true;
 							}
 						}
 					}
 				}
 				
-				if(ossId.isEmpty()) {
+				if (ossId.isEmpty()) {
 					ossId = master.getOssId();
 				}
 				
@@ -1543,10 +1543,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		String licenseId = "";
 		
-		for(List<OssLicense> standardList : andCombLicenseListStandard) {
+		for (List<OssLicense> standardList : andCombLicenseListStandard) {
 			standardList.sort(Comparator.comparing(OssLicense::getLicenseId));
 			
-			for(OssLicense ol : standardList) {
+			for (OssLicense ol : standardList) {
 				licenseId += ol.getLicenseId() + ",";
 			}
 			
@@ -1554,10 +1554,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			licenseId = "";
 		}
 		
-		for(List<OssLicense> compareList : andCombLicenseListCompare) {
+		for (List<OssLicense> compareList : andCombLicenseListCompare) {
 			compareList.sort(Comparator.comparing(OssLicense::getLicenseId));
 			
-			for(OssLicense ol : compareList) {
+			for (OssLicense ol : compareList) {
 				licenseId += ol.getLicenseId() + ",";
 			}
 			
@@ -1593,15 +1593,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<String> ossIdListByName = new ArrayList<>();
 		ossIdListByName.add(ossId);
 		
-		if(ossMap != null && !ossMap.isEmpty()) {
+		if (ossMap != null && !ossMap.isEmpty()) {
 			// 비교대상 key룰 먼저 설정
 			String _key = makeLicenseIdKeyStr(license);
 			
-			for(OssMaster _bean : ossMap.values()) {
-				if(!isEmpty(_bean.getOssId())) {
+			for (OssMaster _bean : ossMap.values()) {
+				if (!isEmpty(_bean.getOssId())) {
 					ossIdListByName.add(_bean.getOssId());
-					if(_bean.getOssLicenses() != null && !ossId.equals(_bean.getOssId())) {
-						if(!_key.equals(makeLicenseIdKeyStr(_bean.getOssLicenses()))) {
+					if (_bean.getOssLicenses() != null && !ossId.equals(_bean.getOssId())) {
+						if (!_key.equals(makeLicenseIdKeyStr(_bean.getOssLicenses()))) {
 							vDiffFlag = true;
 							break;
 						}
@@ -1616,8 +1616,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	private List<List<OssLicense>> makeLicenseKeyList(List<OssLicense> list) {
 		List<List<OssLicense>> andCombLicenseList = new ArrayList<>();
 		
-		for(OssLicense license : list) {
-			if(andCombLicenseList.isEmpty() || "OR".equals(license.getOssLicenseComb())) {
+		for (OssLicense license : list) {
+			if (andCombLicenseList.isEmpty() || "OR".equals(license.getOssLicenseComb())) {
 				andCombLicenseList.add(new ArrayList<>());
 			}
 			
@@ -1631,16 +1631,16 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		String rtnVal = "";
 		List<String> licenseIdList = new ArrayList<>();
 		
-		if(list != null) {
-			for(OssLicense bean : list) {
+		if (list != null) {
+			for (OssLicense bean : list) {
 				licenseIdList.add(bean.getLicenseId());
 			}
 		}
 		
 		Collections.sort(licenseIdList);
 		
-		for(String s : licenseIdList) {
-			if(!isEmpty(rtnVal)) {
+		for (String s : licenseIdList) {
+			if (!isEmpty(rtnVal)) {
 				rtnVal += "-";
 			}
 			
@@ -1658,25 +1658,25 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		boolean isFirst = true;
 		List<OssLicense> andLicenseList = new ArrayList<>();
 
-		for(OssLicense license : ossMaster.getOssLicenses()) {
+		for (OssLicense license : ossMaster.getOssLicenses()) {
 			LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER.get(license.getLicenseName().toUpperCase());
 			master = master != null ? master : new LicenseMaster();
-			if(!isEmpty(master.getLicenseId()) && !license.getLicenseId().equals(master.getLicenseId())) {
+			if (!isEmpty(master.getLicenseId()) && !license.getLicenseId().equals(master.getLicenseId())) {
 				license.setLicenseId(master.getLicenseId());
 			}
 			license.setLicenseType(master.getLicenseType());
 			
 			// obligation 설정
-			if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNeedsCheckYn()))) {
+			if (CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNeedsCheckYn()))) {
 				license.setObligation(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK);
-			} else if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))) {
+			} else if (CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationDisclosingSrcYn()))) {
 				license.setObligation(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
-			} else if(CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNotificationYn()))) {
+			} else if (CoConstDef.FLAG_YES.equals(avoidNull(master.getObligationNotificationYn()))) {
 				license.setObligation(CoConstDef.CD_DTL_OBLIGATION_NOTICE);
 			}
 			
-			if(!isFirst && "OR".equalsIgnoreCase(license.getOssLicenseComb()) ) {
-				if(!andLicenseList.isEmpty()) {
+			if (!isFirst && "OR".equalsIgnoreCase(license.getOssLicenseComb()) ) {
+				if (!andLicenseList.isEmpty()) {
 					orLicenseList.add(andLicenseList);
 					andLicenseList = new ArrayList<>();
 					andLicenseList.add(license);
@@ -1691,15 +1691,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			isFirst = false;
 		}
 
-		if(!andLicenseList.isEmpty()) {
+		if (!andLicenseList.isEmpty()) {
 			orLicenseList.add(andLicenseList);
 		}
 		
 		//  or인 경우는 Permissive한 걸로, and인 경우는 Copyleft 가 강한 것으로 표시
-		for(List<OssLicense> andlicenseGroup : orLicenseList) {
+		for (List<OssLicense> andlicenseGroup : orLicenseList) {
 			OssLicense permissiveLicense = CommonFunction.getLicensePermissiveTypeLicense(andlicenseGroup);
 			
-			if(permissiveLicense != null) {
+			if (permissiveLicense != null) {
 				switch (permissiveLicense.getLicenseType()) {
 					case CoConstDef.CD_LICENSE_TYPE_PMS:
 						currentType = CoConstDef.CD_LICENSE_TYPE_PMS;
@@ -1708,7 +1708,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						
 						break;
 					case CoConstDef.CD_LICENSE_TYPE_WCP:
-						if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(currentType)) {
+						if (!CoConstDef.CD_LICENSE_TYPE_PMS.equals(currentType)) {
 							currentType = CoConstDef.CD_LICENSE_TYPE_WCP;
 							
 							currentObligation = CommonFunction.getObligationTypeWithAndLicense(andlicenseGroup);
@@ -1716,7 +1716,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						
 						break;
 					case CoConstDef.CD_LICENSE_TYPE_CP:
-						if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(currentType)
+						if (!CoConstDef.CD_LICENSE_TYPE_PMS.equals(currentType)
 								&& !CoConstDef.CD_LICENSE_TYPE_WCP.equals(currentType)) {
 							currentType = CoConstDef.CD_LICENSE_TYPE_CP;
 							
@@ -1725,7 +1725,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						
 						break;
 					case CoConstDef.CD_LICENSE_TYPE_PF:
-						if(!CoConstDef.CD_LICENSE_TYPE_PMS.equals(currentType)
+						if (!CoConstDef.CD_LICENSE_TYPE_PMS.equals(currentType)
 								&& !CoConstDef.CD_LICENSE_TYPE_WCP.equals(currentType)
 								&& !CoConstDef.CD_LICENSE_TYPE_CP.equals(currentType)) {
 							currentType = CoConstDef.CD_LICENSE_TYPE_PF;
@@ -1735,7 +1735,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						
 						break;
 					case CoConstDef.CD_LICENSE_TYPE_NA:
-						if(isEmpty(currentType)) {
+						if (isEmpty(currentType)) {
 							currentType = CoConstDef.CD_LICENSE_TYPE_NA;
 							
 							currentObligation = CommonFunction.getObligationTypeWithAndLicense(andlicenseGroup);
@@ -1761,18 +1761,18 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public Map<String, Object> checkExistsOssDownloadLocation(OssMaster ossMaster) {
 		Map<String, Object> returnMap = new HashMap<String, Object>();
 		
-		if(!isEmpty(ossMaster.getDownloadLocation())) {
+		if (!isEmpty(ossMaster.getDownloadLocation())) {
 			List<String> checkOssNameUrl = CoCodeManager.getCodeNames(CoConstDef.CD_CHECK_OSS_NAME_URL);
 			int urlSearchSeq = -1;
 			int seq = 0;
 			
 			try {
-				if(ossMaster.getDownloadLocation().contains(";")) {
+				if (ossMaster.getDownloadLocation().contains(";")) {
 					ossMaster.setDownloadLocation(ossMaster.getDownloadLocation().split(";")[0]);
 				}
 				
-				for(String url : checkOssNameUrl) {
-					if(urlSearchSeq == -1 && ossMaster.getDownloadLocation().contains(url)) {
+				for (String url : checkOssNameUrl) {
+					if (urlSearchSeq == -1 && ossMaster.getDownloadLocation().contains(url)) {
 						urlSearchSeq = seq;
 						break;
 					}
@@ -1781,21 +1781,21 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				
 				String downloadLocationUrl = "";
 				
-				if(ossMaster.getDownloadLocation().startsWith("git://")) {
+				if (ossMaster.getDownloadLocation().startsWith("git://")) {
 					ossMaster.setDownloadLocation(ossMaster.getDownloadLocation().replace("git://", "https://"));
-				} else if(ossMaster.getDownloadLocation().startsWith("ftp://")) {
+				} else if (ossMaster.getDownloadLocation().startsWith("ftp://")) {
 					ossMaster.setDownloadLocation(ossMaster.getDownloadLocation().replace("ftp://", "https://"));
-				} else if(ossMaster.getDownloadLocation().startsWith("svn://")) {
+				} else if (ossMaster.getDownloadLocation().startsWith("svn://")) {
 					ossMaster.setDownloadLocation(ossMaster.getDownloadLocation().replace("svn://", "https://"));
-				} else if(ossMaster.getDownloadLocation().startsWith("git@")) {
+				} else if (ossMaster.getDownloadLocation().startsWith("git@")) {
 					ossMaster.setDownloadLocation(ossMaster.getDownloadLocation().replace("git@", "https://"));
 				}
 				
-				if(ossMaster.getDownloadLocation().contains(".git")) {
-					if(ossMaster.getDownloadLocation().endsWith(".git")) {
+				if (ossMaster.getDownloadLocation().contains(".git")) {
+					if (ossMaster.getDownloadLocation().endsWith(".git")) {
 						ossMaster.setDownloadLocation(ossMaster.getDownloadLocation().substring(0, ossMaster.getDownloadLocation().length()-4));
 					} else {
-						if(ossMaster.getDownloadLocation().contains("#")) {
+						if (ossMaster.getDownloadLocation().contains("#")) {
 							ossMaster.setDownloadLocation(ossMaster.getDownloadLocation().substring(0, ossMaster.getDownloadLocation().indexOf("#")));
 							ossMaster.setDownloadLocation(ossMaster.getDownloadLocation().substring(0, ossMaster.getDownloadLocation().length()-4));
 						}
@@ -1803,37 +1803,37 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				}
 				
 				String[] downloadlocationUrlSplit = ossMaster.getDownloadLocation().split("/");
-				if(downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
+				if (downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
 					ossMaster.setDownloadLocation(ossMaster.getDownloadLocation().substring(0, ossMaster.getDownloadLocation().indexOf("#")));
 				}
 				
-				if(!ossMaster.getDownloadLocation().startsWith("http://") && !ossMaster.getDownloadLocation().startsWith("https://")) {
-					if(ossMaster.getDownloadLocation().contains("//")) {
+				if (!ossMaster.getDownloadLocation().startsWith("http://") && !ossMaster.getDownloadLocation().startsWith("https://")) {
+					if (ossMaster.getDownloadLocation().contains("//")) {
 						ossMaster.setDownloadLocation("https://" + ossMaster.getDownloadLocation().split("//")[1]);
 					} else {
 						ossMaster.setDownloadLocation("https://" + ossMaster.getDownloadLocation());
 					}
 				}
 				
-				if( urlSearchSeq > -1 ) {
+				if ( urlSearchSeq > -1 ) {
 					Pattern p = generatePattern(urlSearchSeq, ossMaster.getDownloadLocation());
 					Matcher m = p.matcher(ossMaster.getDownloadLocation());
 					
-					while(m.find()) {
+					while (m.find()) {
 						ossMaster.setDownloadLocation(m.group(0));
 					}
 				}	
 					
-				if(ossMaster.getDownloadLocation().startsWith("http://") 
+				if (ossMaster.getDownloadLocation().startsWith("http://") 
 						|| ossMaster.getDownloadLocation().startsWith("https://")) {
 					downloadLocationUrl = ossMaster.getDownloadLocation().split("//")[1];
 				}
 				
-				if(downloadLocationUrl.startsWith("www.")) {
+				if (downloadLocationUrl.startsWith("www.")) {
 					downloadLocationUrl = downloadLocationUrl.substring(5, downloadLocationUrl.length());
 				}
 				
-				if(!isEmpty(downloadLocationUrl)) {
+				if (!isEmpty(downloadLocationUrl)) {
 					ossMaster.setDownloadLocation(downloadLocationUrl);
 				}
 				returnMap.put("downloadLocation", ossMapper.checkExistsOssDownloadLocation(ossMaster));
@@ -1850,18 +1850,18 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public Map<String, Object> checkExistsOssHomepage(OssMaster ossMaster) {
 		Map<String, Object> returnMap = new HashMap<String, Object>();
 		
-		if(!isEmpty(ossMaster.getHomepage())) {
+		if (!isEmpty(ossMaster.getHomepage())) {
 			List<String> checkOssNameUrl = CoCodeManager.getCodeNames(CoConstDef.CD_CHECK_OSS_NAME_URL);
 			int urlSearchSeq = -1;
 			int seq = 0;
 			
 			try {
-				if(ossMaster.getHomepage().contains(";")) {
+				if (ossMaster.getHomepage().contains(";")) {
 					ossMaster.setHomepage(ossMaster.getHomepage().split(";")[0]);
 				}
 				
-				for(String url : checkOssNameUrl) {
-					if(urlSearchSeq == -1 && ossMaster.getHomepage().contains(url)) {
+				for (String url : checkOssNameUrl) {
+					if (urlSearchSeq == -1 && ossMaster.getHomepage().contains(url)) {
 						urlSearchSeq = seq;
 						break;
 					}
@@ -1870,21 +1870,21 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				
 				String homepageUrl = "";
 				
-				if(ossMaster.getHomepage().startsWith("git://")) {
+				if (ossMaster.getHomepage().startsWith("git://")) {
 					ossMaster.setHomepage(ossMaster.getHomepage().replace("git://", "https://"));
-				} else if(ossMaster.getHomepage().startsWith("ftp://")) {
+				} else if (ossMaster.getHomepage().startsWith("ftp://")) {
 					ossMaster.setHomepage(ossMaster.getHomepage().replace("ftp://", "https://"));
-				} else if(ossMaster.getHomepage().startsWith("svn://")) {
+				} else if (ossMaster.getHomepage().startsWith("svn://")) {
 					ossMaster.setHomepage(ossMaster.getHomepage().replace("svn://", "https://"));
-				} else if(ossMaster.getHomepage().startsWith("git@")) {
+				} else if (ossMaster.getHomepage().startsWith("git@")) {
 					ossMaster.setHomepage(ossMaster.getHomepage().replace("git@", "https://"));
 				}
 				
-				if(ossMaster.getHomepage().contains(".git")) {
-					if(ossMaster.getHomepage().endsWith(".git")) {
+				if (ossMaster.getHomepage().contains(".git")) {
+					if (ossMaster.getHomepage().endsWith(".git")) {
 						ossMaster.setHomepage(ossMaster.getHomepage().substring(0, ossMaster.getHomepage().length()-4));
 					} else {
-						if(ossMaster.getHomepage().contains("#")) {
+						if (ossMaster.getHomepage().contains("#")) {
 							ossMaster.setHomepage(ossMaster.getHomepage().substring(0, ossMaster.getHomepage().indexOf("#")));
 							ossMaster.setHomepage(ossMaster.getHomepage().substring(0, ossMaster.getHomepage().length()-4));
 						}
@@ -1892,37 +1892,37 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				}
 				
 				String[] homepageUrlSplit = ossMaster.getHomepage().split("/");
-				if(homepageUrlSplit[homepageUrlSplit.length-1].indexOf("#") > -1) {
+				if (homepageUrlSplit[homepageUrlSplit.length-1].indexOf("#") > -1) {
 					ossMaster.setHomepage(ossMaster.getHomepage().substring(0, ossMaster.getHomepage().indexOf("#")));
 				}
 				
-				if(!ossMaster.getHomepage().startsWith("http://") && !ossMaster.getHomepage().startsWith("https://")) {
-					if(ossMaster.getHomepage().contains("//")) {
+				if (!ossMaster.getHomepage().startsWith("http://") && !ossMaster.getHomepage().startsWith("https://")) {
+					if (ossMaster.getHomepage().contains("//")) {
 						ossMaster.setHomepage("https://" + ossMaster.getHomepage().split("//")[1]);
 					} else {
 						ossMaster.setHomepage("https://" + ossMaster.getHomepage());
 					}
 				}
 				
-				if( urlSearchSeq > -1 ) {
+				if ( urlSearchSeq > -1 ) {
 					Pattern p = generatePattern(urlSearchSeq, ossMaster.getHomepage());
 					Matcher m = p.matcher(ossMaster.getHomepage());
 					
-					while(m.find()) {
+					while (m.find()) {
 						ossMaster.setHomepage(m.group(0));
 					}
 				}	
 					
-				if(ossMaster.getHomepage().startsWith("http://") 
+				if (ossMaster.getHomepage().startsWith("http://") 
 						|| ossMaster.getHomepage().startsWith("https://")) {
 					homepageUrl = ossMaster.getHomepage().split("//")[1];
 				}
 				
-				if(homepageUrl.startsWith("www.")) {
+				if (homepageUrl.startsWith("www.")) {
 					homepageUrl = homepageUrl.substring(5, homepageUrl.length());
 				}
 				
-				if(!isEmpty(homepageUrl)) {
+				if (!isEmpty(homepageUrl)) {
 					ossMaster.setHomepage(homepageUrl);
 				}
 				returnMap.put("homepage", ossMapper.checkExistsOssHomepage(ossMaster));
@@ -1972,9 +1972,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		String checkName = "";
 		boolean isValid = false;
 		Matcher ossNameMatcher = p.matcher("https://" + bean.getDownloadLocation());
-		while(ossNameMatcher.find()) {
-			for(String list : androidPlatformList){
-				if(ossNameMatcher.group(3).equals(list)){
+		while (ossNameMatcher.find()) {
+			for (String list : androidPlatformList){
+				if (ossNameMatcher.group(3).equals(list)){
 					isValid = true;
 					break;
 				}
@@ -1987,7 +1987,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			checkName = checkName.substring(0, checkName.length()-1);
 		}
 		bean.setCheckName(checkName);
-		if(!isValid) {
+		if (!isValid) {
 			bean.setCheckOssList("I");
 		}
 		return bean;
@@ -1996,7 +1996,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	private String generateCheckOSSName(int urlSearchSeq, String downloadlocationUrl, Pattern p) {
 		String checkName = "";
 		Matcher ossNameMatcher = p.matcher("https://" + downloadlocationUrl);
-		while(ossNameMatcher.find()){
+		while (ossNameMatcher.find()){
 			switch(urlSearchSeq) {
 				case 0: // github
 					checkName = ossNameMatcher.group(3) + "-" + ossNameMatcher.group(4);
@@ -2004,7 +2004,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				case 1: // npm
 				case 6: // npm
 					checkName = "npm:" + ossNameMatcher.group(4);
-					if(checkName.contains(":@")) {
+					if (checkName.contains(":@")) {
 						checkName += "/" + ossNameMatcher.group(5);
 					}
 					break;
@@ -2030,8 +2030,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	private String appendCheckOssName(List<OssMaster> ossNameList) {
 		String checkName = "";
 
-		for(OssMaster ossBean : ossNameList) {
-			if(!isEmpty(checkName)) {
+		for (OssMaster ossBean : ossNameList) {
+			if (!isEmpty(checkName)) {
 				checkName += "|";
 			}
 			checkName += ossBean.getOssName();
@@ -2044,7 +2044,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 		switch(urlSearchSeq) {
 			case 0: // github
-				if(downloadlocationUrl.contains("www.")) {
+				if (downloadlocationUrl.contains("www.")) {
 					downloadlocationUrl = downloadlocationUrl.replace("www.", "");
 				}
 				p = Pattern.compile("((http|https)://github.com/([^/]+)/([^/]+))");
@@ -2052,7 +2052,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				break;
 			case 1: // npm
 			case 6: // npm
-				if(downloadlocationUrl.contains("/package/@")) {
+				if (downloadlocationUrl.contains("/package/@")) {
 					p = Pattern.compile("((http|https)://npmjs.(org|com)/package/([^/]+)/([^/]+))");
 				}else {
 					p = Pattern.compile("((http|https)://npmjs.(org|com)/package/([^/]+))");
@@ -2082,18 +2082,18 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 
 	private ProjectIdentification downloadlocationFormatter(ProjectIdentification bean, int urlSearchSeq) {
-		if(urlSearchSeq == 0) {
-			if(bean.getDownloadLocation().startsWith("git://")) {
+		if (urlSearchSeq == 0) {
+			if (bean.getDownloadLocation().startsWith("git://")) {
 				bean.setDownloadLocation(bean.getDownloadLocation().replace("git://", "https://"));
 			}
-			if(bean.getDownloadLocation().startsWith("git@")) {
+			if (bean.getDownloadLocation().startsWith("git@")) {
 				bean.setDownloadLocation(bean.getDownloadLocation().replace("git@", "https://"));
 			}
-			if(bean.getDownloadLocation().contains(".git")) {
-				if(bean.getDownloadLocation().endsWith(".git")) {
+			if (bean.getDownloadLocation().contains(".git")) {
+				if (bean.getDownloadLocation().endsWith(".git")) {
 					bean.setDownloadLocation(bean.getDownloadLocation().substring(0, bean.getDownloadLocation().length()-4));
 				} else {
-					if(bean.getDownloadLocation().contains("#")) {
+					if (bean.getDownloadLocation().contains("#")) {
 						bean.setDownloadLocation(bean.getDownloadLocation().substring(0, bean.getDownloadLocation().indexOf("#")));
 						bean.setDownloadLocation(bean.getDownloadLocation().substring(0, bean.getDownloadLocation().length()-4));
 					}
@@ -2103,7 +2103,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		String downloadlocationUrl = bean.getDownloadLocation();
 
 		String[] downloadlocationUrlSplit = downloadlocationUrl.split("/");
-		if(downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
+		if (downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
 			downloadlocationUrl = downloadlocationUrl.substring(0, downloadlocationUrl.indexOf("#"));
 		}
 
@@ -2111,11 +2111,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 		Matcher m = p.matcher(downloadlocationUrl);
 
-		while(m.find()) {
+		while (m.find()) {
 			bean.setDownloadLocation(m.group(0));
 		}
 
-		if(bean.getDownloadLocation().startsWith("http://")
+		if (bean.getDownloadLocation().startsWith("http://")
 				|| bean.getDownloadLocation().startsWith("https://")
 				|| bean.getDownloadLocation().startsWith("git://")
 				|| bean.getDownloadLocation().startsWith("ftp://")
@@ -2123,7 +2123,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			downloadlocationUrl = bean.getDownloadLocation().split("//")[1];
 		}
 
-		if(downloadlocationUrl.startsWith("www.")) {
+		if (downloadlocationUrl.startsWith("www.")) {
 			downloadlocationUrl = downloadlocationUrl.substring(4, downloadlocationUrl.length());
 		}
 
@@ -2137,8 +2137,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		try{
 			Document document = conn.get();
 			Elements parsingDiv = document.getElementsByClass("RepoList-itemName");
-			for(Element element : parsingDiv) {
-				if(!element.text().equals("Name")){
+			for (Element element : parsingDiv) {
+				if (!element.text().equals("Name")){
 					list.add(element.text());
 				}
 			}
@@ -2167,11 +2167,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				})
 				.collect(Collectors.toList());
 
-		for(ProjectIdentification bean : list) {
+		for (ProjectIdentification bean : list) {
 			int seq = 0;
 			urlSearchSeq = -1;
 
-			if(isEmpty(bean.getDownloadLocation())) {
+			if (isEmpty(bean.getDownloadLocation())) {
 				continue;
 			}
 
@@ -2180,11 +2180,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				String semicolonStr = "";
 				String downloadLocation = bean.getDownloadLocation();
 
-				if(bean.getDownloadLocation().contains(";")) {
+				if (bean.getDownloadLocation().contains(";")) {
 					semicolonFlag = true;
 					int idx = 0;
-					for(String smc : bean.getDownloadLocation().split(";")) {
-						if(idx > 0) {
+					for (String smc : bean.getDownloadLocation().split(";")) {
+						if (idx > 0) {
 							semicolonStr += smc + ";";
 						}
 						idx++;
@@ -2193,23 +2193,23 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					bean.setDownloadLocation(bean.getDownloadLocation().split(";")[0]);
 				}
 
-				for(String url : checkOssNameUrl) {
-					if(urlSearchSeq == -1 && bean.getDownloadLocation().contains(url)) {
+				for (String url : checkOssNameUrl) {
+					if (urlSearchSeq == -1 && bean.getDownloadLocation().contains(url)) {
 						urlSearchSeq = seq;
 						break;
 					}
 					seq++;
 				}
 
-				if( urlSearchSeq > -1 ) {
+				if ( urlSearchSeq > -1 ) {
 					bean = downloadlocationFormatter(bean, urlSearchSeq);
 					String downloadlocationUrl = bean.getDownloadLocation();
 					Pattern p = generatePattern(urlSearchSeq, downloadlocationUrl);
 					int cnt = ossMapper.checkOssNameUrl2Cnt(bean);
-					if(cnt == 0) {
+					if (cnt == 0) {
 						bean.setOssNickName(generateCheckOSSName(urlSearchSeq, downloadlocationUrl, p));
 						String checkName = appendCheckOssName(ossMapper.checkOssNameTotal(bean));
-						if(!isEmpty(checkName)) {
+						if (!isEmpty(checkName)) {
 							bean.setCheckOssList("Y");
 							bean.setRecommendedNickname(generateCheckOSSName(urlSearchSeq, downloadlocationUrl, p));
 
@@ -2257,10 +2257,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 							}
 						}
 
-						if(!isEmpty(checkName)){
+						if (!isEmpty(checkName)){
 							bean.setCheckName(checkName);
 							bean.setDownloadLocation(downloadLocation);
-							if(!bean.getOssName().equals(bean.getCheckName())) {
+							if (!bean.getOssName().equals(bean.getCheckName())) {
 								result.add(bean);
 							}
 						}
@@ -2268,17 +2268,17 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				} else {
 					String downloadlocationUrl = "";
 					
-					if(semicolonFlag) {
+					if (semicolonFlag) {
 						downloadlocationUrl = bean.getDownloadLocation().split(";")[0];
 					} else {
 						downloadlocationUrl = bean.getDownloadLocation();
 					}
 					
-					if(downloadlocationUrl.startsWith("git@")) {
+					if (downloadlocationUrl.startsWith("git@")) {
 						downloadlocationUrl = downloadlocationUrl.replace("git@", "");
 					}
 					
-					if(downloadlocationUrl.startsWith("http://") 
+					if (downloadlocationUrl.startsWith("http://") 
 							|| downloadlocationUrl.startsWith("https://")
 							|| downloadlocationUrl.startsWith("git://")
 							|| downloadlocationUrl.startsWith("ftp://")
@@ -2286,15 +2286,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						downloadlocationUrl = downloadlocationUrl.split("//")[1];
 					}
 					
-					if(downloadlocationUrl.startsWith("www.")) {
+					if (downloadlocationUrl.startsWith("www.")) {
 						downloadlocationUrl = downloadlocationUrl.substring(4, downloadlocationUrl.length());
 					}
 					
-					if(downloadlocationUrl.contains(".git")) {
-						if(downloadlocationUrl.endsWith(".git")) {
+					if (downloadlocationUrl.contains(".git")) {
+						if (downloadlocationUrl.endsWith(".git")) {
 							downloadlocationUrl = downloadlocationUrl.substring(0, downloadlocationUrl.length()-4);
 						} else {
-							if(downloadlocationUrl.contains("#")) {
+							if (downloadlocationUrl.contains("#")) {
 								downloadlocationUrl = downloadlocationUrl.substring(0, downloadlocationUrl.indexOf("#"));
 								downloadlocationUrl = downloadlocationUrl.substring(0, downloadlocationUrl.length()-4);
 							}
@@ -2302,7 +2302,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					}
 					
 					String[] downloadlocationUrlSplit = downloadlocationUrl.split("/");
-					if(downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
+					if (downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
 						downloadlocationUrl = downloadlocationUrl.substring(0, downloadlocationUrl.indexOf("#"));
 					}
 					
@@ -2310,22 +2310,22 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					
 					int cnt = ossMapper.checkOssNameUrl2Cnt(bean);
 					
-					if(cnt == 0) {
+					if (cnt == 0) {
 						List<OssMaster> ossNameList = ossMapper.checkOssNameUrl2(bean);
 						String checkName = "";
 						
-						for(OssMaster ossBean : ossNameList) {
-							if(!isEmpty(checkName)) {
+						for (OssMaster ossBean : ossNameList) {
+							if (!isEmpty(checkName)) {
 								checkName += "|";
 							}
 							
 							checkName += ossBean.getOssName();
 						}
 						
-						if(!isEmpty(checkName)) {
+						if (!isEmpty(checkName)) {
 							bean.setCheckOssList("Y");
 							bean.setCheckName(checkName);
-							if(!bean.getOssName().equals(bean.getCheckName())) {
+							if (!bean.getOssName().equals(bean.getCheckName())) {
 								bean.setDownloadLocation(downloadLocation);
 								result.add(bean);
 							}
@@ -2343,7 +2343,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<ProjectIdentification> sortedData = result.stream().filter(CommonFunction.distinctByKey(p -> p.getOssName()+p.getCheckName())).sorted(comp).collect(Collectors.toList());
 		
 		// oss name과 registered oss name이 unique하지 않다면 중복된 data의 downloadlocation을 전부 합쳐서 출력함. 
-		for(ProjectIdentification p : sortedData) {
+		for (ProjectIdentification p : sortedData) {
 			String downloadLocation = result.stream()
 											.filter(e -> (e.getOssName()+e.getCheckName()).equals(p.getOssName()+p.getCheckName()))
 											.map(e -> e.getDownloadLocation())
@@ -2385,8 +2385,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 					paramBean.setDownloadLocation(downloadLocation);
 
-					for(String url : checkOssNameUrl) {
-						if(urlSearchSeq == -1 && downloadLocation.contains(url)) {
+					for (String url : checkOssNameUrl) {
+						if (urlSearchSeq == -1 && downloadLocation.contains(url)) {
 							urlSearchSeq = seq;
 
 							break;
@@ -2395,10 +2395,10 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 						seq++;
 					}
 
-					if( urlSearchSeq > -1 ) {
+					if ( urlSearchSeq > -1 ) {
 						Pattern p = generatePattern(urlSearchSeq, downloadLocation);
 						Matcher m = p.matcher(downloadLocation);
-						while(m.find()) {
+						while (m.find()) {
 							paramBean.setDownloadLocation(m.group(0));
 						}
 					}
@@ -2407,7 +2407,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					
 					switch(targetName.toUpperCase()) {
 						case CoConstDef.CD_CHECK_OSS_SELF:
-							for(String componentId : componentIds) {
+							for (String componentId : componentIds) {
 								String[] gridId = componentId.split("-");
 								paramBean.setGridId(gridId[0]+"-"+gridId[1]);
 								paramBean.setComponentId(gridId[2]);
@@ -2416,18 +2416,18 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 							
 							break;
 						case CoConstDef.CD_CHECK_OSS_PARTNER:
-							for(String componentId : componentIds) {
+							for (String componentId : componentIds) {
 								paramBean.setComponentId(componentId);
 								updateCnt += ossMapper.updateOssCheckNameByPartner(paramBean);
 							}
 
-							if(updateCnt >= 1) {
+							if (updateCnt >= 1) {
 								String commentId = paramBean.getRefPrjId();
 								String checkOssNameComment = "";
 								String changeOssNameInfo = "<p>" + paramBean.getOssName() + " => " + paramBean.getCheckName() + "</p>";
 								CommentsHistory commentInfo = null;
 
-								if(isEmpty(commentId)) {
+								if (isEmpty(commentId)) {
 									checkOssNameComment  = "<p><b>The following open source and license names will be changed to names registered on the system for efficient management.</b></p>";
 									checkOssNameComment += "<p><b>Open Source Name</b></p>";
 									checkOssNameComment += changeOssNameInfo;
@@ -2439,11 +2439,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 								} else {
 									commentInfo = (CommentsHistory) commentService.getCommnetInfo(commentId).get("info");
 
-									if(commentInfo != null) {
+									if (commentInfo != null) {
 										commentInfo = (CommentsHistory) commentService.getCommnetInfo(commentId).get("info");
 
-										if(commentInfo != null) {
-											if(!isEmpty(commentInfo.getContents())) {
+										if (commentInfo != null) {
+											if (!isEmpty(commentInfo.getContents())) {
 												checkOssNameComment  = commentInfo.getContents();
 												checkOssNameComment += changeOssNameInfo;
 												commentInfo.setContents(checkOssNameComment);
@@ -2453,25 +2453,25 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 										}
 									}
 								}
-								if(commentInfo != null) {
+								if (commentInfo != null) {
 									map.put("commentId", commentInfo.getCommId());
 								}
 							}
 
 							break;
 						case CoConstDef.CD_CHECK_OSS_IDENTIFICATION:
-							for(String componentId : componentIds) {
+							for (String componentId : componentIds) {
 								paramBean.setComponentId(componentId);
 								updateCnt += ossMapper.updateOssCheckName(paramBean);
 							}
 							
-							if(updateCnt >= 1) {
+							if (updateCnt >= 1) {
 								String commentId = paramBean.getReferenceId();
 								String checkOssNameComment = "";
 								String changeOssNameInfo = "<p>" + paramBean.getOssName() + " => " + paramBean.getCheckName() + "</p>";
 								CommentsHistory commentInfo = null;
 
-								if(isEmpty(commentId)) {
+								if (isEmpty(commentId)) {
 									checkOssNameComment  = "<p><b>The following open source and license names will be changed to names registered on the system for efficient management.</b></p>";
 									checkOssNameComment += "<p><b>Open Source Name</b></p>";
 									checkOssNameComment += changeOssNameInfo;
@@ -2483,8 +2483,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 								} else {
 									commentInfo = (CommentsHistory) commentService.getCommnetInfo(commentId).get("info");
 
-									if(commentInfo != null) {
-										if(!isEmpty(commentInfo.getContents())) {
+									if (commentInfo != null) {
+										if (!isEmpty(commentInfo.getContents())) {
 											checkOssNameComment  = commentInfo.getContents();
 											checkOssNameComment += changeOssNameInfo;
 											commentInfo.setContents(checkOssNameComment);
@@ -2494,7 +2494,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 									}
 								}
 
-								if(commentInfo != null) {
+								if (commentInfo != null) {
 									map.put("commentId", commentInfo.getCommId());
 								}
 							}
@@ -2502,7 +2502,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 							break;
 					}
 
-					if(updateCnt >= 1) {
+					if (updateCnt >= 1) {
 						map.put("isValid", true);
 						map.put("returnType", "Success");
 					} else {
@@ -2657,13 +2657,13 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			resMap.put("isChangedName", isChangedName);
 			resMap.put("isDeactivateFlag", isDeactivateFlag);
 			resMap.put("isActivateFlag", isActivateFlag);
-			if(beforeBean != null) {
+			if (beforeBean != null) {
 				resMap.put("beforeBean", beforeBean);
 			}
-			if(afterBean != null) {
+			if (afterBean != null) {
 				resMap.put("afterBean", afterBean);
 			}
-			if(updateOssNameVersionDiffMergeObject != null) {
+			if (updateOssNameVersionDiffMergeObject != null) {
 				resMap.put("updateOssNameVersionDiffMergeObject", updateOssNameVersionDiffMergeObject);
 			}
 		}
@@ -2680,7 +2680,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		ossMaster.setOssNickname(paramBean.getOssName());
 		
 		try {
-			if(isEmpty(ossMaster.getOssNickname())) {
+			if (isEmpty(ossMaster.getOssNickname())) {
 				throw new Exception(ossMaster.getOssName() + " -> NickName field is required.");
 			}
 			
@@ -2691,13 +2691,13 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			
 			Map<String, OssMaster> ossMap = getBasicOssInfoList(ossMaster);
 			
-			if(ossMap == null || ossMap.isEmpty()) {}else {
+			if (ossMap == null || ossMap.isEmpty()) {}else {
 				throw new Exception(paramBean.getOssName() + " -> OSS Name registered in OSS list.");
 			}
 			
 			int insertCnt = ossMapper.insertOssNickname(ossMaster);
 			
-			if(insertCnt == 1) {
+			if (insertCnt == 1) {
 				map.put("isValid", true);
 				map.put("returnType", "Success");
 			} else {
@@ -2740,20 +2740,20 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			switch(key) {
 				case "VIEW":
 					String prjId = ossBean.getPrjId();
-					if(CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(ossBean.getReferenceDiv())) {
+					if (CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(ossBean.getReferenceDiv())) {
 						prjId = "3rd_" + prjId;
 					}
 					
 					int analysisListCnt = ossMapper.ossAnalysisListCnt(prjId, ossBean.getStartAnalysisFlag(), ossBean.getCsvComponentIdList());
 					
-					if(analysisListCnt > 0) {
+					if (analysisListCnt > 0) {
 						ossMapper.deleteOssAnalysisList(prjId);
 					}
 					
-					if(ossBean.getComponentIdList().size() > 0) {
+					if (ossBean.getComponentIdList().size() > 0) {
 						int insertCnt = ossMapper.insertOssAnalysisList(ossBean);
 						
-						if(insertCnt <= 0) {
+						if (insertCnt <= 0) {
 							result.put("isValid", false);
 							result.put("returnType", "Failed");
 						}
@@ -2763,7 +2763,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				case "POPUP":
 					int updateCnt = ossMapper.updateOssAnalysisList(ossBean);
 					
-					if(updateCnt != 1) {
+					if (updateCnt != 1) {
 						result.put("isValid", false);
 						result.put("returnType", "Failed");
 					}
@@ -2774,7 +2774,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			log.error(e.getMessage());
 		}
 		
-		if(result.keySet().size() == 0) {
+		if (result.keySet().size() == 0) {
 			result.put("isValid", true);
 			result.put("returnType", "Success");
 		}
@@ -2788,11 +2788,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<OssAnalysis> list = null;
 		String prjId = ossMaster.getPrjId();
 		
-		if(CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(ossMaster.getReferenceDiv())) {
+		if (CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(ossMaster.getReferenceDiv())) {
 			ossMaster.setPrjId("3rd_" + prjId);
 		}
 		
-		if(CoConstDef.FLAG_YES.equals(ossMaster.getStartAnalysisFlag())) {
+		if (CoConstDef.FLAG_YES.equals(ossMaster.getStartAnalysisFlag())) {
 			int records = ossMapper.ossAnalysisListCnt(ossMaster.getPrjId(), ossMaster.getStartAnalysisFlag(), ossMaster.getCsvComponentIdList());
 			ossMaster.setTotListSize(records);
 			
@@ -2803,7 +2803,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			result.put("records", records);
 		}
 		
-		if(!CoConstDef.FLAG_YES.equals(ossMaster.getStartAnalysisFlag())) {
+		if (!CoConstDef.FLAG_YES.equals(ossMaster.getStartAnalysisFlag())) {
 			list = ossMapper.selectOssAnalysisList(ossMaster);
 			CommonFunction.getAnalysisValidation(result, list);
 		}
@@ -2840,7 +2840,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			fileInfo = fileMapper.selectFileInfo(fileSeq);
 			
 			String EMAIL_VAL = ""; // reviewer와 loginUser의 email
-			if(prjId.toUpperCase().indexOf("3RD") > -1){
+			if (prjId.toUpperCase().indexOf("3RD") > -1){
 				EMAIL_VAL = partnerMapper.getReviewerEmail(prjId, loginUserName());
 			} else {
 				EMAIL_VAL = projectMapper.getReviewerEmail(prjId, loginUserName());
@@ -2864,7 +2864,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			int idleTime = Integer.parseInt(CoCodeManager.getCodeExpString(CoConstDef.CD_AUTO_ANALYSIS, CoConstDef.CD_IDLE_TIME));
 			
 			while (!Thread.currentThread().isInterrupted()) {
-				if(count > idleTime) {
+				if (count > idleTime) {
 					oss_auto_analysis_log.info("ANALYSIS TIMEOUT PRJ ID : " + prjId);
 					resultMap.put("isValid", false);
 					resultMap.put("returnMsg", "OSS auto analysis has not been completed yet.");
@@ -2875,7 +2875,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				String result = br.readLine();
 				oss_auto_analysis_log.info("OSS AUTO ANALYSIS READLINE : " + result);
 				
-				if(result != null && result.toLowerCase().indexOf("start download oss") > -1) {
+				if (result != null && result.toLowerCase().indexOf("start download oss") > -1) {
 					oss_auto_analysis_log.info("ANALYSIS START SUCCESS PRJ ID : " + prjId);
 					Project prjInfo = new Project();
 					prjInfo.setPrjId(prjId);
@@ -2913,38 +2913,38 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			resultMap.replace("isValid", false);
 			resultMap.replace("returnMsg", "OSS auto analysis has not been completed yet.");
 		} finally {
-			if(br != null) {
+			if (br != null) {
 				try {
 					br.close();
 				} catch (Exception e2) {}
 			}
 			
-			if(error != null) {
+			if (error != null) {
 				try {
 					error.close();
 				} catch (Exception e2) {}
 			}
 			
-			if(isr != null) {
+			if (isr != null) {
 				try {
 					isr.close();
 				} catch (Exception e2) {}
 			}
 			
-			if(is != null) {
+			if (is != null) {
 				try {
 					is.close();
 				} catch (Exception e2) {}
 			}
 			
-			if(error != null) {
+			if (error != null) {
 				try {
 					error.close();
 				} catch (Exception e2) {}
 			}
 			
 			try {
-				if(process != null) {
+				if (process != null) {
 					oss_auto_analysis_log.info("Do OSS ANALYSIS Process Destry");
 					process.destroy();
 				}
@@ -2960,8 +2960,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public OssAnalysis getNewestOssInfo(OssAnalysis bean) {		
 		OssAnalysis ossNewistData = ossMapper.getNewestOssInfo(bean);
 		
-		if(ossNewistData != null) {
-			if(!isEmpty(ossNewistData.getDownloadLocationGroup())) {
+		if (ossNewistData != null) {
+			if (!isEmpty(ossNewistData.getDownloadLocationGroup())) {
 				String url = "";
 				
 				String[] downloadLocationList = ossNewistData.getDownloadLocationGroup().split(",");
@@ -2971,7 +2971,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 														.filter(CommonFunction.distinctByKey(p -> p))
 														.collect(Collectors.toList()));
 				
-				if(!isEmpty(duplicateRemoveUrl)) {
+				if (!isEmpty(duplicateRemoveUrl)) {
 					url = duplicateRemoveUrl;
 				}
 				
@@ -2988,7 +2988,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	
 		int updateCnt = ossMapper.updateAnalysisComplete(bean);
 		
-		if(updateCnt == 1) {
+		if (updateCnt == 1) {
 			resultMap.put("isValid", true);
 			resultMap.put("returnMsg", "Success");
 		} else {
@@ -3008,9 +3008,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<ProjectIdentification> resultData = new ArrayList<ProjectIdentification>();
 		Map<String, Object> ruleMap = T2CoValidationConfig.getInstance().getRuleAllMap();
 		
-		if(validMap != null) {
-			for(String key : validMap.keySet()) {
-				if(key.toUpperCase().startsWith("OSSNAME") 
+		if (validMap != null) {
+			for (String key : validMap.keySet()) {
+				if (key.toUpperCase().startsWith("OSSNAME") 
 						&& (validMap.get(key).equals(ruleMap.get("OSS_NAME.UNCONFIRMED.MSG")) 
 								|| validMap.get(key).equals(ruleMap.get("OSS_NAME.REQUIRED.MSG")))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
@@ -3019,7 +3019,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 																	.collect(Collectors.toList()));
 				}
 				
-				if(key.toUpperCase().startsWith("OSSVERSION") && validMap.get(key).equals(ruleMap.get("OSS_VERSION.UNCONFIRMED.MSG"))) {
+				if (key.toUpperCase().startsWith("OSSVERSION") && validMap.get(key).equals(ruleMap.get("OSS_VERSION.UNCONFIRMED.MSG"))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
 																	.stream()
 																	.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
@@ -3028,30 +3028,30 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			}
 		}
 		
-		if(diffMap != null) {
-			for(String key : diffMap.keySet()) {
-				if(key.toUpperCase().startsWith("OSSNAME") && diffMap.get(key).equals(ruleMap.get("OSS_NAME.UNCONFIRMED.MSG"))) {
+		if (diffMap != null) {
+			for (String key : diffMap.keySet()) {
+				if (key.toUpperCase().startsWith("OSSNAME") && diffMap.get(key).equals(ruleMap.get("OSS_NAME.UNCONFIRMED.MSG"))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
 																	.stream()
 																	.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
 																	.collect(Collectors.toList()));
 				}
 				
-				if(key.toUpperCase().startsWith("OSSVERSION") && diffMap.get(key).equals(ruleMap.get("OSS_VERSION.UNCONFIRMED.MSG"))) {
+				if (key.toUpperCase().startsWith("OSSVERSION") && diffMap.get(key).equals(ruleMap.get("OSS_VERSION.UNCONFIRMED.MSG"))) {
 					resultData.addAll((List<ProjectIdentification>) componentData
 																	.stream()
 																	.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
 																	.collect(Collectors.toList()));
 				}
 				
-				if(key.toUpperCase().startsWith("DOWNLOADLOCATION") && diffMap.get(key).equals(ruleMap.get("DOWNLOAD_LOCATION.DIFFERENT.MSG"))) {
+				if (key.toUpperCase().startsWith("DOWNLOADLOCATION") && diffMap.get(key).equals(ruleMap.get("DOWNLOAD_LOCATION.DIFFERENT.MSG"))) {
 					int duplicateRow = (int) resultData
 												.stream()
 												.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
 												.collect(Collectors.toList())
 												.size();
 					
-					if(duplicateRow == 0) {
+					if (duplicateRow == 0) {
 						resultData.addAll((List<ProjectIdentification>) componentData
 																		.stream()
 																		.filter(e -> key.split("\\.")[1].equals(e.getComponentId())) // 동일한 componentId을 filter
@@ -3061,7 +3061,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			}
 		}
 		
-		if(validMap == null && diffMap == null) {
+		if (validMap == null && diffMap == null) {
 			resultData.addAll(componentData.stream().filter(e -> e.getOssName().equals("-")).collect(Collectors.toList()));
 		}
 		
@@ -3077,7 +3077,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	public List<OssMaster> getOssListBySync(OssMaster bean) {
 		List<OssMaster> list = ossMapper.getOssListByName(bean);
 		
-		if(list == null) {
+		if (list == null) {
 			list = new ArrayList<>();
 		}
 		
@@ -3085,20 +3085,20 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<OssMaster> newList = new ArrayList<>();
 		Map<String, OssMaster> remakeMap = new HashMap<>();
 		OssMaster currentBean = null;
-		for(OssMaster ossBean : list) {
+		for (OssMaster ossBean : list) {
 			// name + version
-			if(!isEmpty(ossBean.getOssVersion())) {
+			if (!isEmpty(ossBean.getOssVersion())) {
 				ossBean.setOssNameVerStr(ossBean.getOssName() + " (" + ossBean.getOssVersion() + ")");
 			} else {
 				ossBean.setOssNameVerStr(ossBean.getOssName());
 			}
 			
-			if(remakeMap.containsKey(ossBean.getOssId())) {
+			if (remakeMap.containsKey(ossBean.getOssId())) {
 				currentBean = remakeMap.get(ossBean.getOssId());
 			} else {
 				currentBean = ossBean;
 				
-				if(!isEmpty(currentBean.getOssNickname())) {
+				if (!isEmpty(currentBean.getOssNickname())) {
 					currentBean.setOssNickname(currentBean.getOssNickname().replaceAll("\\|", "<br>"));
 				}
 				
@@ -3111,7 +3111,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			if (ossDownloadLocation.size() > 0) {
 				StringBuilder sb = new StringBuilder();
 						
-				for(OssMaster location : ossDownloadLocation) {
+				for (OssMaster location : ossDownloadLocation) {
 					sb.append(location.getDownloadLocation()).append(",");
 				}
 							
@@ -3129,14 +3129,14 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			
 			currentBean.addOssLicense(licenseBean);
 
-			if(remakeMap.containsKey(ossBean.getOssId())) {
+			if (remakeMap.containsKey(ossBean.getOssId())) {
 				remakeMap.replace(ossBean.getOssId(), currentBean);
 			} else {
 				remakeMap.put(ossBean.getOssId(), currentBean);
 			}
 		}
 		
-		for(OssMaster ossBean : remakeMap.values()) {
+		for (OssMaster ossBean : remakeMap.values()) {
 			ossBean.setLicenseName(CommonFunction.makeLicenseExpression(ossBean.getOssLicenses()));
 			newList.add(ossBean);
 		}
@@ -3204,7 +3204,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			int ossLicenseDeclaredIdx = 0;
 			String licenseId = "";
 			
-			for(OssLicense license : list) {
+			for (OssLicense license : list) {
 				ossLicenseDeclaredIdx++;
 				licenseId = CommonFunction.getLicenseIdByName(license.getLicenseName());
 				
@@ -3230,11 +3230,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 			List<String> detectedLicenses = ossMaster.getDetectedLicenses().stream().distinct().collect(Collectors.toList());
 
-			if(detectedLicenses != null) {
+			if (detectedLicenses != null) {
 				int ossLicenseDetectedIdx = 0;
 
-				for(String detectedLicense : detectedLicenses) {
-					if(!isEmpty(detectedLicense)) {
+				for (String detectedLicense : detectedLicenses) {
+					if (!isEmpty(detectedLicense)) {
 						LicenseMaster detectedLicenseInfo = CoCodeManager.LICENSE_INFO_UPPER.get(detectedLicense.toUpperCase());
 
 						OssMaster om = new OssMaster(
@@ -3253,7 +3253,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			registOssDownloadLocation(ossMaster);
 		}
 
-		if(!isEmpty(avoidNull(ossMaster.getComment()).trim())) {
+		if (!isEmpty(avoidNull(ossMaster.getComment()).trim())) {
 			CommentsHistory param = new CommentsHistory();
 			param.setReferenceId(ossMaster.getOssId());
 			param.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_OSS);
@@ -3263,7 +3263,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		}
 
 		// Deactivate Flag Setting
-		if(isEmpty(ossMaster.getDeactivateFlag())) {
+		if (isEmpty(ossMaster.getDeactivateFlag())) {
 			ossMaster.setDeactivateFlag(CoConstDef.FLAG_NO);
 		}
 
@@ -3275,24 +3275,24 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		bean.setLicenseName(CommonFunction.makeLicenseExpression(bean.getOssLicenses()));
 		bean.setOssLicenses(CommonFunction.changeLicenseNameToShort(bean.getOssLicenses()));
 
-		if(!isEmpty(bean.getLicenseDiv())) {
+		if (!isEmpty(bean.getLicenseDiv())) {
 			bean.setMultiLicenseFlag(bean.getLicenseDiv());
 			bean.setLicenseDiv(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_DIV, bean.getLicenseDiv()));
 		}
 
-		if(!isEmpty(bean.getLicenseType())) {
+		if (!isEmpty(bean.getLicenseType())) {
 			bean.setLicenseType(CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_TYPE, bean.getLicenseType()));
 		}
 
-		if(!isEmpty(bean.getObligationType())) {
+		if (!isEmpty(bean.getObligationType())) {
 			bean.setObligation(CoCodeManager.getCodeString(CoConstDef.CD_OBLIGATION_TYPE, bean.getObligationType()));
 		}
 
-		if(!isEmpty(bean.getModifiedDate())) {
+		if (!isEmpty(bean.getModifiedDate())) {
 			bean.setModifiedDate(DateUtil.dateFormatConvert(bean.getModifiedDate(), DateUtil.TIMESTAMP_PATTERN, DateUtil.DATE_PATTERN_DASH));
 		}
 
-		if(!isEmpty(bean.getModifier())) {
+		if (!isEmpty(bean.getModifier())) {
 			bean.setModifier(CoMailManager.getInstance().makeUserNameFormat(bean.getModifier()));
 		}
 
@@ -3308,7 +3308,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		boolean ossVersion_Flag = false;
 		boolean isNew = StringUtil.isEmpty(ossMaster.getOssId());
 		
-		if(!isNew) {
+		if (!isNew) {
 			OssMaster beforeOss = CoCodeManager.OSS_INFO_BY_ID.get(ossMaster.getOssId());
 			
 			List<String> ossNameList = new ArrayList<>();
@@ -3325,7 +3325,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			
 			Map<String, OssMaster> afterOssMap = getBasicOssInfoList(ossMaster);
 									
-			if((afterOssMap == null || afterOssMap.isEmpty()) && beforeOssMap.size() > 1) {
+			if ((afterOssMap == null || afterOssMap.isEmpty()) && beforeOssMap.size() > 1) {
 				ossVersion_Flag = true;
 			}
 			
@@ -3358,14 +3358,14 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		History history;
 		
-		for(OssMaster om : beforeOssMap.values()) {
-			if(!ossMaster.getOssVersion().equals(om.getOssVersion())) {
+		for (OssMaster om : beforeOssMap.values()) {
+			if (!ossMaster.getOssVersion().equals(om.getOssVersion())) {
 				beforeOssNameVersionOssIdList.add(om.getOssId());
 				beforeOssNameVersionBean = getOssInfo(om.getOssId(), true);
 				beforeOssNameVersionBeanList.add(beforeOssNameVersionBean);
 			}
 			
-			if(!beforeOssName.equals(afterOssName)) {
+			if (!beforeOssName.equals(afterOssName)) {
 				om.setOssName(afterOssName);
 				ossMapper.changeOssNameByDelete(om);
 				
@@ -3377,12 +3377,12 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		ossMaster.setOssName(beforeOssName);
 		
-		if(ossMaster.getOssNicknames() != null) {
+		if (ossMaster.getOssNicknames() != null) {
 			ossMapper.deleteOssNickname(ossMaster);
 			
 			ossMaster.setOssName(afterOssName);
-			for(String nickName : ossMaster.getOssNicknames()){
-				if(!isEmpty(nickName)) {
+			for (String nickName : ossMaster.getOssNicknames()){
+				if (!isEmpty(nickName)) {
 					ossMaster.setOssNickname(nickName.trim());
 					ossMapper.insertOssNickname(ossMaster);
 				}
@@ -3393,12 +3393,12 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		
 		CoCodeManager.getInstance().refreshOssInfo();
 		
-		for(String ossId : beforeOssNameVersionOssIdList) {
+		for (String ossId : beforeOssNameVersionOssIdList) {
 			afterOssNameVersionBean = getOssInfo(ossId, true);
 			afterOssNameVersionBeanList.add(afterOssNameVersionBean);
 		}
 		
-		if(beforeOssNameVersionBeanList != null && !beforeOssNameVersionBeanList.isEmpty()) {
+		if (beforeOssNameVersionBeanList != null && !beforeOssNameVersionBeanList.isEmpty()) {
 			beforeOssNameVersionBeanList = beforeOssNameVersionBeanList.stream()
 										.sorted(Comparator.comparing(OssMaster::getOssVersion, Comparator.nullsLast(Comparator.naturalOrder())))
 										.collect(Collectors.toList());
@@ -3410,7 +3410,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		ossNameVersionDiffMergeObject.put("before", beforeOssNameVersionBeanList);
 		ossNameVersionDiffMergeObject.put("after", afterOssNameVersionBeanList);
 		
-		if(!beforeOssName.equals(afterOssName)) {
+		if (!beforeOssName.equals(afterOssName)) {
 			OssMaster param = new OssMaster();
 			param.setOssName(beforeOssName);
 			param.setOssVersion(null);
@@ -3526,7 +3526,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 	@Override
 	public List<Vulnerability> getOssVulnerabilityList2(OssMaster ossMaster) {
-		if("N/A".equals(ossMaster.getOssVersion()) || isEmpty(ossMaster.getOssVersion())) {
+		if ("N/A".equals(ossMaster.getOssVersion()) || isEmpty(ossMaster.getOssVersion())) {
 			ossMaster.setOssVersion("-");
 		}
 		
@@ -3535,24 +3535,24 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<String> dashOssNameList = new ArrayList<>();
 		
 		try {
-			if(ossMaster.getOssName().contains(" ")) {
+			if (ossMaster.getOssName().contains(" ")) {
 				ossMaster.setOssNameTemp(ossMaster.getOssName().replaceAll(" ", "_"));
 			}
 			
-			if(ossMaster.getOssName().contains("-")) {
+			if (ossMaster.getOssName().contains("-")) {
 				dashOssNameList.add(ossMaster.getOssName());
 			}
 			
 			nicknameList = getOssNickNameListByOssName(ossMaster.getOssName());
 			ossMaster.setOssNicknames(nicknameList);
 			
-			for(String nick : nicknameList) {
-				if(nick.contains("-")) {
+			for (String nick : nicknameList) {
+				if (nick.contains("-")) {
 					dashOssNameList.add(nick);
 				}
 			}
 			
-			if(dashOssNameList.size() > 0) {
+			if (dashOssNameList.size() > 0) {
 				ossMaster.setDashOssNameList(dashOssNameList.toArray(new String[dashOssNameList.size()]));
 			}
 			
@@ -3562,7 +3562,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			log.error(e.getMessage());
 		}
 		
-		if(list != null) {
+		if (list != null) {
 			list = checkVulnData(list, nicknameList);
 			list = list.stream().filter(CommonFunction.distinctByKey(e -> e.getCveId())).collect(Collectors.toList());
 		}
@@ -3573,13 +3573,13 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 	private List<Vulnerability> checkVulnData(List<Vulnerability> list, String[] nicknameList) {
 		List<Vulnerability> result = new ArrayList<Vulnerability>();
 		
-		for(Vulnerability bean : list) {
+		for (Vulnerability bean : list) {
 			bean.setOssNameAllSearchFlag(CoConstDef.FLAG_YES);
-			if(nicknameList != null) {
+			if (nicknameList != null) {
 				bean.setOssNicknames(nicknameList);
 			}
 			int vulnCnt = vulnerabilityMapper.checkVulnDataCnt(bean);
-			if(vulnCnt > 0) {
+			if (vulnCnt > 0) {
 				result.add(bean);
 			}
 		}
@@ -3589,7 +3589,7 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 
 	@Override
 	public List<String> getOssNicknameListWithoutOwn(OssMaster ossMaster, List<String> checkList, List<String> duplicatedList) {
-		if(checkList != null && checkList.size() > 0) {
+		if (checkList != null && checkList.size() > 0) {
 			List<OssMaster> ossNameCheckList = ossMapper.selectOssNameList();
 			ossNameCheckList = ossNameCheckList.stream()
 							.filter(e -> checkList.stream().anyMatch(Predicate.isEqual(e.getOssName())))
@@ -3600,17 +3600,17 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 								.filter(e -> checkList.stream().anyMatch(Predicate.isEqual(e.getOssNickname())))
 								.collect(Collectors.toList());
 			
-			if(ossNameCheckList != null && ossNameCheckList.size() > 0) {
-				for(OssMaster om : ossNameCheckList) {
-					if(duplicatedList.isEmpty() || !duplicatedList.contains(om.getOssName())) {
+			if (ossNameCheckList != null && ossNameCheckList.size() > 0) {
+				for (OssMaster om : ossNameCheckList) {
+					if (duplicatedList.isEmpty() || !duplicatedList.contains(om.getOssName())) {
 						duplicatedList.add(om.getOssName());
 					}
 				}
 			}
 			
-			if(ossNicknameCheckList != null && ossNicknameCheckList.size() > 0) {
-				for(OssMaster om : ossNicknameCheckList) {
-					if(duplicatedList.isEmpty() || !duplicatedList.contains(om.getOssNickname())) {
+			if (ossNicknameCheckList != null && ossNicknameCheckList.size() > 0) {
+				for (OssMaster om : ossNicknameCheckList) {
+					if (duplicatedList.isEmpty() || !duplicatedList.contains(om.getOssNickname())) {
 						duplicatedList.add(om.getOssNickname());
 					}
 				}
@@ -3727,8 +3727,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 		List<String> checkOssNameUrl = CoCodeManager.getCodeNames(CoConstDef.CD_CHECK_OSS_NAME_URL);
 		int urlSearchSeq = -1;
 		int seq = 0;
-		for(String url : checkOssNameUrl) {
-			if(urlSearchSeq == -1 && paramBean.getDownloadLocation().contains(url)) {
+		for (String url : checkOssNameUrl) {
+			if (urlSearchSeq == -1 && paramBean.getDownloadLocation().contains(url)) {
 				urlSearchSeq = seq;
 				break;
 			}

--- a/src/main/java/oss/fosslight/service/impl/PartnerServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/PartnerServiceImpl.java
@@ -76,13 +76,13 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		//파트너 와쳐
 		List<PartnerWatcher> watcher = partnerMapper.selectPartnerWatcher(partnerMaster);
 		
-		if(watcher != null){
+		if (watcher != null){
 			result.setPartnerWatcher(watcher);	
 		}
 		String partnerId = "3rd_" + result.getPartnerId();
 		int resultCnt = partnerMapper.getOssAnalysisDataCnt(partnerId);
 		
-		if(resultCnt > 0) {
+		if (resultCnt > 0) {
 			PartnerMaster analysisStatus = partnerMapper.getOssAnalysisData(partnerId);
 			
 			result.setAnalysisStartDate(analysisStatus.getAnalysisStartDate());
@@ -101,11 +101,11 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		partnerMaster.setTotListSize(records);
 		List<PartnerMaster> list = partnerMapper.selectPartnerList(partnerMaster);
 		
-		if(list != null) {
-			for(PartnerMaster bean : list) {
+		if (list != null) {
+			for (PartnerMaster bean : list) {
 				OssMaster nvdMaxScoreInfo = projectMapper.findIdentificationMaxNvdInfo(bean.getPartnerId(), CoConstDef.CD_DTL_COMPONENT_PARTNER);
 				
-				if(nvdMaxScoreInfo != null) {
+				if (nvdMaxScoreInfo != null) {
 					bean.setCveId(nvdMaxScoreInfo.getCveId());
 					bean.setCvssScore(nvdMaxScoreInfo.getCvssScore());
 					bean.setVulnYn(nvdMaxScoreInfo.getVulnYn());
@@ -194,9 +194,9 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 	@CacheEvict(value="autocompletePartnerCache", allEntries=true)
 	public void registPartnerMaster(PartnerMaster partnerMaster, List<ProjectIdentification> ossComponents, List<List<ProjectIdentification>> ossComponentsLicense) {		
 		//파트너 마스터 테이블
-		if(partnerMaster.getPartnerId() != null) {
+		if (partnerMaster.getPartnerId() != null) {
 			// admin이 아니라면 creator를 변경하지 않는다.
-			if(!CommonFunction.isAdmin()) {
+			if (!CommonFunction.isAdmin()) {
 				partnerMaster.setCreator(null);
 			}
 		} else {
@@ -214,9 +214,9 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		
 		String[] delDocumentsFile = partnerMaster.getDelDocumentsFile().split(",");
 		
-		if(delDocumentsFile.length > 0){
-			for(String fileSeq : delDocumentsFile){
-				if(!isEmpty(fileSeq)) {
+		if (delDocumentsFile.length > 0){
+			for (String fileSeq : delDocumentsFile){
+				if (!isEmpty(fileSeq)) {
 					T2File delFile = new T2File();
 					delFile.setFileSeq(fileSeq);
 					delFile.setGubn("A");
@@ -229,17 +229,17 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		
 		PartnerMaster beforePartner =  partnerMapper.selectPartnerMaster(partnerMaster);
 		
-		if(beforePartner != null) {
-			if(!isEmpty(beforePartner.getConfirmationFileId())) {
-				if(partnerMaster.getConfirmationFileId() == null || !partnerMaster.getConfirmationFileId().equals(beforePartner.getConfirmationFileId())) {
+		if (beforePartner != null) {
+			if (!isEmpty(beforePartner.getConfirmationFileId())) {
+				if (partnerMaster.getConfirmationFileId() == null || !partnerMaster.getConfirmationFileId().equals(beforePartner.getConfirmationFileId())) {
 					T2File delFile = new T2File();
 					delFile.setFileSeq(beforePartner.getConfirmationFileId());
 					fileService.deletePhysicalFile(delFile, "PARTNER");
 				}
 			}
 			
-			if(!isEmpty(beforePartner.getOssFileId())) {
-				if(partnerMaster.getOssFileId() == null || !partnerMaster.getOssFileId().equals(beforePartner.getOssFileId())) {
+			if (!isEmpty(beforePartner.getOssFileId())) {
+				if (partnerMaster.getOssFileId() == null || !partnerMaster.getOssFileId().equals(beforePartner.getOssFileId())) {
 					T2File delFile = new T2File();
 					delFile.setFileSeq(beforePartner.getOssFileId());
 					fileService.deletePhysicalFile(delFile, "PARTNER");
@@ -253,23 +253,23 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		deleteparam.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_PARTNER);
 		List<OssComponents> componentsId = projectMapper.selectComponentId(deleteparam);
 		
-		for(int j = 0; j < componentsId.size(); j++){
+		for (int j = 0; j < componentsId.size(); j++){
 			projectMapper.deleteOssComponentsLicense(componentsId.get(j));
 		}
 		
 		ossComponents =  projectService.convertOssNickName(ossComponents);
 		ossComponentsLicense = projectService.convertLicenseNickName(ossComponentsLicense);
 		
-		for(ProjectIdentification bean : ossComponents) {
+		for (ProjectIdentification bean : ossComponents) {
 			bean.setObligationType(bean.getObligationLicense());
 			bean.setBomWithAndroidFlag(CoConstDef.FLAG_YES);
 			
-			if(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(bean.getObligationLicense())) {
-				if(CoConstDef.FLAG_YES.equals(bean.getSource())) {
+			if (CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(bean.getObligationLicense())) {
+				if (CoConstDef.FLAG_YES.equals(bean.getSource())) {
 					bean.setObligationType(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
-				} else if(CoConstDef.FLAG_YES.equals(bean.getNotify())) {
+				} else if (CoConstDef.FLAG_YES.equals(bean.getNotify())) {
 					bean.setObligationType(CoConstDef.CD_DTL_OBLIGATION_NOTICE);
-				} else if(CoConstDef.FLAG_NO.equals(bean.getNotify()) && CoConstDef.FLAG_NO.equals(bean.getSource())) {
+				} else if (CoConstDef.FLAG_NO.equals(bean.getNotify()) && CoConstDef.FLAG_NO.equals(bean.getSource())) {
 					bean.setObligationType(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK_SELECTED);
 				} else {
 					bean.setObligationType(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK);
@@ -292,36 +292,36 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 			
 			// oss_id를 다시 찾는다. (oss name과 oss id가 일치하지 않는 경우가 있을 수 있음)
 			bean = CommonFunction.findOssIdAndName(bean);
-			if(isEmpty(bean.getOssId())) {
+			if (isEmpty(bean.getOssId())) {
 				bean.setOssId(null);
 			}
 			
 			String downloadLocationUrl = bean.getDownloadLocation();
 			String homepageUrl = bean.getHomepage();
 			
-			if(!isEmpty(downloadLocationUrl)) {
-				if(downloadLocationUrl.endsWith("/")) {
+			if (!isEmpty(downloadLocationUrl)) {
+				if (downloadLocationUrl.endsWith("/")) {
 					bean.setDownloadLocation(downloadLocationUrl.substring(0, downloadLocationUrl.length()-1));
 				}
 			}
 			
-			if(!isEmpty(homepageUrl)) {
-				if(homepageUrl.endsWith("/")) {
+			if (!isEmpty(homepageUrl)) {
+				if (homepageUrl.endsWith("/")) {
 					bean.setHomepage(homepageUrl.substring(0, homepageUrl.length()-1));
 				}
 			}
 			
 			//update
-			if(!StringUtil.contains(bean.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
+			if (!StringUtil.contains(bean.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
 				//ossComponents 등록
 				projectMapper.updateSrcOssList(bean);
 				deleteRows.add(bean.getComponentId());
 				
 				//멀티라이센스일 경우
-				if("M".equals(bean.getLicenseDiv())){
+				if ("M".equals(bean.getLicenseDiv())){
 					for (List<ProjectIdentification> comLicenseList : ossComponentsLicense) {
 						for (ProjectIdentification comLicense : comLicenseList) {
-							if(bean.getComponentId().equals(comLicense.getComponentId())){
+							if (bean.getComponentId().equals(comLicense.getComponentId())){
 								OssComponentsLicense license = new OssComponentsLicense();
 								// 컴포넌트 ID 설정
 								license.setComponentId(comLicense.getComponentId());
@@ -376,18 +376,18 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 				deleteRows.add(bean.getComponentId());
 				
 				//멀티라이센스일 경우
-				if("M".equals(bean.getLicenseDiv())){
+				if ("M".equals(bean.getLicenseDiv())){
 					for (List<ProjectIdentification> comLicenseList : ossComponentsLicense) {
 						for (ProjectIdentification comLicense : comLicenseList) {
 							String gridId = comLicense.getGridId();
 							
-							if(isEmpty(gridId)) {
+							if (isEmpty(gridId)) {
 								continue;
 							}
 							
 							gridId = gridId.split("-")[0];
 							
-							if(exComponentId.equals(comLicense.getComponentId())
+							if (exComponentId.equals(comLicense.getComponentId())
 									|| exComponentId.equals(gridId)){
 								OssComponentsLicense license = new OssComponentsLicense();
 								// 컴포넌트 ID 설정
@@ -450,7 +450,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		projectMapper.deleteOssComponentsWithIds(param);
 		
 		// delete and insert
-		if(isNew) {
+		if (isNew) {
 			// partner watcher insert
 			ArrayList<Map<String, String>> divisionList = new ArrayList<Map<String, String>>();
 			ArrayList<Map<String, String>> emailList = new ArrayList<Map<String, String>>();
@@ -462,9 +462,9 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 					Map<String, String> m = new HashMap<String, String>();
 					arr = watcher.split("\\/");
 
-					if(!"Email".equals(arr[1])) {
+					if (!"Email".equals(arr[1])) {
 						partnerMaster.setParDivision(arr[0]);
-						if(arr.length > 1){
+						if (arr.length > 1){
 							partnerMaster.setParUserId(arr[1]);
 						}else{
 							partnerMaster.setParUserId("");
@@ -487,7 +487,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 
 					List<PartnerMaster> watcherList = partnerMapper.selectWatchersCheck(partnerMaster);
 					
-					if(watcherList.size() == 0){
+					if (watcherList.size() == 0){
 						partnerMapper.registPartnerWatcher(partnerMaster);
 					}
 				}
@@ -515,7 +515,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		//ossComponents
 		List<OssComponents> componentId = partnerMapper.selectComponentId(partnerMaster.getPartnerId());
 		
-		for(int i = 0; i<componentId.size(); i++){
+		for (int i = 0; i<componentId.size(); i++){
 			partnerMapper.deleteOssComponentsLicense(componentId.get(i));
 		}
 		
@@ -544,9 +544,9 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 	public void changeStatus(PartnerMaster partnerMaster) {
 		CoMail mailBean = null;
 		
-		if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(partnerMaster.getStatus())) {
+		if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(partnerMaster.getStatus())) {
 			PartnerMaster orgPartnerMaster = partnerMapper.selectPartnerMaster(partnerMaster);
-			if(isEmpty(orgPartnerMaster.getReviewer())) {
+			if (isEmpty(orgPartnerMaster.getReviewer())) {
 				partnerMaster.setReviewer(partnerMaster.getLoginUserName());
 				mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PARTER_REVIEWER_CHANGED);
 				mailBean.setToIds(new String[] {partnerMaster.getLoginUserName()});
@@ -556,7 +556,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		
 		partnerMapper.changeStatus(partnerMaster);
 		
-		if(mailBean != null) {
+		if (mailBean != null) {
 			try {
 				CoMailManager.getInstance().sendMail(mailBean);
 			} catch (Exception e) {
@@ -575,11 +575,11 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 	public String checkViewOnly(String partnerId) {
 		String rtnFlag = CoConstDef.FLAG_NO;
 		
-		if(!CommonFunction.isAdmin()) {
+		if (!CommonFunction.isAdmin()) {
 			PartnerMaster param = new PartnerMaster();
 			param.setPartnerId(partnerId);
 			
-			if(partnerMapper.checkWatcherAuth(param) == 0) {
+			if (partnerMapper.checkWatcherAuth(param) == 0) {
 				rtnFlag = CoConstDef.FLAG_YES;
 			}
 		}
@@ -589,9 +589,9 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 
 	@Override
 	public void addWatcher(PartnerMaster project) {
-		if(!isEmpty(project.getParEmail())) {
+		if (!isEmpty(project.getParEmail())) {
 			// 이미 추가된 watcher 체크
-			if(partnerMapper.existsWatcherByEmail(project) == 0) {
+			if (partnerMapper.existsWatcherByEmail(project) == 0) {
 				// watcher 추가
 				partnerMapper.insertWatcher(project);
 				
@@ -609,7 +609,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 			}
 		} else {
 			// 이미 추가된 watcher 체크
-			if(partnerMapper.existsWatcherByUser(project) == 0) {
+			if (partnerMapper.existsWatcherByUser(project) == 0) {
 				// watcher 추가
 				partnerMapper.insertWatcher(project);
 			}
@@ -641,7 +641,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		
 		int i = partnerMapper.existsWatcher(project);
 		
-		if(i > 0){
+		if (i > 0){
 			result = true;
 		}	
 		
@@ -659,7 +659,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		PartnerMaster partnerInfo = new PartnerMaster();
 		T2CoProjectValidator pv = new T2CoProjectValidator();
 		
-		if(prjBean.getPartnerId() == null){
+		if (prjBean.getPartnerId() == null){
 			partnerInfo.setPartnerId(prjBean.getReferenceId());
 		}else{
 			partnerInfo.setPartnerId(prjBean.getPartnerId());
@@ -683,16 +683,16 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 
 			T2CoValidationResult vr = pv.validate(new HashMap<>());
 			
-			if(!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+			if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
 				partnerList.replace("mainData", CommonFunction.identificationSortByValidInfo(
 						(List<ProjectIdentification>) partnerList.get("mainData"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false, true));
-				if(!vr.isValid()) {
+				if (!vr.isValid()) {
 					partnerList.put("validData", vr.getValidMessageMap());
 				}
-				if(!vr.isDiff()) {
+				if (!vr.isDiff()) {
 					partnerList.put("diffData", vr.getDiffMessageMap());
 				}
-				if(vr.hasInfo()) {
+				if (vr.hasInfo()) {
 					partnerList.put("infoData", vr.getInfoMessageMap());
 				}
 			}
@@ -709,11 +709,11 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		List<String> duplicateList = new ArrayList<>();
 		List<String> componentIdList = new ArrayList<>();
 		
-		if(errorMap != null) {
-			for(ProjectIdentification prjBean : mainData) {
+		if (errorMap != null) {
+			for (ProjectIdentification prjBean : mainData) {
 				String checkKey = prjBean.getOssName() + "_" + prjBean.getOssVersion();
 				// 중복된 oss Info는 제외함.
-				if(duplicateList.contains(checkKey)) {
+				if (duplicateList.contains(checkKey)) {
 					continue;
 				}
 				
@@ -721,7 +721,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 				String ossNameErrorMsg = errorMap.containsKey("ossName."+componentId) ? errorMap.get("ossName."+componentId) : "";
 				String ossVersionErrorMsg = errorMap.containsKey("ossVersion."+componentId) ? errorMap.get("ossVersion."+componentId) : "";
 				
-				if(ossNameErrorMsg.indexOf("Unconfirmed") > -1 
+				if (ossNameErrorMsg.indexOf("Unconfirmed") > -1 
 						|| ossVersionErrorMsg.indexOf("Unconfirmed") > -1) {
 					duplicateList.add(checkKey);
 					componentIdList.add(componentId);
@@ -742,13 +742,13 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		
 		boolean isLoadFromProject = isEmpty(identification.getReferenceId()) && !isEmpty(identification.getRefPrjId());
 		
-		if(isLoadFromProject) {
+		if (isLoadFromProject) {
 			identification.setReferenceId(identification.getRefPrjId());
 		}
 		
 		boolean isApplyFromBat = isEmpty(identification.getReferenceId()) && !isEmpty(identification.getRefBatId());
 		
-		if(isApplyFromBat) {
+		if (isApplyFromBat) {
 			identification.setReferenceId(identification.getRefBatId());
 		}
 			
@@ -756,7 +756,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 			
 		list = projectMapper.selectIdentificationGridList(identification);
 		
-		if(list != null && !list.isEmpty()) {
+		if (list != null && !list.isEmpty()) {
 
 			ProjectIdentification param = new ProjectIdentification();
 			param.setReferenceDiv(identification.getReferenceDiv());
@@ -764,15 +764,15 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 			OssMaster ossParam = new OssMaster();
 			
 			// components license 정보를 한번에 가져온다
-			for(ProjectIdentification bean : list) {
+			for (ProjectIdentification bean : list) {
 				param.addComponentIdList(bean.getComponentId());
 				
-				if(!isEmpty(bean.getOssId())) {
+				if (!isEmpty(bean.getOssId())) {
 					ossParam.addOssIdList(bean.getOssId());
 				}
 				
 				// oss Name은 작성하고, oss Version은 작성하지 않은 case경우 해당 분기문에서 처리
-				if(isEmpty(bean.getCveId()) 
+				if (isEmpty(bean.getCveId()) 
 						&& isEmpty(bean.getOssVersion()) 
 						&& !isEmpty(bean.getCvssScoreMax())
 						&& !("-".equals(bean.getOssName()))){ 
@@ -785,15 +785,15 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 			// oss id로 oss master에 등록되어 있는 라이선스 정보를 취득
 			Map<String, OssMaster> componentOssInfoMap = null;
 			
-			if(ossParam.getOssIdList() != null && !ossParam.getOssIdList().isEmpty()) {
+			if (ossParam.getOssIdList() != null && !ossParam.getOssIdList().isEmpty()) {
 				componentOssInfoMap = ossService.getBasicOssInfoListById(ossParam);
 			}
 				
 			List<ProjectIdentification> licenseList = projectMapper.identificationSubGrid(param);
 			
-			for(ProjectIdentification licenseBean : licenseList) {
-				for(ProjectIdentification bean : list) {
-					if(licenseBean.getComponentId().equals(bean.getComponentId())) {
+			for (ProjectIdentification licenseBean : licenseList) {
+				for (ProjectIdentification bean : list) {
+					if (licenseBean.getComponentId().equals(bean.getComponentId())) {
 						// 수정가능 여부 초기설정
 						licenseBean.setEditable(CoConstDef.FLAG_YES);
 						bean.addComponentLicenseList(licenseBean);
@@ -803,32 +803,32 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 			}
 
 			// license 정보 등록
-			for(ProjectIdentification bean : list) {
-				if(bean.getComponentLicenseList()!=null){
+			for (ProjectIdentification bean : list) {
+				if (bean.getComponentLicenseList()!=null){
 					String licenseCopy = "";
 						
 					// multi dual 라이선스의 경우, main row에 표시되는 license 정보는 OSS List에 등록되어진 라이선스를 기준으로 표시한다.
 					// ossId가 없는 경우는 기본적으로 subGrid로 등록될 수 없다
 					// 이짓거리를 하는 두번째 이유는, subgrid 에서 사용자가 추가한 라이선스와 oss 에 등록되어 있는 라이선스를 구분하기 위함
-					if(componentOssInfoMap == null) {
+					if (componentOssInfoMap == null) {
 						componentOssInfoMap = new HashMap<>();
 					}
 					
 					OssMaster ossBean = componentOssInfoMap.get(bean.getOssId());
 						
-					if(ossBean != null
+					if (ossBean != null
 							&& CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())
 							&& ossBean.getOssLicenses() != null && !ossBean.getOssLicenses().isEmpty()) {
-						for(OssLicense ossLicenseBean : ossBean.getOssLicenses()) {
-							if(!isEmpty(ossLicenseBean.getOssCopyright())) {
+						for (OssLicense ossLicenseBean : ossBean.getOssLicenses()) {
+							if (!isEmpty(ossLicenseBean.getOssCopyright())) {
 								licenseCopy += (!isEmpty(licenseCopy) ? "\r\n" : "") + ossLicenseBean.getOssCopyright();
 							}
 								
 							//삭제 불가 처리
-							for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+							for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
 								// license index 까지 비교하는 이유는
 								// multi dual 혼용인 경우, 동일한 라이선스가 두번 등록 될 수 있기 때문
-								if(ossLicenseBean.getLicenseId().equals(licenseBean.getLicenseId()) 
+								if (ossLicenseBean.getLicenseId().equals(licenseBean.getLicenseId()) 
 										&& ossLicenseBean.getOssLicenseIdx().equals(licenseBean.getRnum())) {
 									licenseBean.setEditable(CoConstDef.FLAG_NO);
 									break;
@@ -839,8 +839,8 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 						bean.setLicenseName(CommonFunction.makeLicenseExpressionIdentify(bean.getComponentLicenseList(), ","));
 					} else {
 						// license text는 표시하지 않기 때문에 설정할 필요는 없음
-						for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
-							if(!isEmpty(licenseBean.getCopyrightText())) {
+						for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+							if (!isEmpty(licenseBean.getCopyrightText())) {
 								licenseCopy += (!isEmpty(licenseCopy) ? "\r\n" : "") + licenseBean.getCopyrightText();
 							}
 						}
@@ -860,21 +860,21 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 			}
 			
 			// 다른 프로젝트에서 load한 경우 component id 초기화
-			if(isLoadFromProject || isApplyFromBat) {
+			if (isLoadFromProject || isApplyFromBat) {
 				subMap = new HashMap<>();
 
 				// refproject id + "p" + componentid 로 component_id를 재생성 하고, 
 				// license 의 경우 재성생한 component_id + 기존 license grid_id의 component_license_id 부분을 결합
-				for(ProjectIdentification bean : list) {
-					if(isLoadFromProject) {
+				for (ProjectIdentification bean : list) {
+					if (isLoadFromProject) {
 						bean.setRefPrjId(identification.getRefPrjId());
-					} else if(isApplyFromBat) {
+					} else if (isApplyFromBat) {
 						bean.setRefBatId(identification.getRefBatId());
 					}
 						
 					String _compId = CoConstDef.GRID_NEWROW_DEFAULT_PREFIX;
 					
-					if(isLoadFromProject) {
+					if (isLoadFromProject) {
 						_compId += identification.getRefPrjId();
 					} else if (isApplyFromBat) {
 						_compId += identification.getRefBatId();
@@ -885,8 +885,8 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 					bean.setComponentId("");
 					bean.setGridId(_compId);
 
-					if(bean.getComponentLicenseList()!=null){
-						for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+					if (bean.getComponentLicenseList()!=null){
+						for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
 							licenseBean.setComponentId("");
 							licenseBean.setGridId(_compId + "-"+ licenseBean.getComponentLicenseId());
 						}
@@ -899,13 +899,13 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 			
 		// 편집중인 data 가 존재할 경우 append 한다.
 		{
-			if(identification.getMainDataGridList() != null) {
-				for(ProjectIdentification bean : identification.getMainDataGridList()) {
+			if (identification.getMainDataGridList() != null) {
+				for (ProjectIdentification bean : identification.getMainDataGridList()) {
 					//멀티라이센스일 경우
-					if(CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())){
+					if (CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())){
 						for (List<ProjectIdentification> comLicenseList : identification.getSubDataGridList()) {
 							for (ProjectIdentification comLicense : comLicenseList) {
-								if(bean.getComponentId().equals(comLicense.getComponentId())){
+								if (bean.getComponentId().equals(comLicense.getComponentId())){
 									bean.addComponentLicenseList(comLicense);
 								}
 							}
@@ -922,7 +922,7 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 					}
 				}
 
-				for(ProjectIdentification bean : identification.getMainDataGridList()) {
+				for (ProjectIdentification bean : identification.getMainDataGridList()) {
 					list.add(0, bean);
 					subMap.put(bean.getGridId(), bean.getComponentLicenseList());
 				}
@@ -933,8 +933,8 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		List<ProjectIdentification> newSortList = new ArrayList<>();
 		List<ProjectIdentification> excludeList = new ArrayList<>();
 		
-		for(ProjectIdentification bean : list) {
-			if(CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+		for (ProjectIdentification bean : list) {
+			if (CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 				excludeList.add(bean);
 			} else {
 				newSortList.add(bean);
@@ -965,11 +965,11 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 		String division = partnerMaster.getParDivision();
 		String comment = "";
 		
-		for(String partnerId : partnerMaster.getPartnerIds()) {
+		for (String partnerId : partnerMaster.getPartnerIds()) {
 			param.setPartnerId(partnerId);
 			PartnerMaster beforeBean = getPartnerMasterOne(param);
 			
-			if(!avoidNull(beforeBean.getDivision(), "").equals(division)) {
+			if (!avoidNull(beforeBean.getDivision(), "").equals(division)) {
 				PartnerMaster afterBean = getPartnerMasterOne(param);
 				afterBean.setDivision(division);
 				
@@ -984,11 +984,11 @@ public class PartnerServiceImpl extends CoTopComponent implements PartnerService
 			}
 		}
 		
-		if(!beforeBeanList.isEmpty()) {
+		if (!beforeBeanList.isEmpty()) {
 			updatePartnerDivMap.put("before", beforeBeanList);
 		}
 		
-		if(!afterBeanList.isEmpty()) {
+		if (!afterBeanList.isEmpty()) {
 			updatePartnerDivMap.put("after", afterBeanList);
 		}
 		

--- a/src/main/java/oss/fosslight/service/impl/ProcessGuideServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProcessGuideServiceImpl.java
@@ -30,7 +30,7 @@ public class ProcessGuideServiceImpl extends CoTopComponent implements ProcessGu
 		Map<String, Object> map = null;
 		int records = processGuideMapper.selectProcessGuideTotalCount(vo);
 		
-		if(records > 0) {
+		if (records > 0) {
 			vo.setTotListSize(records);
 			// Grid paging 처리를 위한 기본 param 설정 Map 생성(반드시 totlistsize를 set 하고 나서 생성해야함)
 			map = getGridPagerMap(vo);
@@ -53,10 +53,10 @@ public class ProcessGuideServiceImpl extends CoTopComponent implements ProcessGu
 		Map<String, Object> map = new HashMap<String, Object>();
 		int records = processGuideMapper.selectProcessGuideCount(vo);
 		
-		if(records > 0) {
+		if (records > 0) {
 			ProcessGuide guide = processGuideMapper.selectProcessGuide(vo);
 			
-			if(guide != null) {
+			if (guide != null) {
 				map.put("processGuide", guide);
 			}
 		}

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -126,10 +126,10 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 		try {
 			// OSS NAME으로 검색하는 경우 NICK NAME을 포함하도록 추가
-			if(!isEmpty(project.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(project.getOssName().toUpperCase())) {
+			if (!isEmpty(project.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(project.getOssName().toUpperCase())) {
 				String[] nickNames = ossService.getOssNickNameListByOssName(project.getOssName());
 				
-				if(nickNames != null && nickNames.length > 0) {
+				if (nickNames != null && nickNames.length > 0) {
 					project.setOssNickNames(nickNames);
 				}
 			}
@@ -141,20 +141,20 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			if (!StringUtil.isEmpty(ossId)) {
 				list = projectMapper.selectUnlimitedOssComponentBomList(project);
 			} else {
-				if(CommonFunction.propertyFlagCheck("menu.bat.use.flag", CoConstDef.FLAG_NO)) {
+				if (CommonFunction.propertyFlagCheck("menu.bat.use.flag", CoConstDef.FLAG_NO)) {
 					project.setIdentificationSubStatusBat(CoConstDef.FLAG_NO);
 				}
 				
 				list = projectMapper.selectProjectList(project);
 				
-				if(list != null) {
+				if (list != null) {
 					// 코드변환처리
-					for(Project bean : list) {
+					for (Project bean : list) {
 						// DISTRIBUTION Android Flag
 						String androidFlag = CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equalsIgnoreCase(avoidNull(bean.getNoticeType())) ? CoConstDef.FLAG_YES : CoConstDef.FLAG_NO;
 						bean.setAndroidFlag(androidFlag);
 						
-						if(CoConstDef.FLAG_YES.equals(androidFlag)) {
+						if (CoConstDef.FLAG_YES.equals(androidFlag)) {
 							bean.setNoticeTypeEtc(CommonFunction.tabTitleSubStr(CoConstDef.CD_PLATFORM_GENERATED, bean.getNoticeTypeEtc()));
 						}
 						
@@ -177,7 +177,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						
 						OssMaster nvdMaxScoreInfo = projectMapper.findIdentificationMaxNvdInfo(bean.getPrjId(), null);
 						
-						if(nvdMaxScoreInfo != null) {
+						if (nvdMaxScoreInfo != null) {
 							bean.setCveId(nvdMaxScoreInfo.getCveId());
 							bean.setCvssScore(nvdMaxScoreInfo.getCvssScore());
 							bean.setVulnYn(nvdMaxScoreInfo.getVulnYn());
@@ -204,7 +204,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		// 이전에 생성된 프로젝트를 위해 Default를 설정한다.
 		Map<String, Object> NoticeInfo = projectMapper.getNoticeType(project.getPrjId());
-		if(NoticeInfo == null) {
+		if (NoticeInfo == null) {
 			NoticeInfo = new HashMap<>();
 		}
 		project.setNoticeType(avoidNull((String) NoticeInfo.get("noticeType"), CoConstDef.CD_DTL_NOTICE_TYPE_GENERAL));
@@ -221,16 +221,16 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		project.setAndroidNoticeFile(projectMapper.selectAndroidNoticeFile(project));
 		project.setAndroidResultFile(projectMapper.selectAndroidResultFile(project));
 		
-		if(!isEmpty(project.getBinCsvFileId())) {
+		if (!isEmpty(project.getBinCsvFileId())) {
 			project.setBinCsvFile(projectMapper.selectFileInfoById(project.getBinCsvFileId()));
 		}
 		
-		if(!isEmpty(project.getBinBinaryFileId())) {
+		if (!isEmpty(project.getBinBinaryFileId())) {
 			project.setBinBinaryFile(projectMapper.selectFileInfoById(project.getBinBinaryFileId()));
 		}
 
 		//  button(삭제/복사/저장) view 여부
-		if(CommonFunction.isAdmin()) {
+		if (CommonFunction.isAdmin()) {
 			project.setViewOnlyFlag(CoConstDef.FLAG_NO);
 		} else {
 			project.setViewOnlyFlag(projectMapper.selectViewOnlyFlag(project));
@@ -238,7 +238,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		int resultCnt = projectMapper.getOssAnalysisDataCnt(project);
 		
-		if(resultCnt > 0) {
+		if (resultCnt > 0) {
 			Project analysisStatus = projectMapper.getOssAnalysisData(project);
 			project.setAnalysisStartDate(analysisStatus.getAnalysisStartDate());
 			project.setOssAnalysisStatus(analysisStatus.getOssAnalysisStatus());
@@ -260,19 +260,19 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 		identification.setRoleOutLicense(CoCodeManager.CD_ROLE_OUT_LICENSE);
 		
-		if(CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST != null && !CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST.isEmpty()) {
+		if (CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST != null && !CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST.isEmpty()) {
 			identification.setRoleOutLicenseIdList(CoCodeManager.CD_ROLE_OUT_LICENSE_ID_LIST);
 		}
 		
 		boolean isLoadFromProject = isEmpty(identification.getReferenceId()) && !isEmpty(identification.getRefPrjId());
 		
-		if(isLoadFromProject) {
+		if (isLoadFromProject) {
 			identification.setReferenceId(identification.getRefPrjId());
 		}
 		
 		boolean isApplyFromBat = isEmpty(identification.getReferenceId()) && !isEmpty(identification.getRefBatId());
 		
-		if(isApplyFromBat) {
+		if (isApplyFromBat) {
 			identification.setReferenceId(identification.getRefBatId());
 		}
 
@@ -315,12 +315,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			// bom merge 버튼을 클릭하고, 표시대상이 있을 경우, 기존에 저장되어 있는 내용을 취득한다.
 			// need check의 저장값을 유지하기 위함
-			if(CoConstDef.FLAG_YES.equals(reqMergeFlag) && list != null && !list.isEmpty()) {
+			if (CoConstDef.FLAG_YES.equals(reqMergeFlag) && list != null && !list.isEmpty()) {
 				identification.setMerge(CoConstDef.FLAG_NO);
 				List<ProjectIdentification> bomBeforeList = projectMapper.selectBomList(identification);
 				
-				if(bomBeforeList != null) {
-					for(ProjectIdentification _orgIdentificationBean : bomBeforeList) {
+				if (bomBeforeList != null) {
+					for (ProjectIdentification _orgIdentificationBean : bomBeforeList) {
 						obligationTypeMergeMap.put(_orgIdentificationBean.getRefComponentId(), _orgIdentificationBean.getObligationType());
 					}
 				}
@@ -340,8 +340,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				ll.setOssComponentsLicenseList(listLicense);
 				ll.setObligationLicense(CoConstDef.FLAG_YES.equals(ll.getAdminCheckYn()) ? CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK : CommonFunction.checkObligationSelectedLicense(listLicense));
 				
-				if(CoConstDef.FLAG_YES.equals(reqMergeFlag)) {
-					if(obligationTypeMergeMap.containsKey(ll.getComponentId())) {
+				if (CoConstDef.FLAG_YES.equals(reqMergeFlag)) {
+					if (obligationTypeMergeMap.containsKey(ll.getComponentId())) {
 						ll.setObligationType(obligationTypeMergeMap.get(ll.getComponentId()));
 					} else {
 						ll.setObligationType(ll.getObligationLicense());
@@ -351,14 +351,14 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				// grouping 된 file path를 br tag로 변경
 				ll.setFilePath(CommonFunction.lineReplaceToBR(ll.getFilePath()));
 				
-				if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(ll.getReferenceDiv())) {
-					if(!batMergeSrcMap.containsKey(ll.getOssName().toUpperCase())) {
+				if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(ll.getReferenceDiv())) {
+					if (!batMergeSrcMap.containsKey(ll.getOssName().toUpperCase())) {
 						batMergeSrcMap.put(ll.getOssName().toUpperCase(), ll);
-					} else if(StringUtil.compareTo(ll.getOssVersion(), batMergeSrcMap.get(ll.getOssName().toUpperCase()).getOssVersion()) > 0) {
+					} else if (StringUtil.compareTo(ll.getOssVersion(), batMergeSrcMap.get(ll.getOssName().toUpperCase()).getOssVersion()) > 0) {
 						batMergeSrcMap.replace(ll.getOssName().toUpperCase(), ll);
 					}
-				} else if(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(ll.getReferenceDiv())) {
-					if(!batMergePartnerMap.containsKey(ll.getOssName().toUpperCase())) {
+				} else if (CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(ll.getReferenceDiv())) {
+					if (!batMergePartnerMap.containsKey(ll.getOssName().toUpperCase())) {
 						batMergePartnerMap.put(ll.getOssName().toUpperCase(), ll);
 					} else if (StringUtil.compareTo(ll.getOssVersion(), batMergePartnerMap.get(ll.getOssName().toUpperCase()).getOssVersion()) > 0) {
 						batMergePartnerMap.replace(ll.getOssName().toUpperCase(), ll);
@@ -366,7 +366,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}
 				
 				// oss Name은 작성하고, oss Version은 작성하지 않은 case경우 해당 분기문에서 처리
-				if(isEmpty(ll.getCveId()) 
+				if (isEmpty(ll.getCveId()) 
 						&& isEmpty(ll.getOssVersion()) 
 						&& !isEmpty(ll.getCvssScoreMax())
 						&& !("-".equals(ll.getOssName()))){ 
@@ -388,31 +388,31 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			for (ProjectIdentification ll : list) {
 
 				// 이미 추가된 oss의 경우
-				if(egnoreList.contains(ll.getComponentId())) {
+				if (egnoreList.contains(ll.getComponentId())) {
 					continue;
 				}
 				
 				int addIdx = -1;
 				
-				if(!isEmpty(ll.getOssName())) {
+				if (!isEmpty(ll.getOssName())) {
 					String mergeKey = ll.getOssName().toUpperCase();
 					// main oss로 표시되는 bat oss의 version이 명시되어 있지 않은 경우
-					if(CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(ll.getReferenceDiv()) && isEmpty(ll.getMergePreDiv()) && isEmpty(ll.getOssVersion())) {
+					if (CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(ll.getReferenceDiv()) && isEmpty(ll.getMergePreDiv()) && isEmpty(ll.getOssVersion())) {
 						ProjectIdentification refBean = null;
 						
-						if( batMergeSrcMap.containsKey(mergeKey)) {
+						if ( batMergeSrcMap.containsKey(mergeKey)) {
 							// bat => src
 							refBean = batMergeSrcMap.get(mergeKey);
 							
 							// 설정된 license가 상이하고, bat와 동일한 license가 src에 존재한다면 (최상위 버전이 아닌경우)
 							// continue하고 다음 loop에서 merge
-							if(!CommonFunction.isSameLicense(refBean.getOssComponentsLicenseList(), ll.getOssComponentsLicenseList())) {
+							if (!CommonFunction.isSameLicense(refBean.getOssComponentsLicenseList(), ll.getOssComponentsLicenseList())) {
 								String ossNameAndVersion = findBatOssOtherVersionWithLicense(ll, refBean, list);
 								
-								if(!isEmpty(ossNameAndVersion)) {
+								if (!isEmpty(ossNameAndVersion)) {
 									List<ProjectIdentification> _batList = null;
 									
-									if(srcSameLicenseMap.containsKey(ossNameAndVersion)) {
+									if (srcSameLicenseMap.containsKey(ossNameAndVersion)) {
 										_batList = srcSameLicenseMap.get(ossNameAndVersion);
 										_batList.add(ll);
 										srcSameLicenseMap.replace(ossNameAndVersion, _batList);
@@ -434,11 +434,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 							// 순서 정렬
 							addIdx = findOssAppendIndex(CoConstDef.CD_DTL_COMPONENT_ID_SRC, refBean.getComponentId(), list);
 							
-							if(addIdx > -1) {
+							if (addIdx > -1) {
 								addIdx = addIdx +1;
 								ll.setGroupingColumn(refBean.getOssName() + refBean.getOssVersion());
 							}					
-						} else if( batMergePartnerMap.containsKey(mergeKey)) {
+						} else if ( batMergePartnerMap.containsKey(mergeKey)) {
 							// 3rd => bat
 							refBean = batMergePartnerMap.get(mergeKey);
 
@@ -450,12 +450,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 							
 							// bin 에 누락된 정보를 3rd의 첫번재 row에서 채워 넣는다.
 							// DOWNLOAD_LOCATION
-							if(isEmpty(ll.getDownloadLocation())) {
+							if (isEmpty(ll.getDownloadLocation())) {
 								ll.setDownloadLocation(refBean.getDownloadLocation());
 							}
 							
 							// HOMEPAGE
-							if(isEmpty(ll.getHomepage())) {
+							if (isEmpty(ll.getHomepage())) {
 								ll.setHomepage(refBean.getHomepage());
 							}
 							
@@ -470,16 +470,16 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 							// 3rd party의 우선순위가 가장 낮기 때문에, 복수건을 취득하는 경우는 없지만, 기능 확장을 고려해서 list 형으로 반환
 							groupList = findOssGroupList(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER, batMergePartnerMap.get(mergeKey).getOssName(), batMergePartnerMap.get(mergeKey).getOssVersion(), list);
 							
-							if(groupList != null && !groupList.isEmpty()) {
-								for(ProjectIdentification _groupBean : groupList) {
+							if (groupList != null && !groupList.isEmpty()) {
+								for (ProjectIdentification _groupBean : groupList) {
 									egnoreList.add(_groupBean.getComponentId());
 								}
 							}
 						}
 					} 
 					// 3rd party의 경우, bat에 동일한 oss가 없을 경우만 추가 (정렬)
-					else if(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(ll.getReferenceDiv()) && isEmpty(ll.getMergePreDiv()) ) {
-						if(existsBatOSS(ll.getOssName(), list)) {
+					else if (CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(ll.getReferenceDiv()) && isEmpty(ll.getMergePreDiv()) ) {
+						if (existsBatOSS(ll.getOssName(), list)) {
 							continue;
 						}
 					}
@@ -499,8 +499,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				// License Restriction 저장
 				ll.setRestriction(CommonFunction.setLicenseRestrictionListById(ll.getLicenseId()));
 
-				if(addIdx > -1) {
-					if(addIdx > _list.size() -1) {
+				if (addIdx > -1) {
+					if (addIdx > _list.size() -1) {
 						_list.add(ll);
 					} else {
 						_list.add(addIdx, ll);
@@ -508,26 +508,26 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				} else {
 					_list.add(ll);
 					
-					if(groupList != null && !groupList.isEmpty()) {
+					if (groupList != null && !groupList.isEmpty()) {
 						_list.addAll(groupList);
 					}
 				}
 				
-				if(CoConstDef.FLAG_YES.equals(ll.getAdminCheckYn())) {
+				if (CoConstDef.FLAG_YES.equals(ll.getAdminCheckYn())) {
 					adminCheckList.add(ll.getComponentId());
 				}
 			}
 			
 			// src oss중에서 bat와 merge할 수 있는 동일한 oss에 최신 version 외 라이선스까지 동일한 bat가 존재하는 경우
-			if(!srcSameLicenseMap.isEmpty()) {
+			if (!srcSameLicenseMap.isEmpty()) {
 				List<ProjectIdentification> _tmp = new ArrayList<>();
 				
-				for(ProjectIdentification bean : _list) {
+				for (ProjectIdentification bean : _list) {
 					_tmp.add(bean);
 					String _key = bean.getOssName() + "-" + avoidNull(bean.getOssVersion());
 					
-					if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(bean.getReferenceDiv()) && srcSameLicenseMap.containsKey(_key)) {
-						for(ProjectIdentification _mergeBean : srcSameLicenseMap.get(_key)) {
+					if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(bean.getReferenceDiv()) && srcSameLicenseMap.containsKey(_key)) {
+						for (ProjectIdentification _mergeBean : srcSameLicenseMap.get(_key)) {
 							_mergeBean.setOssId(bean.getOssId());
 							_mergeBean.setOssName(bean.getOssName());
 							_mergeBean.setOssVersion(bean.getOssVersion());
@@ -545,13 +545,13 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			Project param = new Project();
 			param.setPrjId(identification.getReferenceId());
 
-			if(avoidNull(getProjectDetail(param).getIdentificationStatus()).equals("CONF")){
+			if (avoidNull(getProjectDetail(param).getIdentificationStatus()).equals("CONF")){
 				List<ProjectIdentification> confList = new ArrayList<>();
-				for(ProjectIdentification bean : _list) {
+				for (ProjectIdentification bean : _list) {
 					String ossCopyright = findAddedOssCopyright(bean.getOssId(), bean.getLicenseId(), bean.getOssCopyright());
-					if(!isEmpty(ossCopyright)){
+					if (!isEmpty(ossCopyright)){
 						String addCopyright = avoidNull(bean.getCopyrightText());
-						if(!isEmpty(bean.getCopyrightText())) {
+						if (!isEmpty(bean.getCopyrightText())) {
 							addCopyright += "\n";
 						}
 						addCopyright += ossCopyright;
@@ -564,13 +564,13 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				map.put("rows", _list);
 			}
 
-			if(adminCheckList.size() > 0) {
+			if (adminCheckList.size() > 0) {
 				map.put("adminCheckList", adminCheckList);
 			}
 		} else { // bom 외 서브 그리드
 			// bat oss list를 대상
 			// 정렬 순서를 변경한다.
-			if(CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(identification.getReferenceDiv()) 
+			if (CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(identification.getReferenceDiv()) 
 					|| CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(identification.getReferenceDiv())
 					|| CoConstDef.CD_DTL_COMPONENT_BAT.equals(identification.getReferenceDiv())) {
 				identification.setSortAndroidFlag(CoConstDef.FLAG_YES);
@@ -579,7 +579,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			HashMap<String, Object> subMap = new HashMap<String, Object>();
 			
 			// src, bin, bin(android) 의 경우만 comment를 포함한다.
-			if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(identification.getReferenceDiv()) 
+			if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(identification.getReferenceDiv()) 
 					|| CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(identification.getReferenceDiv())
 					|| CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(identification.getReferenceDiv())) {
 				identification.setIncCommentsFlag(CoConstDef.FLAG_YES);
@@ -587,22 +587,22 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			list = projectMapper.selectIdentificationGridList(identification);
 			
-			if(list != null && !list.isEmpty()) {
-				for(ProjectIdentification project : list){
+			if (list != null && !list.isEmpty()) {
+				for (ProjectIdentification project : list){
 					String _test = project.getOssName().trim() + "_" + project.getOssVersion().trim();
 					String _test2 = project.getOssName().trim() + "_" + project.getOssVersion().trim() + ".0";
 					String licenseDiv = "";
 					
-					if(CoCodeManager.OSS_INFO_UPPER.containsKey(_test.toUpperCase())){
+					if (CoCodeManager.OSS_INFO_UPPER.containsKey(_test.toUpperCase())){
 						licenseDiv = CoCodeManager.OSS_INFO_UPPER.get(_test.toUpperCase()).getLicenseDiv(); 
-					} else if(CoCodeManager.OSS_INFO_UPPER.containsKey(_test2.toUpperCase())){
+					} else if (CoCodeManager.OSS_INFO_UPPER.containsKey(_test2.toUpperCase())){
 						licenseDiv = CoCodeManager.OSS_INFO_UPPER.get(_test2.toUpperCase()).getLicenseDiv();
 					}
 					
 					project.setLicenseDiv(licenseDiv);
 					
 					// oss Name은 작성하고, oss Version은 작성하지 않은 case경우 해당 분기문에서 처리
-					if(isEmpty(project.getCveId()) 
+					if (isEmpty(project.getCveId()) 
 							&& isEmpty(project.getOssVersion()) 
 							&& !isEmpty(project.getCvssScoreMax())
 							&& !("-".equals(project.getOssName()))){ 
@@ -616,10 +616,10 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				OssMaster ossParam = new OssMaster();
 				
 				// components license 정보를 한번에 가져온다
-				for(ProjectIdentification bean : list) {
+				for (ProjectIdentification bean : list) {
 					param.addComponentIdList(bean.getComponentId());
 					
-					if(!isEmpty(bean.getOssId())) {
+					if (!isEmpty(bean.getOssId())) {
 						ossParam.addOssIdList(bean.getOssId());
 					}
 				}
@@ -627,15 +627,15 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				// oss id로 oss master에 등록되어 있는 라이선스 정보를 취득
 				Map<String, OssMaster> componentOssInfoMap = null;
 				
-				if(ossParam.getOssIdList() != null && !ossParam.getOssIdList().isEmpty()) {
+				if (ossParam.getOssIdList() != null && !ossParam.getOssIdList().isEmpty()) {
 					componentOssInfoMap = ossService.getBasicOssInfoListById(ossParam);
 				}
 				
 				List<ProjectIdentification> licenseList = projectMapper.identificationSubGrid(param);
 				
-				for(ProjectIdentification licenseBean : licenseList) {
-					for(ProjectIdentification bean : list) {
-						if(licenseBean.getComponentId().equals(bean.getComponentId())) {
+				for (ProjectIdentification licenseBean : licenseList) {
+					for (ProjectIdentification bean : list) {
+						if (licenseBean.getComponentId().equals(bean.getComponentId())) {
 							// 수정가능 여부 초기설정
 							licenseBean.setEditable(CoConstDef.FLAG_YES);
 							bean.addComponentLicenseList(licenseBean);
@@ -646,15 +646,15 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}
 				
 				// license 정보 등록
-				for(ProjectIdentification bean : list) {
-					if(bean.getComponentLicenseList() != null) {
+				for (ProjectIdentification bean : list) {
+					if (bean.getComponentLicenseList() != null) {
 						//String licenseText = "";
 						String licenseCopy = "";
 						
 						// multi dual 라이선스의 경우, main row에 표시되는 license 정보는 OSS List에 등록되어진 라이선스를 기준으로 표시한다.
 						// ossId가 없는 경우는 기본적으로 subGrid로 등록될 수 없다
 						// 이짓거리를 하는 두번째 이유는, subgrid 에서 사용자가 추가한 라이선스와 oss 에 등록되어 있는 라이선스를 구분하기 위함
-						if(componentOssInfoMap == null) {
+						if (componentOssInfoMap == null) {
 							componentOssInfoMap = new HashMap<>();
 						}
 						
@@ -663,20 +663,20 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						// Restriction 대응을 위해 (BOM 외 추가) License Id를 콤마 구분으로 격납
 						String strLicenseIds = "";
 						
-						if(ossBean != null
+						if (ossBean != null
 								&& CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())
 								&& ossBean.getOssLicenses() != null && !ossBean.getOssLicenses().isEmpty()) {
-							for(OssLicense ossLicenseBean : ossBean.getOssLicenses()) {
+							for (OssLicense ossLicenseBean : ossBean.getOssLicenses()) {
 								
-								if(!isEmpty(ossLicenseBean.getOssCopyright())) {
+								if (!isEmpty(ossLicenseBean.getOssCopyright())) {
 									licenseCopy += (!isEmpty(licenseCopy) ? "\r\n" : "") + ossLicenseBean.getOssCopyright();
 								}
 								
 								//삭제 불가 처리
-								for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+								for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
 									// license index 까지 비교하는 이유는
 									// multi dual 혼용인 경우, 동일한 라이선스가 두번 등록 될 수 있기 때문
-									if(ossLicenseBean.getLicenseId().equals(licenseBean.getLicenseId()) 
+									if (ossLicenseBean.getLicenseId().equals(licenseBean.getLicenseId()) 
 											&& ossLicenseBean.getOssLicenseIdx().equals(licenseBean.getRnum())) {
 										licenseBean.setEditable(CoConstDef.FLAG_NO);
 										break;
@@ -684,29 +684,29 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 								}
 								
 								// Restriction 설정을 위해 license id 격납
-								if(!isEmpty(ossLicenseBean.getLicenseId())) {
+								if (!isEmpty(ossLicenseBean.getLicenseId())) {
 									strLicenseIds += (!isEmpty(strLicenseIds) ? "," : "") + ossLicenseBean.getLicenseId();
 								}
 								
 							}
 							
 							// 어짜피 여기서 설정하는 라이선스 이름은 의미가 없음
-							if(bean.getComponentLicenseList() != null && bean.getComponentLicenseList().size() == 1 && bean.getComponentLicenseList().get(0) != null) {
+							if (bean.getComponentLicenseList() != null && bean.getComponentLicenseList().size() == 1 && bean.getComponentLicenseList().get(0) != null) {
 								bean.setLicenseName(bean.getComponentLicenseList().get(0).getLicenseName());
-							} else if(CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())) {
+							} else if (CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())) {
 								bean.setLicenseName(CommonFunction.makeLicenseExpressionIdentify(bean.getComponentLicenseList(), ","));
 							} else {
 								// TODO - 여기 수정하면 될거 같음.. multiUIFlag
 								bean.setLicenseName(CommonFunction.makeLicenseExpression(ossBean.getOssLicenses()));
 							}
 						} else {
-							for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
-								if(!isEmpty(licenseBean.getCopyrightText())) {
+							for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+								if (!isEmpty(licenseBean.getCopyrightText())) {
 									licenseCopy += (!isEmpty(licenseCopy) ? "\r\n" : "") + licenseBean.getCopyrightText();
 								}
 
 								// Restriction 설정을 위해 license id 격납
-								if(!isEmpty(licenseBean.getLicenseId())) {
+								if (!isEmpty(licenseBean.getLicenseId())) {
 									strLicenseIds += (!isEmpty(strLicenseIds) ? "," : "") + licenseBean.getLicenseId();
 								}
 							}
@@ -716,33 +716,33 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						
 
 						// Restriction 설정
-						if(!isEmpty(strLicenseIds)) {
+						if (!isEmpty(strLicenseIds)) {
 							bean.setRestriction(CommonFunction.setLicenseRestrictionListById(strLicenseIds));
 						}
 						
 						// customBinary 설정
-						if(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(identification.getReferenceDiv())
+						if (CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(identification.getReferenceDiv())
 								|| CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(identification.getReferenceDiv())) {
 							bean.setCustomBinaryYn(CoConstDef.FLAG_YES);
 						}
 						
 						// 3rd party의 경우 obligation 처리를 위해 license에 따른 obligation 설정을 추가
-						if(CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(identification.getReferenceDiv())) {
+						if (CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(identification.getReferenceDiv())) {
 							bean.setObligationLicense(CommonFunction.checkObligationSelectedLicense2(bean.getComponentLicenseList()));
 							
-							if(isEmpty(bean.getObligationType())) {
+							if (isEmpty(bean.getObligationType())) {
 								bean.setObligationType(bean.getObligationLicense());
 							}
 							
 							// need check 인 경우
-							if(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(bean.getObligationLicense())) {
-								if(CoConstDef.CD_DTL_OBLIGATION_NOTICE.equals(bean.getObligationType())) {
+							if (CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK.equals(bean.getObligationLicense())) {
+								if (CoConstDef.CD_DTL_OBLIGATION_NOTICE.equals(bean.getObligationType())) {
 									bean.setNotify(CoConstDef.FLAG_YES);
 									bean.setSource(CoConstDef.FLAG_NO);
-								} else if(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE.equals(bean.getObligationType())) {
+								} else if (CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE.equals(bean.getObligationType())) {
 									bean.setNotify(CoConstDef.FLAG_YES);
 									bean.setSource(CoConstDef.FLAG_YES);
-								} else if(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK_SELECTED.equals(bean.getObligationType())) {
+								} else if (CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK_SELECTED.equals(bean.getObligationType())) {
 									bean.setNotify(CoConstDef.FLAG_NO);
 									bean.setSource(CoConstDef.FLAG_NO);
 								} else {
@@ -762,19 +762,19 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 					}
 					
 					// bat 분석 결과의 경우
-					if(!isEmpty(bean.getBatPercentage()) || !isEmpty(bean.getBatStringMatchPercentage())) {
+					if (!isEmpty(bean.getBatPercentage()) || !isEmpty(bean.getBatStringMatchPercentage())) {
 						String batPercentageStr = avoidNull(bean.getBatStringMatchPercentage());
 						
-						if(CoConstDef.BAT_MATCHED_STR.equalsIgnoreCase(avoidNull(bean.getBatPercentage()).trim())) {
+						if (CoConstDef.BAT_MATCHED_STR.equalsIgnoreCase(avoidNull(bean.getBatPercentage()).trim())) {
 							batPercentageStr = CoConstDef.BAT_MATCHED_STR;
-						} else if(!isEmpty(bean.getBatPercentage())) {
+						} else if (!isEmpty(bean.getBatPercentage())) {
 							batPercentageStr += " (" + bean.getBatPercentage() + ")";
 						}
 
 						bean.setBatStrPlus(batPercentageStr);
 						
 						// Change bat grid result percentage (UI) Number only
-						if(!isEmpty(bean.getBatStringMatchPercentage())) {
+						if (!isEmpty(bean.getBatStringMatchPercentage())) {
 							bean.setBatStringMatchPercentageFloat(bean.getBatStringMatchPercentage().replace("%", "").trim());
 						}
 						
@@ -789,21 +789,21 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				
 
 				// 다른 프로젝트에서 load한 경우 component id 초기화
-				if(isLoadFromProject || isApplyFromBat) {
+				if (isLoadFromProject || isApplyFromBat) {
 					subMap = new HashMap<>();
 
 					// refproject id + "p" + componentid 로 component_id를 재생성 하고, 
 					// license 의 경우 재성생한 component_id + 기존 license grid_id의 component_license_id 부분을 결합
-					for(ProjectIdentification bean : list) {
-						if(isLoadFromProject) {
+					for (ProjectIdentification bean : list) {
+						if (isLoadFromProject) {
 							bean.setRefPrjId(identification.getRefPrjId());
-						} else if(isApplyFromBat) {
+						} else if (isApplyFromBat) {
 							bean.setRefBatId(identification.getRefBatId());
 						}
 						
 						String _compId = CoConstDef.GRID_NEWROW_DEFAULT_PREFIX;
 						
-						if(isLoadFromProject) {
+						if (isLoadFromProject) {
 							_compId += identification.getRefPrjId();
 						} else if (isApplyFromBat) {
 							_compId += identification.getRefBatId();
@@ -814,8 +814,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						bean.setComponentId("");
 						bean.setGridId(_compId);
 
-						if(bean.getComponentLicenseList()!=null){
-							for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+						if (bean.getComponentLicenseList()!=null){
+							for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
 								licenseBean.setComponentId("");
 								licenseBean.setGridId(_compId + "-"+ licenseBean.getComponentLicenseId());
 							}
@@ -828,14 +828,14 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			// 편집중인 data 가 존재할 경우 append 한다.
 			{
-				if(identification.getMainDataGridList() != null) {
-					for(ProjectIdentification bean : identification.getMainDataGridList()) {
-						if(bean.getComponentLicenseList() == null || bean.getComponentLicenseList().isEmpty()){
+				if (identification.getMainDataGridList() != null) {
+					for (ProjectIdentification bean : identification.getMainDataGridList()) {
+						if (bean.getComponentLicenseList() == null || bean.getComponentLicenseList().isEmpty()){
 							//멀티라이센스일 경우
-							if(CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())){
+							if (CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())){
 								for (List<ProjectIdentification> comLicenseList : identification.getSubDataGridList()) {
 									for (ProjectIdentification comLicense : comLicenseList) {
-										if(bean.getComponentId().equals(comLicense.getComponentId())){
+										if (bean.getComponentId().equals(comLicense.getComponentId())){
 											bean.addComponentLicenseList(comLicense);
 										}
 									}
@@ -853,7 +853,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						}
 					}
 
-					for(ProjectIdentification bean : identification.getMainDataGridList()) {
+					for (ProjectIdentification bean : identification.getMainDataGridList()) {
 						list.add(0, bean);
 						
 						subMap.put(bean.getGridId(), bean.getComponentLicenseList());
@@ -865,8 +865,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			List<ProjectIdentification> newSortList = new ArrayList<>();
 			List<ProjectIdentification> excludeList = new ArrayList<>();
 			
-			for(ProjectIdentification bean : list) {
-				if(CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+			for (ProjectIdentification bean : list) {
+				if (CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 					excludeList.add(bean);
 				} else {
 					newSortList.add(bean);
@@ -884,11 +884,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	}
 
 	private String findAddedOssCopyright(String ossId, String licenseId, String ossCopyright) {
-		if(!isEmpty(ossId) && !isEmpty(licenseId)) {
+		if (!isEmpty(ossId) && !isEmpty(licenseId)) {
 			OssMaster bean = CoCodeManager.OSS_INFO_BY_ID.get(ossId);
 			if (bean != null) {
-				for(OssLicense license : bean.getOssLicenses()) {
-					if(licenseId.equals(license.getLicenseId()) && !isEmpty(license.getOssCopyright())) {
+				for (OssLicense license : bean.getOssLicenses()) {
+					if (licenseId.equals(license.getLicenseId()) && !isEmpty(license.getOssCopyright())) {
 						return license.getOssCopyright();
 					}
 				}
@@ -906,12 +906,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	 * @return
 	 */
 	private String findBatOssOtherVersionWithLicense(ProjectIdentification ll, ProjectIdentification refBean, List<ProjectIdentification> list) {
-		for(ProjectIdentification bean : list) {
-			if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(bean.getReferenceDiv()) 
+		for (ProjectIdentification bean : list) {
+			if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(bean.getReferenceDiv()) 
 					&& bean.getOssName().equals(refBean.getOssName())
 					&& !bean.getOssVersion().equals(refBean.getOssVersion())
 					&& bean.getOssName().equals(ll.getOssName())) {
-				if(CommonFunction.isSameLicense(bean.getOssComponentsLicenseList(), ll.getOssComponentsLicenseList())) {
+				if (CommonFunction.isSameLicense(bean.getOssComponentsLicenseList(), ll.getOssComponentsLicenseList())) {
 					return bean.getOssName() + "-" + avoidNull(bean.getOssVersion());
 				}
 			}
@@ -923,8 +923,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	private int findOssAppendIndex(String type, String componentId, List<ProjectIdentification> list) {
 		int idx = 0;
 		
-		for(ProjectIdentification bean : list) {
-			if(type.equals(bean.getReferenceDiv()) && componentId.equals(bean.getComponentId())) {
+		for (ProjectIdentification bean : list) {
+			if (type.equals(bean.getReferenceDiv()) && componentId.equals(bean.getComponentId())) {
 				return idx;
 			}
 			
@@ -938,8 +938,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		String targetGroup = avoidNull(ossName) + avoidNull(ossVersion);
 		List<ProjectIdentification> groupList = new ArrayList<>();
 		
-		for(ProjectIdentification bean : list) {
-			if(type.equals(bean.getReferenceDiv()) && targetGroup.equalsIgnoreCase(bean.getGroupingColumn())) {
+		for (ProjectIdentification bean : list) {
+			if (type.equals(bean.getReferenceDiv()) && targetGroup.equalsIgnoreCase(bean.getGroupingColumn())) {
 				groupList.add(bean);
 			}
 		}
@@ -948,8 +948,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	}
 	
 	private boolean existsBatOSS(String ossName, List<ProjectIdentification> list) {
-		for(ProjectIdentification bean : list) {
-			if(CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(bean.getReferenceDiv()) && isEmpty(bean.getMergePreDiv()) && isEmpty(bean.getOssVersion())
+		for (ProjectIdentification bean : list) {
+			if (CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(bean.getReferenceDiv()) && isEmpty(bean.getMergePreDiv()) && isEmpty(bean.getOssVersion())
 					&& ossName.equalsIgnoreCase(bean.getOssName())) {
 				return true;
 			}
@@ -1008,7 +1008,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			String prjId = project.getPrjId();
 			notice = verificationService.selectOssNoticeOne(prjId);
 			
-			if(isEmpty(notice.getCompanyNameFull()) 
+			if (isEmpty(notice.getCompanyNameFull()) 
 					&& isEmpty(notice.getDistributionSiteUrl()) 
 					&& isEmpty(notice.getEmail())
 					&& isEmpty(notice.getAppended())
@@ -1032,46 +1032,46 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				String distributeType = avoidNull(project.getDistributeTarget(), CoConstDef.CD_DISTRIBUTE_SITE_SKS); // LGE, NA => LGE로 표기, SKS => SKS로 표기함.
 				String distributeCode = CoConstDef.CD_DISTRIBUTE_SITE_SKS.equals(distributeType) ? CoConstDef.CD_NOTICE_DEFAULT_SKS : CoConstDef.CD_NOTICE_DEFAULT;
 				
-				if(isEmpty(notice.getCompanyNameFull())) {
+				if (isEmpty(notice.getCompanyNameFull())) {
 					notice.setCompanyNameFull(CoCodeManager.getCodeExpString(distributeCode, CoConstDef.CD_DTL_NOTICE_DEFAULT_FULLNAME));
 				}
 				
-				if(isEmpty(notice.getDistributionSiteUrl())) {
+				if (isEmpty(notice.getDistributionSiteUrl())) {
 					notice.setDistributionSiteUrl(CoCodeManager.getCodeExpString(distributeCode, CoConstDef.CD_DTL_NOTICE_DEFAULT_DISTRIBUTE_SITE));
 				}
 				
-				if(isEmpty(notice.getEmail())) {
+				if (isEmpty(notice.getEmail())) {
 					notice.setEmail(CoCodeManager.getCodeExpString(distributeCode, CoConstDef.CD_DTL_NOTICE_DEFAULT_EMAIL));
 				}
 				
-				if(isEmpty(notice.getAppended())){
+				if (isEmpty(notice.getAppended())){
 					notice.setAppended(CoCodeManager.getCodeExpString(distributeCode, CoConstDef.CD_DTL_NOTICE_DEFAULT_APPENDED));
 				}
-			} else if(CoConstDef.FLAG_YES.equals(notice.getEditNoticeYn())
+			} else if (CoConstDef.FLAG_YES.equals(notice.getEditNoticeYn())
 					&& CoConstDef.CD_NOTICE_TYPE_GENERAL.equals(notice.getNoticeType())) {
 				
 			} else {
-				if(!isEmpty(notice.getCompanyNameFull())){
+				if (!isEmpty(notice.getCompanyNameFull())){
 					notice.setEditCompanyYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
 				
-				if(!isEmpty(notice.getDistributionSiteUrl())){
+				if (!isEmpty(notice.getDistributionSiteUrl())){
 					notice.setEditDistributionSiteUrlYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
 				
-				if(!isEmpty(notice.getEmail())){
+				if (!isEmpty(notice.getEmail())){
 					notice.setEditEmailYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
 				
-				if(!isEmpty(notice.getAppended())){
+				if (!isEmpty(notice.getAppended())){
 					notice.setEditAppendedYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
 				
-				if(CoConstDef.CD_NOTICE_TYPE_GENERAL_WITHOUT_OSS_VERSION.equals(project.getNoticeType())){
+				if (CoConstDef.CD_NOTICE_TYPE_GENERAL_WITHOUT_OSS_VERSION.equals(project.getNoticeType())){
 					notice.setHideOssVersionYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
@@ -1102,7 +1102,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	public History work(Object param) {
 		History h = new History();
 		
-		if(Project.class.equals(param.getClass())) {
+		if (Project.class.equals(param.getClass())) {
 			Project vo = (Project) param;
 			Project prj = getProjectDetail(vo);
 			prj.setModelList(projectMapper.selectModelList(prj.getPrjId()));
@@ -1188,7 +1188,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	@CacheEvict(value="autocompleteProjectCache", allEntries=true)
 	public void registProject(Project project) {
 		//copy 건
-		if("true".equals(project.getCopy())){
+		if ("true".equals(project.getCopy())){
 			String oldId = project.getPrjId();
 			project.setPrjId(null);
 			project.setCopyPrjId(oldId);
@@ -1204,7 +1204,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			noticeParam.setPrjId(project.getPrjId());
 			noticeParam.setNoticeType(avoidNull(project.getNoticeType(), CoConstDef.CD_DTL_NOTICE_TYPE_GENERAL));
 			
-			if(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(project.getNoticeType())) {
+			if (CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(project.getNoticeType())) {
 				noticeParam.setNoticeTypeEtc(project.getNoticeTypeEtc());
 			}
 			
@@ -1212,13 +1212,13 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 			// project model insert
 			if (project.getModelList().size() > 0) {
-				for(Project modelBean : project.getModelList()) {
+				for (Project modelBean : project.getModelList()) {
 					modelBean.setPrjId(project.getPrjId());
 					modelBean.setModelName(modelBean.getModelName().trim().toUpperCase().replaceAll("\t", ""));
 					
 					// copy 한 프로젝트의 경우, 배포사이트 연동 정보는 삭제한다.
 					// 삭제된 이력이 있는 모델은 추가할 필요 없음
-					if(CoConstDef.FLAG_YES.equals(modelBean.getDelYn())) {
+					if (CoConstDef.FLAG_YES.equals(modelBean.getDelYn())) {
 						continue;
 					}
 					
@@ -1243,10 +1243,10 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 					Map<String, String> m = new HashMap<String, String>();
 					arr = watcher.split("\\/");
 					
-					if(!"Email".equals(arr[1])){
+					if (!"Email".equals(arr[1])){
 						project.setPrjDivision(arr[0]);
 						
-						if(arr.length > 1){
+						if (arr.length > 1){
 							project.setPrjUserId(arr[1]);
 						}else{
 							project.setPrjUserId("");
@@ -1268,7 +1268,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 					List<Project> watcherList = projectMapper.selectWatchersCheck(project);
 					
-					if(watcherList.size() == 0){
+					if (watcherList.size() == 0){
 						projectMapper.insertProjectWatcher(project);
 					}
 				}
@@ -1291,7 +1291,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				newBean.setPrjId(prjId);
 				newBean.setModifier(newBean.getLoginUserName());
 				
-				if(!isEmpty(orgBean.getIdentificationStatus())) {
+				if (!isEmpty(orgBean.getIdentificationStatus())) {
 					newBean.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_PROGRESS);
 				}
 				
@@ -1302,24 +1302,24 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				newBean.setIdentificationSubStatusBat(orgBean.getIdentificationSubStatusBat());
 				
 				// distribute target이 변경된 경우, 마스터 카테고리는 복사하지 않는다.
-				if(!CoConstDef.CD_DTL_DISTRIBUTE_NA.equals(project.getDistributeTarget()) 
+				if (!CoConstDef.CD_DTL_DISTRIBUTE_NA.equals(project.getDistributeTarget()) 
 						&& avoidNull(project.getDistributeTarget()).equals(orgBean.getDistributeTarget())) {
 					newBean.setDistributeMasterCategory(orgBean.getDistributeMasterCategory());
 					newBean.setDistributeName(orgBean.getDistributeName());
 					newBean.setDistributeSoftwareType(orgBean.getDistributeSoftwareType());
 				}
 				
-				if(!avoidNull(project.getDistributionType()).equals(orgBean.getDistributionType())) {}
+				if (!avoidNull(project.getDistributionType()).equals(orgBean.getDistributionType())) {}
 				
-				if(!isEmpty(orgBean.getSrcAndroidCsvFileId())) {
+				if (!isEmpty(orgBean.getSrcAndroidCsvFileId())) {
 					newBean.setSrcAndroidCsvFileId(fileService.copyFileInfo(orgBean.getSrcAndroidCsvFileId()));
 				}
 				
-				if(!isEmpty(orgBean.getSrcAndroidNoticeFileId())) {
+				if (!isEmpty(orgBean.getSrcAndroidNoticeFileId())) {
 					newBean.setSrcAndroidNoticeFileId(fileService.copyFileInfo(orgBean.getSrcAndroidNoticeFileId()));
 				}
 				
-				if(!isEmpty(orgBean.getSrcAndroidResultFileId())) {
+				if (!isEmpty(orgBean.getSrcAndroidResultFileId())) {
 					newBean.setSrcAndroidResultFileId(fileService.copyFileInfo(orgBean.getSrcAndroidResultFileId()));
 				}
 				
@@ -1360,7 +1360,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			boolean isNew = isEmpty(project.getPrjId());
 			
 			// 신규 프로젝트 생성시, Android model  의 경우, 3rd, src, bin Tab을  N/A 처리한다.
-			if(isNew && "A".equals(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE, project.getDistributionType())) ) {
+			if (isNew && "A".equals(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE, project.getDistributionType())) ) {
 				 project.setIdentificationSubStatusPartner(CoConstDef.FLAG_NO);
 				 project.setIdentificationSubStatusSrc(CoConstDef.FLAG_NO);
 				 project.setIdentificationSubStatusBin(CoConstDef.FLAG_NO);
@@ -1368,18 +1368,18 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			}
 			
 			// admin이 아니라면 creator를 변경하지 않는다.
-			if(!CommonFunction.isAdmin()) {
+			if (!CommonFunction.isAdmin()) {
 				project.setCreator(null);
 			}
 			
 			project.setPublicYn(avoidNull(project.getPublicYn(), CoConstDef.FLAG_YES));
 			
 			// if complete value equals 'Y', set
-			if(!isNew) {
+			if (!isNew) {
 				Project prjBean = projectMapper.selectProjectMaster(project);
 				
-				if(prjBean != null) {
-					if(CoConstDef.FLAG_YES.equals(prjBean.getCompleteYn())) {
+				if (prjBean != null) {
+					if (CoConstDef.FLAG_YES.equals(prjBean.getCompleteYn())) {
 						project.setCompleteYn(CoConstDef.FLAG_YES);
 					}
 				}
@@ -1391,7 +1391,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			noticeParam.setPrjId(project.getPrjId());
 			noticeParam.setNoticeType(avoidNull(project.getNoticeType(), CoConstDef.CD_DTL_NOTICE_TYPE_GENERAL));
 			
-			if(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(project.getNoticeType())) {
+			if (CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(project.getNoticeType())) {
 				noticeParam.setNoticeTypeEtc(project.getNoticeTypeEtc());
 			}
 			
@@ -1410,17 +1410,17 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			Project result = projectMapper.getProjectBasicInfo(project);
 			
-			if("CONF".equals(result.getVerificationStatus()) 
+			if ("CONF".equals(result.getVerificationStatus()) 
 					&& isEmpty(result.getDestributionStatus())
 					&& CoConstDef.CD_DTL_DISTRIBUTE_NA.equals(project.getDistributeTarget())) {
 				projectMapper.updateProjectDistributionStatus(project.getPrjId(), CoConstDef.CD_DTL_DISTRIBUTE_NA);
-			} else if("CONF".equals(result.getVerificationStatus()) 
+			} else if ("CONF".equals(result.getVerificationStatus()) 
 					&& CoConstDef.CD_DTL_DISTRIBUTE_NA.equals(result.getDestributionStatus())
 					&& !CoConstDef.CD_DTL_DISTRIBUTE_NA.equals(project.getDistributeTarget())) {
 				projectMapper.updateProjectDistributionStatus(project.getPrjId(), null);
 			}
 			
-			if(isNew) {
+			if (isNew) {
 				// project watcher insert
 				ArrayList<Map<String, String>> divisionList = new ArrayList<Map<String, String>>();
 				ArrayList<Map<String, String>> emailList = new ArrayList<Map<String, String>>();
@@ -1432,10 +1432,10 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						Map<String, String> m = new HashMap<String, String>();
 						arr = watcher.split("\\/");
 						
-						if(!"Email".equals(arr[1])){
+						if (!"Email".equals(arr[1])){
 							project.setPrjDivision(arr[0]);
 							
-							if(arr.length > 1){
+							if (arr.length > 1){
 								project.setPrjUserId(arr[1]);
 							}else{
 								project.setPrjUserId("");
@@ -1457,7 +1457,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 						List<Project> watcherList = projectMapper.selectWatchersCheck(project);
 						
-						if(watcherList.size() == 0){
+						if (watcherList.size() == 0){
 							projectMapper.insertProjectWatcher(project);
 						}
 					}
@@ -1486,7 +1486,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			ProjectIdentification prjOssMaster = projectMapper.getOssId(identification);
 			List<ProjectIdentification> Licenselist = projectMapper.getLicenses(prjOssMaster);
 			
-			if(Licenselist.size() != 0){
+			if (Licenselist.size() != 0){
 				//excludeYn 체크해주기
 				Licenselist = CommonFunction.makeLicenseExcludeYn(Licenselist);
 				// multi/dual license인 경우 연산식 표기로 변경
@@ -1512,7 +1512,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		List<OssComponents> componentsLicense = projectMapper.selectComponentId(components);
 		
-		for(OssComponents oc : componentsLicense) {
+		for (OssComponents oc : componentsLicense) {
 			projectMapper.deleteOssComponentsLicense(oc);
 		}
 		
@@ -1536,7 +1536,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			// 최초 저장시에만 상태 변경
 			// row count가 0이어도 사용자가 한번이라도 저장하면 progress 상태로 인지되어야함
-			if(isEmpty(prjBasicInfo.getIdentificationStatus())) {
+			if (isEmpty(prjBasicInfo.getIdentificationStatus())) {
 				projectSubStatus.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_PROGRESS);
 			}
 			
@@ -1555,8 +1555,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			Map<String, Object> _map = getIdentificationThird(compParam);
 			List<ProjectIdentification> rows = (List<ProjectIdentification>) _map.get("rows");
 			
-			if(rows != null) {
-				for(ProjectIdentification bean : rows) {
+			if (rows != null) {
+				for (ProjectIdentification bean : rows) {
 					orgOssMap.put(bean.getComponentId(), bean);
 				}
 			}
@@ -1568,14 +1568,14 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		List<String> deleteList = new ArrayList<>();
 		
 		// 순서대로 등록 1) update, 2) delete, 3)insert from project , 4) insert from 3rd 
-		for(OssComponents bean : ossComponentsList) {
+		for (OssComponents bean : ossComponentsList) {
 			// 기존에 등록되어 있는 경우는 update
-			if(orgOssMap.containsKey(avoidNull(bean.getComponentId()))) {
+			if (orgOssMap.containsKey(avoidNull(bean.getComponentId()))) {
 				// exclude 여부만 사용
 				updateList.add(bean);
 				deleteList.add(bean.getComponentId());
 			} else {
-				if(!isEmpty(bean.getRefPrjId())) {
+				if (!isEmpty(bean.getRefPrjId())) {
 					// 신규 추가이면서, ref 프로젝트 id가 있으면 
 					// componentsid + prjid + exclude 여부만 사용
 					insertFromPrjList.add(bean);
@@ -1588,12 +1588,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 		
 		// 1) update
-		for(OssComponents bean : updateList) {
+		for (OssComponents bean : updateList) {
 			projectMapper.updatePartnerOssList(bean);
 		}
 		
 		// 2) delete
-		if(orgOssMap != null && !orgOssMap.isEmpty()) {
+		if (orgOssMap != null && !orgOssMap.isEmpty()) {
 			OssComponents param = new OssComponents();
 			param.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER);
 			param.setReferenceId(prjId);
@@ -1601,7 +1601,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			List<String> deleteComponentIds = projectMapper.getDeleteOssComponentsLicenseIds(param);
 			param.setOssComponentsIdList(deleteComponentIds);
 			
-			if(deleteComponentIds.size() > 0){
+			if (deleteComponentIds.size() > 0){
 				projectMapper.deleteOssComponentsLicenseWithIds(param);
 				// deleteOssComponentsWithIds는 not in 값을 delete, deleteOssComponentsWithIds2는 in 값을 delete함.
 				projectMapper.deleteOssComponentsWithIds2(param); 
@@ -1609,7 +1609,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 		
 		// 3) insert from project
-		for(OssComponents bean : insertFromPrjList) {
+		for (OssComponents bean : insertFromPrjList) {
 			bean.setComponentId(bean.getRefComponentId());
 			bean.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER);
 			bean.setReferenceId(prjId);
@@ -1620,7 +1620,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 		
 		// 4) insert from 3rd part
-		for(OssComponents bean : insertFromPartnerList) {
+		for (OssComponents bean : insertFromPartnerList) {
 			bean.setComponentId(bean.getRefComponentId());
 			bean.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER);
 			bean.setReferenceId(prjId);
@@ -1635,8 +1635,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		{
 			Map<String, Object> _map = getThirdPartyMap(prjId);
 			
-			if(_map != null) {
-				for(PartnerMaster bean : (List<PartnerMaster>) _map.get("rows")) {
+			if (_map != null) {
+				for (PartnerMaster bean : (List<PartnerMaster>) _map.get("rows")) {
 					thirdPartyMap.put(bean.getPartnerId(), bean);
 				}
 			}
@@ -1646,9 +1646,9 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		List<PartnerMaster> thirdPartyInsertList = new ArrayList<>();
 		List<String> thirdPartyDeleteList = new ArrayList<>();
 		
-		for(PartnerMaster bean : thirdPartyList) {
+		for (PartnerMaster bean : thirdPartyList) {
 			// 기존에 등록되어 있는 경우는 update
-			if(thirdPartyMap.containsKey(avoidNull(bean.getPartnerId()))) {
+			if (thirdPartyMap.containsKey(avoidNull(bean.getPartnerId()))) {
 				thirdPartyUpdateList.add(bean);
 			} else {
 				thirdPartyInsertList.add(bean);
@@ -1658,26 +1658,26 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		Map<String, PartnerMaster> deleteCheckMap = new HashMap<>();
 		
 		// 1) update
-		for(PartnerMaster bean : thirdPartyUpdateList) {
+		for (PartnerMaster bean : thirdPartyUpdateList) {
 			deleteCheckMap.put(bean.getPartnerId(), bean);
 		}
 				
 		// 3) insert
-		for(PartnerMaster bean : thirdPartyInsertList) {
+		for (PartnerMaster bean : thirdPartyInsertList) {
 			deleteCheckMap.put(bean.getPartnerId(), bean);
 			bean.setPrjId(prjId);
 			
 			partnerMapper.insertPartnerMapList(bean);
 		}
 		
-		for(String s : thirdPartyMap.keySet()) {
-			if(!deleteCheckMap.containsKey(s)) {
+		for (String s : thirdPartyMap.keySet()) {
+			if (!deleteCheckMap.containsKey(s)) {
 				thirdPartyDeleteList.add(s);
 			}
 		}
 		
 		// 2) delete
-		if(!thirdPartyDeleteList.isEmpty()) {
+		if (!thirdPartyDeleteList.isEmpty()) {
 			PartnerMaster param = new PartnerMaster();
 			param.setPrjId(prjId);
 			param.setThirdPartyPartnerIdList(thirdPartyDeleteList);
@@ -1691,41 +1691,41 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		List<OssMaster> ossNickNameList = null;
 		Map<String, OssMaster> ossNickNameConvertMap = new HashMap<>();
 		
-		for(OssComponents bean : ossComponents) {
+		for (OssComponents bean : ossComponents) {
 			String _ossName = avoidNull(bean.getOssName()).trim();
 			
-			if(!isEmpty(_ossName) && !"-".equals(_ossName) && !ossCheckParam.contains(_ossName)) {
+			if (!isEmpty(_ossName) && !"-".equals(_ossName) && !ossCheckParam.contains(_ossName)) {
 				ossCheckParam.add(_ossName);
 			}
 		}
 		
-		if(!ossCheckParam.isEmpty()) {
+		if (!ossCheckParam.isEmpty()) {
 			OssMaster param = new OssMaster();
 			param.setOssNames(ossCheckParam.toArray(new String[ossCheckParam.size()]));
 			ossNickNameList = projectMapper.checkOssNickName(param);
 			
-			if(ossNickNameList != null) {
-				for(OssMaster bean : ossNickNameList) {
+			if (ossNickNameList != null) {
+				for (OssMaster bean : ossNickNameList) {
 					ossNickNameConvertMap.put(bean.getOssNickname().toUpperCase(), bean);
 				}
 			}
 		}
 
-		for(OssComponents bean : ossComponents) {
-			if(ossNickNameConvertMap.containsKey(avoidNull(bean.getOssName()).trim().toUpperCase())) {
+		for (OssComponents bean : ossComponents) {
+			if (ossNickNameConvertMap.containsKey(avoidNull(bean.getOssName()).trim().toUpperCase())) {
 				bean.setOssName(ossNickNameConvertMap.get(avoidNull(bean.getOssName()).trim().toUpperCase()).getOssName());
 			}
 			
 			// license nickname 체크
-			if(!avoidNull(bean.getLicenseName()).contains(",")) {
+			if (!avoidNull(bean.getLicenseName()).contains(",")) {
 				String _licenseName = avoidNull(bean.getLicenseName()).trim();
 				
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
 					LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(_licenseName.toUpperCase());
 					
-					if(licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
-						for(String s : licenseMaster.getLicenseNicknameList()) {
-							if(_licenseName.equalsIgnoreCase(s)) {
+					if (licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
+						for (String s : licenseMaster.getLicenseNicknameList()) {
+							if (_licenseName.equalsIgnoreCase(s)) {
 								bean.setLicenseName(avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseNameTemp()));
 								
 								break;
@@ -1758,24 +1758,24 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	public void registSrcOss(List<ProjectIdentification> ossComponent,
 			List<List<ProjectIdentification>> ossComponentLicense, Project project, String refDiv) {
 		// 한건도 없을시 프로젝트 마스터 SRC 사용가능여부가 N이면 N 그외 null
-		if(ossComponent.size()==0){
+		if (ossComponent.size()==0){
 			Project projectSubStatus = new Project();
 			projectSubStatus.setPrjId(project.getPrjId());
 			
-			if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(refDiv)) {
-				if(!StringUtil.isEmpty(project.getIdentificationSubStatusSrc())){
+			if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(refDiv)) {
+				if (!StringUtil.isEmpty(project.getIdentificationSubStatusSrc())){
 					projectSubStatus.setIdentificationSubStatusSrc(project.getIdentificationSubStatusSrc());
 				} else {
 					projectSubStatus.setIdentificationSubStatusSrc("X");
 				}
-			} else if(CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(refDiv)) {
-				if(!StringUtil.isEmpty(project.getIdentificationSubStatusBin())){
+			} else if (CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(refDiv)) {
+				if (!StringUtil.isEmpty(project.getIdentificationSubStatusBin())){
 					projectSubStatus.setIdentificationSubStatusBin(project.getIdentificationSubStatusBin());
 				} else {
 					projectSubStatus.setIdentificationSubStatusBin("X");
 				}
 			} else {
-				if(!StringUtil.isEmpty(project.getIdentificationSubStatusAndroid())){
+				if (!StringUtil.isEmpty(project.getIdentificationSubStatusAndroid())){
 					projectSubStatus.setIdentificationSubStatusAndroid(project.getIdentificationSubStatusAndroid());
 				} else {
 					projectSubStatus.setIdentificationSubStatusAndroid("X");
@@ -1796,15 +1796,15 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		updateOssComponentList(project, refDiv, refId, ossComponent, ossComponentLicense);
 
 		// delete file
-		if(project.getCsvFile() != null && project.getCsvFile().size() > 0) {
+		if (project.getCsvFile() != null && project.getCsvFile().size() > 0) {
 			deleteUploadFile(project, refDiv);
 		}
 		
 		// 파일 등록
-		if(!isEmpty(project.getSrcCsvFileId()) || !isEmpty(project.getSrcAndroidCsvFileId()) || !isEmpty(project.getSrcAndroidNoticeFileId()) || !isEmpty(project.getBinCsvFileId()) || !isEmpty(project.getBinBinaryFileId())){
+		if (!isEmpty(project.getSrcCsvFileId()) || !isEmpty(project.getSrcAndroidCsvFileId()) || !isEmpty(project.getSrcAndroidNoticeFileId()) || !isEmpty(project.getBinCsvFileId()) || !isEmpty(project.getBinBinaryFileId())){
 			projectMapper.updateFileId(project);
 			
-			if(project.getCsvFileSeq() != null) {
+			if (project.getCsvFileSeq() != null) {
 				for (int i = 0; i < project.getCsvFileSeq().size(); i++) {
 					projectMapper.updateFileBySeq(project.getCsvFileSeq().get(i));
 				}				
@@ -1812,8 +1812,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 		
 		// bin android 의 경우 다른 프로젝트에서 load한 정보를 save할 경우, notice html과 result text 정보를 변경한다.
-		if(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(refDiv) && CoConstDef.FLAG_YES.equals(project.getLoadFromAndroidProjectFlag())) {
-			if(isEmpty(project.getSrcAndroidResultFileId())) {
+		if (CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(refDiv) && CoConstDef.FLAG_YES.equals(project.getLoadFromAndroidProjectFlag())) {
+			if (isEmpty(project.getSrcAndroidResultFileId())) {
 				project.setSrcAndroidResultFileId(null);
 			}
 			
@@ -1825,39 +1825,39 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		Project prjFileCheck = projectMapper.getProjectBasicInfo(project);
 		boolean fileDeleteCheckFlag = false;
 		
-		if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(refDiv)) {
-			if(project.getCsvFileSeq().size() == 0 && !isEmpty(prjFileCheck.getSrcCsvFileId())) {
+		if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(refDiv)) {
+			if (project.getCsvFileSeq().size() == 0 && !isEmpty(prjFileCheck.getSrcCsvFileId())) {
 				project.setSrcCsvFileFlag(CoConstDef.FLAG_YES);
 				fileDeleteCheckFlag = true;
 			}
-		} else if(CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(refDiv)) {
-			if(isEmpty(project.getBinCsvFileId()) && !isEmpty(prjFileCheck.getBinCsvFileId())) {
+		} else if (CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(refDiv)) {
+			if (isEmpty(project.getBinCsvFileId()) && !isEmpty(prjFileCheck.getBinCsvFileId())) {
 				project.setBinCsvFileFlag(CoConstDef.FLAG_YES);
 				fileDeleteCheckFlag = true;
 			}
-			if(isEmpty(project.getBinBinaryFileId()) && !isEmpty(prjFileCheck.getBinBinaryFileId())) {
+			if (isEmpty(project.getBinBinaryFileId()) && !isEmpty(prjFileCheck.getBinBinaryFileId())) {
 				project.setBinBinaryFileFlag(CoConstDef.FLAG_YES);
 				fileDeleteCheckFlag = true;
 			}
 		} else {
-			if(isEmpty(project.getSrcAndroidCsvFileId()) && !isEmpty(prjFileCheck.getSrcAndroidCsvFileId())) {
+			if (isEmpty(project.getSrcAndroidCsvFileId()) && !isEmpty(prjFileCheck.getSrcAndroidCsvFileId())) {
 				project.setSrcAndroidCsvFileFlag(CoConstDef.FLAG_YES);
 				fileDeleteCheckFlag = true;
 			}
-			if(isEmpty(project.getSrcAndroidNoticeFileId()) && !isEmpty(prjFileCheck.getSrcAndroidNoticeFileId())) {
+			if (isEmpty(project.getSrcAndroidNoticeFileId()) && !isEmpty(prjFileCheck.getSrcAndroidNoticeFileId())) {
 				project.setSrcAndroidNoticeFileFlag(CoConstDef.FLAG_YES);
 				fileDeleteCheckFlag = true;
 			}
 		}
 		
-		if(project.getCsvFile() != null && project.getCsvFile().size() > 0) {
+		if (project.getCsvFile() != null && project.getCsvFile().size() > 0) {
 			for (int i = 0; i < project.getCsvFile().size(); i++) {
 				projectMapper.deleteFileBySeq(project.getCsvFile().get(i));
 				fileService.deletePhysicalFile(project.getCsvFile().get(i), "Identification");
 			}
 		}
 		
-		if(fileDeleteCheckFlag) {
+		if (fileDeleteCheckFlag) {
 			projectMapper.updateFileId2(project);
 		}
 	}
@@ -1875,7 +1875,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		// 컴포넌트 마스터 라이센스 지우기
 		ProjectIdentification prj = new ProjectIdentification();
 		
-		if(isEmpty(refId)) {
+		if (isEmpty(refId)) {
 			refId = project.getPrjId();
 		}
 		
@@ -1887,8 +1887,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			projectMapper.deleteOssComponentsLicense(componentId.get(i));
 		}
 		
-		if(!CoConstDef.CD_DTL_COMPONENT_BAT.equals(refDiv)) {
-			if(!ossComponent.isEmpty()) {
+		if (!CoConstDef.CD_DTL_COMPONENT_BAT.equals(refDiv)) {
+			if (!ossComponent.isEmpty()) {
 				Project projectStatus = new Project();
 				projectStatus.setPrjId(refId);
 				projectStatus = projectMapper.selectProjectMaster(projectStatus);
@@ -1898,23 +1898,23 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 					projectStatus.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_PROGRESS);
 				}
 				
-				if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(refDiv)) {
+				if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(refDiv)) {
 					// 프로젝트 마스터 SRC 사용가능여부가 N 이면 N 그외 Y
-					if(!StringUtil.isEmpty(project.getIdentificationSubStatusSrc())){
+					if (!StringUtil.isEmpty(project.getIdentificationSubStatusSrc())){
 						projectStatus.setIdentificationSubStatusSrc(project.getIdentificationSubStatusSrc());
 					} else {
 						projectStatus.setIdentificationSubStatusSrc(CoConstDef.FLAG_YES);
 					}
-				} else if(CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(refDiv)) {
+				} else if (CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(refDiv)) {
 					// 프로젝트 마스터 SRC 사용가능여부가 N 이면 N 그외 Y
-					if(!StringUtil.isEmpty(project.getIdentificationSubStatusBin())){
+					if (!StringUtil.isEmpty(project.getIdentificationSubStatusBin())){
 						projectStatus.setIdentificationSubStatusBin(project.getIdentificationSubStatusBin());
 					} else {
 						projectStatus.setIdentificationSubStatusBin(CoConstDef.FLAG_YES);
 					}
 				} else {
 					// 프로젝트 마스터 SRC 사용가능여부가 N 이면 N 그외 Y
-					if(!StringUtil.isEmpty(project.getIdentificationSubStatusAndroid())){
+					if (!StringUtil.isEmpty(project.getIdentificationSubStatusAndroid())){
 						projectStatus.setIdentificationSubStatusAndroid(project.getIdentificationSubStatusAndroid());
 					} else {
 						projectStatus.setIdentificationSubStatusAndroid(CoConstDef.FLAG_YES);
@@ -1942,38 +1942,38 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			// oss_id를 다시 찾는다. (oss name과 oss id가 일치하지 않는 경우가 있을 수 있음)
 			ossBean = CommonFunction.findOssIdAndName(ossBean);
-			if(isEmpty(ossBean.getOssId())) {
+			if (isEmpty(ossBean.getOssId())) {
 				ossBean.setOssId(null);
 			}
 			
 			String downloadLocationUrl = ossBean.getDownloadLocation();
 			String homepageUrl = ossBean.getHomepage();
 			
-			if(!isEmpty(downloadLocationUrl)) {
-				if(downloadLocationUrl.endsWith("/")) {
+			if (!isEmpty(downloadLocationUrl)) {
+				if (downloadLocationUrl.endsWith("/")) {
 					ossBean.setDownloadLocation(downloadLocationUrl.substring(0, downloadLocationUrl.length()-1));
 				}
 			}
 			
-			if(!isEmpty(homepageUrl)) {
-				if(homepageUrl.endsWith("/")) {
+			if (!isEmpty(homepageUrl)) {
+				if (homepageUrl.endsWith("/")) {
 					ossBean.setHomepage(homepageUrl.substring(0, homepageUrl.length()-1));
 				}
 			}
 			
 			//update
-			if(!ossBean.getGridId().contains(CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
+			if (!ossBean.getGridId().contains(CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
 				//ossComponents 등록
 				// android project의 경우, bom 처리를 하지 않기 때문에, bom save에서 처리하는 obligation type을 여기서 설정해야한다.
-				if(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(refDiv)) {
+				if (CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(refDiv)) {
 					List<OssComponentsLicense> _list = new ArrayList<>();
 					
-					if(CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())) {
+					if (CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())) {
 						for (List<ProjectIdentification> comLicenseList : ossComponentLicense) {
 							for (ProjectIdentification comLicense : comLicenseList) {
-								if(ossBean.getComponentId().equals(comLicense.getComponentId())){
+								if (ossBean.getComponentId().equals(comLicense.getComponentId())){
 									// multi license oss에 license를 추가한 경우, license 명을 입력하지 않은 경우는 무시
-									if(isEmpty(comLicense.getLicenseName()) && isEmpty(comLicense.getLicenseText()) && isEmpty(comLicense.getOssCopyright())) {
+									if (isEmpty(comLicense.getLicenseName()) && isEmpty(comLicense.getLicenseText()) && isEmpty(comLicense.getOssCopyright())) {
 										continue;
 									}
 									
@@ -1993,17 +1993,17 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				deleteRows.add(ossBean.getComponentId());
 				
 				//멀티라이센스일 경우
-				if(CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())){
+				if (CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())){
 					List<String> duplicateLicense = new ArrayList<String>();
 					for (List<ProjectIdentification> comLicenseList : ossComponentLicense) {
 						for (ProjectIdentification comLicense : comLicenseList) {
-							if(ossBean.getComponentId().equals(comLicense.getComponentId())){
-								if(!isEmpty(comLicense.getLicenseId()) && duplicateLicense.contains(comLicense.getLicenseId())) {
+							if (ossBean.getComponentId().equals(comLicense.getComponentId())){
+								if (!isEmpty(comLicense.getLicenseId()) && duplicateLicense.contains(comLicense.getLicenseId())) {
 									continue;
 								}
 								
 								// multi license oss에 license를 추가한 경우, license 명을 입력하지 않은 경우는 무시
-								if((isEmpty(comLicense.getLicenseName()) 
+								if ((isEmpty(comLicense.getLicenseName()) 
 										&& isEmpty(comLicense.getLicenseText()) 
 										&& isEmpty(comLicense.getOssCopyright()))) {
 									OssComponentsLicense license = CommonFunction.reMakeLicenseBean(ossBean, CoConstDef.LICENSE_DIV_SINGLE);
@@ -2031,22 +2031,22 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				ossBean.setReferenceDiv(refDiv);
 				
 				// android project의 경우, bom 처리를 하지 않기 때문에, bom save에서 처리하는 obligation type을 여기서 설정해야한다.
-				if(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(refDiv)) {
+				if (CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(refDiv)) {
 					List<OssComponentsLicense> _list = new ArrayList<>();
 					
-					if(CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())) {
+					if (CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())) {
 
 						for (List<ProjectIdentification> comLicenseList : ossComponentLicense) {
 							for (ProjectIdentification comLicense : comLicenseList) {
 								String gridId = comLicense.getGridId();
 								
-								if(isEmpty(gridId)) {
+								if (isEmpty(gridId)) {
 									continue;
 								}
 								
 								gridId = gridId.split("-")[0];
 								
-								if(exComponentId.equals(comLicense.getComponentId())
+								if (exComponentId.equals(comLicense.getComponentId())
 										|| exComponentId.equals(gridId)){
 									_list.add(CommonFunction.reMakeLicenseBean(comLicense, CoConstDef.LICENSE_DIV_MULTI));
 								}
@@ -2066,25 +2066,25 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				deleteRows.add(ossBean.getComponentId());
 				
 				//멀티라이센스일 경우
-				if(CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())){
+				if (CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())){
 					List<String> duplicateLicense = new ArrayList<String>();
 					for (List<ProjectIdentification> comLicenseList : ossComponentLicense) {
 						for (ProjectIdentification comLicense : comLicenseList) {
 							String gridId = comLicense.getGridId();
 							
-							if(isEmpty(gridId)) {
+							if (isEmpty(gridId)) {
 								continue;
 							}
 							
 							gridId = gridId.split("-")[0];
 							
-							if(exComponentId.equals(comLicense.getComponentId()) || exComponentId.equals(gridId)){
-								if(!isEmpty(comLicense.getLicenseId()) && duplicateLicense.contains(comLicense.getLicenseId())) {
+							if (exComponentId.equals(comLicense.getComponentId()) || exComponentId.equals(gridId)){
+								if (!isEmpty(comLicense.getLicenseId()) && duplicateLicense.contains(comLicense.getLicenseId())) {
 									continue;
 								}
 								
 								// multi license oss에 license를 추가한 경우, license 명을 입력하지 않은 경우는 무시
-								if((isEmpty(comLicense.getLicenseName()) 
+								if ((isEmpty(comLicense.getLicenseName()) 
 									&& isEmpty(comLicense.getLicenseText()) 
 									&& isEmpty(comLicense.getOssCopyright()))) {
 									OssComponentsLicense license = CommonFunction.reMakeLicenseBean(ossBean, CoConstDef.LICENSE_DIV_SINGLE);
@@ -2121,33 +2121,33 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	
 	@Transactional
 	private void addOssComponentByBinaryInfo(List<OssComponents> componentList, Map<String, List<Map<String, Object>>> binaryRegInfoMap) {
-		for(OssComponents bean : componentList) {
+		for (OssComponents bean : componentList) {
 			String binaryName = avoidNull(bean.getBinaryName());
 			String componentId = bean.getComponentId();
 			
-			if(isEmpty(binaryName)) {
+			if (isEmpty(binaryName)) {
 				continue;
 			}
 			
-			if(!binaryRegInfoMap.containsKey(binaryName)) {
+			if (!binaryRegInfoMap.containsKey(binaryName)) {
 				continue;
 			}
 			
 			List<Map<String, Object>> binaryInfoList = (List<Map<String, Object>>) binaryRegInfoMap.get(binaryName);
 			
 			boolean addOssComponentFlag = false;
-			for(Map<String, Object> binaryInfo : binaryInfoList) {
-				if(binaryInfo.containsKey("ossName")) {
+			for (Map<String, Object> binaryInfo : binaryInfoList) {
+				if (binaryInfo.containsKey("ossName")) {
 					Map<String, OssMaster> ossInfo = CoCodeManager.OSS_INFO_UPPER;
 					String ossName = (String) binaryInfo.get("ossName");
 					String ossVersion = "";
 					String _binaryLicenseStr = "";
 					
-					if(binaryInfo.containsKey("ossVersion")) {
+					if (binaryInfo.containsKey("ossVersion")) {
 						ossVersion = (String) binaryInfo.get("ossVersion");
 					}
 					
-					if(binaryInfo.containsKey("license")) {
+					if (binaryInfo.containsKey("license")) {
 						_binaryLicenseStr = (String) binaryInfo.get("license");
 					}
 					
@@ -2161,8 +2161,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 					// ossmaster => projectIdentification 으로 변한
 					ProjectIdentification updateBean = new ProjectIdentification();
 					
-					if(ossBean != null) {
-						if(!isEmptyOss) {
+					if (ossBean != null) {
+						if (!isEmptyOss) {
 							updateBean.setOssId(ossBean.getOssId());
 						}
 						
@@ -2188,7 +2188,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 					updateBean.setCustomBinaryYn(bean.getCustomBinaryYn());
 					
 					// 하나의 binary에 대해서 여러개의 OSS가 적용된 경우, 최초 한번만 업데이트하고 이후부터는 신규 등록한다.
-					if(addOssComponentFlag) {
+					if (addOssComponentFlag) {
 						updateBean.setReferenceId(bean.getReferenceId());
 						updateBean.setReferenceDiv(bean.getReferenceDiv());
 						
@@ -2206,9 +2206,9 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						
 					List<String> selectedLicenseIdList = new ArrayList<>();
 					
-					if(!isEmpty(_binaryLicenseStr)) {
-						for(String _licenseName : _binaryLicenseStr.split(",")) {
-							if(isEmpty(_licenseName)) {
+					if (!isEmpty(_binaryLicenseStr)) {
+						for (String _licenseName : _binaryLicenseStr.split(",")) {
+							if (isEmpty(_licenseName)) {
 								continue;
 							}
 							
@@ -2216,7 +2216,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 							
 							String _licenseId = CommonFunction.getLicenseIdByName(_licenseName);
 							
-							if(!isEmpty(_licenseId)) {
+							if (!isEmpty(_licenseId)) {
 								selectedLicenseIdList.add(_licenseId);
 							}
 						}
@@ -2225,10 +2225,10 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 					List<OssComponentsLicense> updateLicenseList = new ArrayList<>();
 						
 					// oss name이 하이픈이 아니라면, OSS List에 등록된 정보를 기준으로 취합
-					if(!isEmptyOss) {
+					if (!isEmptyOss) {
 						boolean hasSelectedLicense = false;
 						
-						for(OssLicense license : ossBean.getOssLicenses()) {
+						for (OssLicense license : ossBean.getOssLicenses()) {
 							OssComponentsLicense componentLicense = new OssComponentsLicense();
 							
 							componentLicense.setComponentId(componentId);
@@ -2236,7 +2236,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 							componentLicense.setLicenseName(license.getLicenseName());
 							// license text 설정은 불필요함
 							
-							if(selectedLicenseIdList.contains(componentLicense.getLicenseId())) {
+							if (selectedLicenseIdList.contains(componentLicense.getLicenseId())) {
 								hasSelectedLicense = true;
 								componentLicense.setExcludeYn(CoConstDef.FLAG_NO);
 							}
@@ -2244,8 +2244,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 							updateLicenseList.add(componentLicense);
 						}
 						
-						for(OssComponentsLicense license : updateLicenseList) {
-							if(hasSelectedLicense) {
+						for (OssComponentsLicense license : updateLicenseList) {
+							if (hasSelectedLicense) {
 								license.setExcludeYn(avoidNull(license.getExcludeYn(), CoConstDef.FLAG_YES));
 							} else {
 								license.setExcludeYn(CoConstDef.FLAG_NO);
@@ -2261,7 +2261,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						license.setComponentId(componentId);
 						
 						// binary db에 등록된 license 정보가 license master에 등록되어 있다면 master 정보를 사용
-						if(!isEmpty(_binaryLicenseStr) && CoCodeManager.LICENSE_INFO_UPPER.containsKey(_binaryLicenseStr.toUpperCase().trim())) {
+						if (!isEmpty(_binaryLicenseStr) && CoCodeManager.LICENSE_INFO_UPPER.containsKey(_binaryLicenseStr.toUpperCase().trim())) {
 							LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(_binaryLicenseStr.toUpperCase().trim());
 							license.setLicenseId(licenseMaster.getLicenseId());
 							license.setLicenseName(avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseName()));
@@ -2280,23 +2280,23 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	
 	@Transactional
 	private void addOssComponentByBinaryInfoAndroid(List<OssComponents> componentList, Map<String, List<Map<String, Object>>> binaryRegInfoMap) {
-		for(OssComponents bean : componentList) {
+		for (OssComponents bean : componentList) {
 			String binaryName = avoidNull(bean.getBinaryName());
 			
-			if(binaryName.indexOf("/") > -1) {
+			if (binaryName.indexOf("/") > -1) {
 				binaryName = binaryName.substring(binaryName.lastIndexOf("/") + 1);
 			}
 			
-			if(isEmpty(binaryName)) {
+			if (isEmpty(binaryName)) {
 				continue;
 			}
 			
 			// 사용자가 입력한 oss가 있으면 설정하지 않음
-			if(!isEmpty(bean.getOssName())) {
+			if (!isEmpty(bean.getOssName())) {
 				continue;
 			}
 			
-			if(!binaryRegInfoMap.containsKey(binaryName)) {
+			if (!binaryRegInfoMap.containsKey(binaryName)) {
 				continue;
 			}
 			
@@ -2304,24 +2304,24 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			boolean addOssComponentFlag = false;
 			
-			for(Map<String, Object> binaryInfo : binaryInfoList) {
-				if(binaryInfo.containsKey("ossName")) {
+			for (Map<String, Object> binaryInfo : binaryInfoList) {
+				if (binaryInfo.containsKey("ossName")) {
 					Map<String, OssMaster> ossInfo = CoCodeManager.OSS_INFO_UPPER;
 					String ossName = (String) binaryInfo.get("ossName");
 					String ossVersion = "";
 					String _binaryLicenseStr = "";
 					
-					if(binaryInfo.containsKey("ossVersion")) {
+					if (binaryInfo.containsKey("ossVersion")) {
 						ossVersion = (String) binaryInfo.get("ossVersion");
 					}
 					
-					if(binaryInfo.containsKey("license")) {
+					if (binaryInfo.containsKey("license")) {
 						_binaryLicenseStr = (String) binaryInfo.get("license");
 					}
 					
 					String key = ossName + "_" + ossVersion;
 					
-					if("-".equals(ossName) || ossInfo.containsKey(key.toUpperCase())) {
+					if ("-".equals(ossName) || ossInfo.containsKey(key.toUpperCase())) {
 						// oss name + version 이 일치하는 oss 가 존재하면, update 한다.
 						boolean isEmptyOss = "-".equals(ossName);
 						OssMaster ossBean = ossInfo.get(key.toUpperCase());
@@ -2330,7 +2330,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						// ossmaster => projectIdentification 으로 변한
 						ProjectIdentification updateBean = new ProjectIdentification();
 						
-						if(!isEmptyOss) {
+						if (!isEmptyOss) {
 							updateBean.setOssId(ossBean.getOssId());
 						}
 						
@@ -2348,7 +2348,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						updateBean.setCustomBinaryYn(bean.getCustomBinaryYn());
 						
 						// 하나의 binary에 대해서 여러개의 OSS가 적용된 경우, 최초 한번만 업데이트하고 이후부터는 신규 등록한다.
-						if(addOssComponentFlag) {
+						if (addOssComponentFlag) {
 							updateBean.setReferenceId(bean.getReferenceId());
 							updateBean.setReferenceDiv(bean.getReferenceDiv());
 							
@@ -2366,16 +2366,16 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 						List<String> selectedLicenseIdList = new ArrayList<>();
 						
-						if(!isEmpty(_binaryLicenseStr)) {
-							for(String _licenseName : _binaryLicenseStr.split(",")) {
-								if(isEmpty(_licenseName)) {
+						if (!isEmpty(_binaryLicenseStr)) {
+							for (String _licenseName : _binaryLicenseStr.split(",")) {
+								if (isEmpty(_licenseName)) {
 									continue;
 								}
 								
 								_licenseName = _licenseName.trim();
 								String _licenseId = CommonFunction.getLicenseIdByName(_licenseName);
 								
-								if(!isEmpty(_licenseId)) {
+								if (!isEmpty(_licenseId)) {
 									selectedLicenseIdList.add(_licenseId);
 								}
 							}
@@ -2383,17 +2383,17 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						List<OssComponentsLicense> updateLicenseList = new ArrayList<>();
 						
 						// oss name이 하이픈이 아니라면, OSS List에 등록된 정보를 기준으로 취합
-						if(!isEmptyOss) {
+						if (!isEmptyOss) {
 							boolean hasSelectedLicense = false;
 							
-							for(OssLicense license : ossBean.getOssLicenses()) {
+							for (OssLicense license : ossBean.getOssLicenses()) {
 								OssComponentsLicense componentLicense = new OssComponentsLicense();
 								componentLicense.setComponentId(bean.getComponentId());
 								componentLicense.setLicenseId(license.getLicenseId());
 								componentLicense.setLicenseName(license.getLicenseName());
 								
 								// license text 설정은 불필요함
-								if(selectedLicenseIdList.contains(componentLicense.getLicenseId())) {
+								if (selectedLicenseIdList.contains(componentLicense.getLicenseId())) {
 									hasSelectedLicense = true;
 									componentLicense.setExcludeYn(CoConstDef.FLAG_NO);
 								}
@@ -2401,8 +2401,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 								updateLicenseList.add(componentLicense);
 							}
 							
-							for(OssComponentsLicense license : updateLicenseList) {
-								if(hasSelectedLicense) {
+							for (OssComponentsLicense license : updateLicenseList) {
+								if (hasSelectedLicense) {
 									license.setExcludeYn(avoidNull(license.getExcludeYn(), CoConstDef.FLAG_YES));
 								} else {
 									license.setExcludeYn(CoConstDef.FLAG_NO);
@@ -2418,7 +2418,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 							license.setComponentId(addOssComponentFlag ? updateBean.getComponentId() : bean.getComponentId());
 							
 							// binary db에 등록된 license 정보가 license master에 등록되어 있다면 master 정보를 사용
-							if(!isEmpty(_binaryLicenseStr) && CoCodeManager.LICENSE_INFO_UPPER.containsKey(_binaryLicenseStr.toUpperCase().trim())) {
+							if (!isEmpty(_binaryLicenseStr) && CoCodeManager.LICENSE_INFO_UPPER.containsKey(_binaryLicenseStr.toUpperCase().trim())) {
 								LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(_binaryLicenseStr.toUpperCase().trim());
 								license.setLicenseId(licenseMaster.getLicenseId());
 								license.setLicenseName(avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseName()));
@@ -2445,19 +2445,19 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		List<String> ossCheckParam = new ArrayList<>();
 		List<String> licenseCheckParam = new ArrayList<>();
 		
-		for(ProjectIdentification bean : ossComponentList) {
+		for (ProjectIdentification bean : ossComponentList) {
 			String _ossName = avoidNull(bean.getOssName()).trim();
 			int isAdminCheck = projectMapper.selectAdminCheckCnt(bean);
 			
-			if(!isEmpty(_ossName) && !"-".equals(_ossName) && !ossCheckParam.contains(_ossName) && isAdminCheck < 1) {
+			if (!isEmpty(_ossName) && !"-".equals(_ossName) && !ossCheckParam.contains(_ossName) && isAdminCheck < 1) {
 				ossCheckParam.add(_ossName);
 			}
 			
-			if(CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())) {
+			if (CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())) {
 				// 여기서 할 필요 없음
 			} else {
 				String _licenseName = avoidNull(bean.getLicenseName()).trim();
-				if(!isEmpty(_licenseName) && !licenseCheckParam.contains(_licenseName)) {
+				if (!isEmpty(_licenseName) && !licenseCheckParam.contains(_licenseName)) {
 					licenseCheckParam.add(_licenseName);
 				}
 			}
@@ -2468,7 +2468,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			for (ProjectIdentification licenseBean : licenseList) {
 				String _licenseName = avoidNull(licenseBean.getLicenseName()).trim();
 				
-				if(!isEmpty(_licenseName) && !licenseCheckParam.contains(_licenseName)) {
+				if (!isEmpty(_licenseName) && !licenseCheckParam.contains(_licenseName)) {
 					licenseCheckParam.add(_licenseName);
 				}
 			}
@@ -2476,32 +2476,32 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		List<OssMaster> ossNickNameList = null;
 		
-		if(!ossCheckParam.isEmpty()) {
+		if (!ossCheckParam.isEmpty()) {
 			OssMaster param = new OssMaster();
 			param.setOssNames(ossCheckParam.toArray(new String[ossCheckParam.size()]));
 			ossNickNameList = projectMapper.checkOssNickName(param);
 			
-			if(ossNickNameList != null) {
-				for(OssMaster bean : ossNickNameList) {
+			if (ossNickNameList != null) {
+				for (OssMaster bean : ossNickNameList) {
 					String _disp = bean.getOssNickname() + " => " + bean.getOssName();
 					
-					if(!ossNickNameCheckResult.contains(_disp)) {
+					if (!ossNickNameCheckResult.contains(_disp)) {
 						ossNickNameCheckResult.add(_disp);
 					}
 				}
 			}
 		}
 		
-		if(!licenseCheckParam.isEmpty()) {
-			for(String licenseName : licenseCheckParam) {
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
+		if (!licenseCheckParam.isEmpty()) {
+			for (String licenseName : licenseCheckParam) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
 					LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(licenseName.toUpperCase());
-					if(licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
-						for(String s : licenseMaster.getLicenseNicknameList()) {
-							if(licenseName.equalsIgnoreCase(s)) {
+					if (licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
+						for (String s : licenseMaster.getLicenseNicknameList()) {
+							if (licenseName.equalsIgnoreCase(s)) {
 								String disp = licenseName + " => " + avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseNameTemp());
 								
-								if(!licenseNickNameCheckResult.contains(disp)) {
+								if (!licenseNickNameCheckResult.contains(disp)) {
 									licenseNickNameCheckResult.add(disp);
 									
 									break;
@@ -2534,7 +2534,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		List<OssComponents> componentId = projectMapper.selectComponentId(identification);
 		
 		// 기존 bom 정보를 모두 물리삭제하고 다시 등록한다.
-		if(componentId.size() > 0){
+		if (componentId.size() > 0){
 			for (int i = 0; i < componentId.size(); i++) {
 				projectMapper.deleteOssComponentsLicense(componentId.get(i));
 			}
@@ -2544,8 +2544,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		Map<String, Object> mergeListMap = getIdentificationGridList(identification);
 		
-		if(mergeListMap != null && mergeListMap.get("rows") != null) {
-			for(ProjectIdentification bean : (List<ProjectIdentification>)mergeListMap.get("rows")) {
+		if (mergeListMap != null && mergeListMap.get("rows") != null) {
+			for (ProjectIdentification bean : (List<ProjectIdentification>)mergeListMap.get("rows")) {
 				
 				bean.setRefDiv(bean.getReferenceDiv());
 				bean.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_BOM);
@@ -2556,19 +2556,19 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				// 그리드 데이터 넣기
 				for (ProjectIdentification gridData : projectIdentification) {
 					// merge 결과 (src/bat/3rd) 일시
-					if(gridData.getRefComponentId().contains(bean.getRefComponentId())){
+					if (gridData.getRefComponentId().contains(bean.getRefComponentId())){
 						bean.setMergePreDiv(gridData.getMergePreDiv());
 						
 						// BOM에 초기표시된 obligation을 초기 값으로 설정
 						// needs check의 경우만 화면에서 입력받는다.
-						if(CoConstDef.FLAG_YES.equals(gridData.getAdminCheckYn())) {
+						if (CoConstDef.FLAG_YES.equals(gridData.getAdminCheckYn())) {
 							bean.setAdminCheckYn(gridData.getAdminCheckYn());
 							
-							if(CoConstDef.FLAG_YES.equals(gridData.getSource())) {
+							if (CoConstDef.FLAG_YES.equals(gridData.getSource())) {
 								bean.setObligationType(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
-							} else if(CoConstDef.FLAG_YES.equals(gridData.getNotify())) {
+							} else if (CoConstDef.FLAG_YES.equals(gridData.getNotify())) {
 								bean.setObligationType(CoConstDef.CD_DTL_OBLIGATION_NOTICE);
-							} else if(CoConstDef.FLAG_NO.equals(gridData.getNotify()) && CoConstDef.FLAG_NO.equals(gridData.getSource())) {
+							} else if (CoConstDef.FLAG_NO.equals(gridData.getNotify()) && CoConstDef.FLAG_NO.equals(gridData.getSource())) {
 								bean.setObligationType(CoConstDef.CD_DTL_OBLIGATION_NEEDSCHECK_SELECTED);
 							}
 						}
@@ -2583,7 +2583,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				projectMapper.registBomComponents(bean);
 				List<OssComponentsLicense> licenseList = CommonFunction.findOssLicenseIdAndName(bean.getOssId(), bean.getOssComponentsLicenseList());
 				
-				for(OssComponentsLicense licenseBean : licenseList) {
+				for (OssComponentsLicense licenseBean : licenseList) {
 					licenseBean.setComponentId(bean.getComponentId());
 					
 					projectMapper.registComponentLicense(licenseBean);
@@ -2610,8 +2610,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		param = projectMapper.selectProjectMaster2(param);
 		
 		//review 상태로 변경시 reviewer가 설정되어 있지 않은 경우, reviewer도 업데이트 한다.
-		if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(project.getIdentificationStatus())) {
-			if(isEmpty(param.getReviewer())) {
+		if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(project.getIdentificationStatus())) {
+			if (isEmpty(param.getReviewer())) {
 				param.setModifier(param.getLoginUserName());
 				param.setReviewer(param.getLoginUserName());
 				
@@ -2642,7 +2642,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		String userComment = project.getUserComment();
 		String statusCode = project.getIdentificationStatus();
 		
-		if(isEmpty(statusCode)) {
+		if (isEmpty(statusCode)) {
 			statusCode = project.getVerificationStatus();
 		}
 		
@@ -2686,25 +2686,25 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				
 				String networkRedistribution = CoCodeManager.getCodeString(CoConstDef.CD_LICENSE_RESTRICTION, CoConstDef.CD_LICENSE_NETWORK_RESTRICTION);
 				
-				for(ProjectIdentification _projectBean : (List<ProjectIdentification>) map.get("rows")) {
-					if(hasSourceOss && hasNotificationOss && isNetworkRestriction) {
+				for (ProjectIdentification _projectBean : (List<ProjectIdentification>) map.get("rows")) {
+					if (hasSourceOss && hasNotificationOss && isNetworkRestriction) {
 						break;
 					}
 					
-					if(!hasNotificationOss) {
-						if(!CoConstDef.FLAG_YES.equals(_projectBean.getExcludeYn()) && ("10".equals(_projectBean.getObligationType()) || "11".equals(_projectBean.getObligationType()) )) {
+					if (!hasNotificationOss) {
+						if (!CoConstDef.FLAG_YES.equals(_projectBean.getExcludeYn()) && ("10".equals(_projectBean.getObligationType()) || "11".equals(_projectBean.getObligationType()) )) {
 							hasNotificationOss = true;
 						}
 					}
 					
-					if(!hasSourceOss) {
-						if("11".equals(_projectBean.getObligationType())){
+					if (!hasSourceOss) {
+						if ("11".equals(_projectBean.getObligationType())){
 							hasSourceOss = true;
 						}
 					}
 					
-					if(!isNetworkRestriction) {
-						if(_projectBean.getRestriction().toUpperCase().contains(networkRedistribution.toUpperCase())) {
+					if (!isNetworkRestriction) {
+						if (_projectBean.getRestriction().toUpperCase().contains(networkRedistribution.toUpperCase())) {
 							isNetworkRestriction = true;
 						}
 					}
@@ -2747,8 +2747,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}
 			}
 			
-			if(CoConstDef.FLAG_YES.equals(prjInfo.getNetworkServerType())) {
-				if(!isNetworkRestriction) {
+			if (CoConstDef.FLAG_YES.equals(prjInfo.getNetworkServerType())) {
+				if (!isNetworkRestriction) {
 					project.setSkipPackageFlag(CoConstDef.FLAG_YES);
 					project.setVerificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_NA);
 					project.setDestributionStatus(CoConstDef.CD_DTL_DISTRIBUTE_STATUS_NA);
@@ -2765,8 +2765,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}
 			}
 			
-			if(CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType())) {
-				if(!hasSourceOss) {
+			if (CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType())) {
+				if (!hasSourceOss) {
 					project.setSkipPackageFlag(CoConstDef.FLAG_YES);
 					project.setVerificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_NA);
 					project.setDestributionStatus(CoConstDef.CD_DTL_DISTRIBUTE_STATUS_NA);
@@ -2777,7 +2777,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			updateProjectIdentificationConfirm(project);
 			
 			// network server 이면서 notice 생성 대상이 없을 경우
-			if( hasNotificationOss
+			if ( hasNotificationOss
 					&& CoConstDef.FLAG_NO.equals(avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTION_TYPE,
 							prjInfo.getDistributionType())).trim().toUpperCase())
 					&& verificationService.checkNetworkServer(prjInfo.getPrjId()) ) {
@@ -2808,7 +2808,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			String _tempComment = "";
 			
-			if(CoConstDef.FLAG_YES.equals(project.getCompleteYn())) {
+			if (CoConstDef.FLAG_YES.equals(project.getCompleteYn())) {
 				_tempComment = avoidNull(CoCodeManager.getCodeExpString(CoConstDef.CD_MAIL_DEFAULT_CONTENTS, CoConstDef.CD_MAIL_TYPE_PROJECT_COMPLETED));
 				userComment =  avoidNull(userComment) + "<br />" + _tempComment;
 			}
@@ -2819,7 +2819,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			// complete mail 발송
 			mailType = CoConstDef.FLAG_YES.equals(project.getCompleteYn()) ? CoConstDef.CD_MAIL_TYPE_PROJECT_COMPLETED : CoConstDef.CD_MAIL_TYPE_PROJECT_REOPENED;
-		} else if(!isEmpty(project.getDropYn())){
+		} else if (!isEmpty(project.getDropYn())){
 			// project drop 시
 			updateProjectMaster(project);
 			
@@ -2846,7 +2846,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				mailType = CoConstDef.CD_MAIL_TYPE_PROJECT_IDENTIFICATION_REQ_REVIEW;
 				
 				// Admin 사용자의 경우 오류가 있어도 request review 가능하도록 수정
-				if(CommonFunction.isAdmin()) {
+				if (CommonFunction.isAdmin()) {
 					ignoreValidation = true;
 				}
 			} else if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_PROGRESS.equals(project.getIdentificationStatus())) {
@@ -2884,7 +2884,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			}
 			
 			// 사용자가 reject하는 경우는 validation check 수행하지 않음
-			if(!ignoreValidation) {
+			if (!ignoreValidation) {
 				// Identification Reqeust review인 경우, 필수 항목 체크 추가
 				Map<String, Object> map = null;
 				// confirm 시 다시 DB Data를 가져와서 체크한다.
@@ -2952,13 +2952,13 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			project.setModifier(project.getLoginUserName());
 			project.setModifiedDate(project.getCreatedDate());
 			
-			if(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(project.getIdentificationStatus())) {
+			if (CoConstDef.CD_DTL_IDENTIFICATION_STATUS_REVIEW.equals(project.getIdentificationStatus())) {
 				checkProjectReviewer(project);
 			}
 			
 			projectMapper.updateProjectMaster(project);
 			
-			if(!isEmpty(project.getVerificationStatus())) {
+			if (!isEmpty(project.getVerificationStatus())) {
 				verificationService.updateProjectAllowDownloadBitFlag(project);
 			}
 		}
@@ -2995,11 +2995,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			List<OssComponents> oldPackagingList = verificationService.getVerifyOssList(project);
 			Map<String, OssComponents> oldPackageInfoMap = new HashMap<>();
 			
-			if(oldPackagingList != null && !oldPackagingList.isEmpty()) {
+			if (oldPackagingList != null && !oldPackagingList.isEmpty()) {
 				// key value 형식으로
 				// key = ref + oss name + oss version + license name
-				for(OssComponents oldBean : oldPackagingList) {
-					if(!isEmpty(oldBean.getFilePath())) {
+				for (OssComponents oldBean : oldPackagingList) {
+					if (!isEmpty(oldBean.getFilePath())) {
 						String key = oldBean.getReferenceDiv() + "|" + oldBean.getOssId() + "|" + oldBean.getLicenseName();
 						
 						oldPackageInfoMap.put(key, oldBean);
@@ -3033,13 +3033,13 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			List<String> groupingList = new ArrayList<>(); // 불필요한 row (중복) 는 미등록
 			List<String> componentList = new ArrayList<>();
 			
-			if(bomList != null) {
-				for(ProjectIdentification bean : bomList) {
-					if(groupingList.contains(bean.getGroupingColumn())) {
+			if (bomList != null) {
+				for (ProjectIdentification bean : bomList) {
+					if (groupingList.contains(bean.getGroupingColumn())) {
 						continue;
 					}
 					
-					if(CoConstDef.FLAG_YES.equals(bean.getAdminCheckYn()) && ("11".equals(bean.getObligationType()) || "10".equals(bean.getObligationType()))) {
+					if (CoConstDef.FLAG_YES.equals(bean.getAdminCheckYn()) && ("11".equals(bean.getObligationType()) || "10".equals(bean.getObligationType()))) {
 						componentList.add(bean.getComponentId()+"-"+bean.getAdminCheckYn());
 					}else {
 						componentList.add(bean.getComponentId());
@@ -3048,15 +3048,15 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			}
 			
 			// 안드로이드 모델인 경우 없을 수도 있음
-			if(!componentList.isEmpty()) {
-				for(String refComponentId : componentList) {
+			if (!componentList.isEmpty()) {
+				for (String refComponentId : componentList) {
 					OssComponents copyParam = new OssComponents();
 					copyParam.setReferenceId(project.getPrjId());
 					copyParam.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_PACKAGING);
 					copyParam.setExcludeYn(CoConstDef.FLAG_NO);
 					copyParam.setAndroidFlag(project.getAndroidFlag());
 					
-					if(refComponentId.contains("-")) {
+					if (refComponentId.contains("-")) {
 						String[] ids = refComponentId.split("-");
 						copyParam.setRefComponentId(ids[0]);
 						copyParam.setAdminCheckYn(ids[1]);
@@ -3069,16 +3069,16 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}
 			}
 			
-			if(oldPackageInfoMap != null && !oldPackageInfoMap.isEmpty()) {
+			if (oldPackageInfoMap != null && !oldPackageInfoMap.isEmpty()) {
 				List<OssComponents> afterPackagingList = verificationService.getVerifyOssList(project);
 				
-				if(afterPackagingList != null && !afterPackagingList.isEmpty()) {
+				if (afterPackagingList != null && !afterPackagingList.isEmpty()) {
 					// key value 형식으로
 					// key = ref + oss name + oss version + license name
-					for(OssComponents newBean : afterPackagingList) {
+					for (OssComponents newBean : afterPackagingList) {
 						String key = newBean.getReferenceDiv() + "|" + newBean.getOssId() + "|" + newBean.getLicenseName();
 						
-						if(oldPackageInfoMap.containsKey(key)) {
+						if (oldPackageInfoMap.containsKey(key)) {
 							newBean.setFilePath(oldPackageInfoMap.get(key).getFilePath());
 							projectMapper.updateFilePath(newBean);
 						}
@@ -3104,7 +3104,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	public void updateProjectMaster(Project project) {
 		projectMapper.updateProjectMaster(project);
 		
-		if(CoConstDef.FLAG_YES.equals(project.getCompleteYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getCompleteYn())) {
 			projectMapper.updateProjectStatusWithComplete(project);
 		}
 	}
@@ -3130,7 +3130,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		List<PartnerMaster> list = new ArrayList<PartnerMaster>();
 		partnerMaster.setStatus("CONF");
 		
-		if("ROLE_USER".equals(partnerMaster.getLoginUserRole())){
+		if ("ROLE_USER".equals(partnerMaster.getLoginUserRole())){
 			records = partnerMapper.selectPartnerMasterTotalCountUser(partnerMaster);
 			partnerMaster.setTotListSize(records);
 			list = partnerMapper.selectPartnerListUser(partnerMaster);
@@ -3165,10 +3165,10 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			list = projectMapper.selectProjectList(project);
 		}
 		
-		if(list != null) {
-			for(Project bean : list) {
+		if (list != null) {
+			for (Project bean : list) {
 				// distribution type code 변환
-				if(!isEmpty(bean.getDistributionType())) {
+				if (!isEmpty(bean.getDistributionType())) {
 					bean.setDistributionType(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, bean.getDistributionType()));
 				}
 			}
@@ -3192,16 +3192,16 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		deleteparam.setReferenceDiv(prjYn?CoConstDef.CD_DTL_COMPONENT_ID_BAT:CoConstDef.CD_DTL_COMPONENT_PARTNER_BAT); // 3rd 추가
 		List<OssComponents> componentsId = projectMapper.selectComponentId(deleteparam);
 		
-		for(int j = 0; j < componentsId.size(); j++){
+		for (int j = 0; j < componentsId.size(); j++){
 			projectMapper.deleteOssComponentsLicense(componentsId.get(j));
 		}
 		
 		// // 한건도 없을시 프로젝트 마스터 BAT 사용가능여부가 N이면 N 그외 null
-		if(ossComponents.size()==0 && prjYn){
+		if (ossComponents.size()==0 && prjYn){
 			Project projectSubStatus = new Project();
 			projectSubStatus.setPrjId(prjId);
 			
-			if(!StringUtil.isEmpty(identificationSubStatusBat)){
+			if (!StringUtil.isEmpty(identificationSubStatusBat)){
 				projectSubStatus.setIdentificationSubStatusBat(identificationSubStatusBat);
 			}else{
 				projectSubStatus.setIdentificationSubStatusBat("X");
@@ -3227,12 +3227,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			// oss_id를 다시 찾는다. (oss name과 oss id가 일치하지 않는 경우가 있을 수 있음)
 			ossBean = CommonFunction.findOssIdAndName(ossBean);
-			if(isEmpty(ossBean.getOssId())) {
+			if (isEmpty(ossBean.getOssId())) {
 				ossBean.setOssId(null);
 			}
 			
 			// BAT STATUS 등록
-			if(i==0 && prjYn){
+			if (i==0 && prjYn){
 				Project projectStatus = new Project();
 				projectStatus.setPrjId(prjId);
 				projectStatus = projectMapper.selectProjectMaster(projectStatus);
@@ -3243,7 +3243,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}
 				
 				// 프로젝트 마스터 BAT 사용가능여부가 N 이면 N 그외 Y
-				if(!StringUtil.isEmpty(identificationSubStatusBat)) {
+				if (!StringUtil.isEmpty(identificationSubStatusBat)) {
 					projectStatus.setIdentificationSubStatusBat(identificationSubStatusBat);
 				} else {
 					projectStatus.setIdentificationSubStatusBat(CoConstDef.FLAG_YES);
@@ -3256,16 +3256,16 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			}
 			
 			//update
-			if(!StringUtil.contains(ossBean.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
+			if (!StringUtil.contains(ossBean.getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
 				//ossComponents 등록
 				projectMapper.updateSrcOssList(ossBean);
 				deleteRows.add(ossBean.getComponentId());
 				
 				//멀티라이센스일 경우
-				if("M".equals(ossBean.getLicenseDiv())){
+				if ("M".equals(ossBean.getLicenseDiv())){
 					for (List<ProjectIdentification> comLicenseList : ossComponentsLicense) {
 						for (ProjectIdentification comLicense : comLicenseList) {
-							if(ossBean.getComponentId().equals(comLicense.getComponentId())){
+							if (ossBean.getComponentId().equals(comLicense.getComponentId())){
 								OssComponentsLicense license = new OssComponentsLicense();
 								// 컴포넌트 ID 설정
 								license.setComponentId(comLicense.getComponentId());
@@ -3319,10 +3319,10 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				deleteRows.add(ossBean.getComponentId());
 				
 				//멀티라이센스일 경우
-				if("M".equals(ossBean.getLicenseDiv())){
+				if ("M".equals(ossBean.getLicenseDiv())){
 					for (List<ProjectIdentification> comLicenseList : ossComponentsLicense) {
 						for (ProjectIdentification comLicense : comLicenseList) {
-							if(exComponentId.equals(comLicense.getComponentId())){
+							if (exComponentId.equals(comLicense.getComponentId())){
 								OssComponentsLicense license = new OssComponentsLicense();
 								// 컴포넌트 ID 설정
 								license.setComponentId(projectMapper.selectLastComponent());
@@ -3385,12 +3385,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		ossComponents.setReferenceDiv(avoidNull(ossComponents.getReferenceDiv(), CoConstDef.CD_DTL_COMPONENT_PARTNER));
 		List<OssComponents> list = projectMapper.getPartnerOssList(ossComponents);
 		
-		for(OssComponents oc : list){
-			if(CoConstDef.FLAG_YES.equals(oc.getExcludeYn())){
+		for (OssComponents oc : list){
+			if (CoConstDef.FLAG_YES.equals(oc.getExcludeYn())){
 				ProjectIdentification PI = new ProjectIdentification();
 				PI.setComponentId(oc.getComponentId());
 				List<ProjectIdentification> subGridData = projectMapper.identificationSubGrid(PI);
-				if(!subGridData.isEmpty()) {
+				if (!subGridData.isEmpty()) {
 					PI = subGridData.get(0);
 					
 					oc.setLicenseName(PI.getLicenseName());
@@ -3425,7 +3425,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				license = projectMapper.selectBomLicense(list.get(i));
 				
 				for (int j = 0; j < license.size(); j++){
-					if(j == 0) {
+					if (j == 0) {
 						licenseId = license.get(j).getLicenseId();
 						licenseName = license.get(j).getLicenseName();
 						licenseText = license.get(j).getLicenseText();
@@ -3443,7 +3443,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				list.get(i).setCopyrightText(copyrightText);
 				
 				// oss Name은 작성하고, oss Version은 작성하지 않은 case경우 해당 분기문에서 처리
-				if(isEmpty(list.get(i).getCveId()) 
+				if (isEmpty(list.get(i).getCveId()) 
 						&& isEmpty(list.get(i).getOssVersion()) 
 						&& !isEmpty(list.get(i).getCvssScoreMax())
 						&& !("-".equals(list.get(i).getOssName()))) { 
@@ -3485,12 +3485,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		ossComponents.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER);
 		List<ProjectIdentification> list = projectMapper.getPartnerOssListValidation(ossComponents);
 		
-		for(ProjectIdentification oc : list){
-			if(CoConstDef.FLAG_YES.equals(oc.getExcludeYn())){
+		for (ProjectIdentification oc : list){
+			if (CoConstDef.FLAG_YES.equals(oc.getExcludeYn())){
 				ProjectIdentification PI = new ProjectIdentification();
 				PI.setComponentId(oc.getComponentId());
 				List<ProjectIdentification> subGridData = projectMapper.identificationSubGrid(PI);
-				if(!subGridData.isEmpty()) {
+				if (!subGridData.isEmpty()) {
 					PI = subGridData.get(0);
 					
 					oc.setLicenseName(PI.getLicenseName());
@@ -3513,15 +3513,15 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			// Identification, 3rd Party 의 OSS Table 정렬 순위 변경 - Restriction 추가
 			map.put("rows", CommonFunction.identificationSortByValidInfo(list, vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false, true));
 			
-			if(!vr.isValid()) {
+			if (!vr.isValid()) {
 				map.put("validData", vr.getValidMessageMap());
 			}
 			
-			if(!vr.isDiff()) {
+			if (!vr.isDiff()) {
 				map.put("diffData", vr.getDiffMessageMap());
 			}
 			
-			if(vr.hasInfo()) {
+			if (vr.hasInfo()) {
 				map.put("infoData", vr.getInfoMessageMap());
 			}
 		}
@@ -3583,7 +3583,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		resultMap.put("reportData", reportData);
 		
-		if(!validMap.isEmpty()) {
+		if (!validMap.isEmpty()) {
 			resultMap.put("validData", validMap);
 		}
 		
@@ -3646,25 +3646,25 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		boolean dbSrcUseFlag = CoConstDef.FLAG_NO.equals(projectInfo.getIdentificationSubStatusSrc());
 		boolean dbBinUseFlag = CoConstDef.FLAG_NO.equals(projectInfo.getIdentificationSubStatusBin());
 		
-		if(partnerUseFlag != dbPartnerUseFlag) {
+		if (partnerUseFlag != dbPartnerUseFlag) {
 			return getMessage("msg.project.checke.changed", new String[]{CoCodeManager.getCodeString(CoConstDef.CD_COMPONENT_DIVISION, CoConstDef.CD_DTL_COMPONENT_ID_PARTNER)});
-		} else if(srcUseFlag != dbSrcUseFlag) {
+		} else if (srcUseFlag != dbSrcUseFlag) {
 			return getMessage("msg.project.checke.changed", new String[]{CoCodeManager.getCodeString(CoConstDef.CD_COMPONENT_DIVISION, CoConstDef.CD_DTL_COMPONENT_ID_SRC)});
-		} else if(binUseFlag != dbBinUseFlag) {
+		} else if (binUseFlag != dbBinUseFlag) {
 			return getMessage("msg.project.checke.changed", new String[]{CoCodeManager.getCodeString(CoConstDef.CD_COMPONENT_DIVISION, CoConstDef.CD_DTL_COMPONENT_ID_BIN)});
 		}
 		
- 		if(dbInfoList != null && !dbInfoList.isEmpty()) {
- 			for(String key : dbInfoList) {
+ 		if (dbInfoList != null && !dbInfoList.isEmpty()) {
+ 			for (String key : dbInfoList) {
  				key = key.toUpperCase();
- 				if(!dbPartnerUseFlag && key.startsWith(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER)) {
+ 				if (!dbPartnerUseFlag && key.startsWith(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER)) {
  					// 3rd의 경우 라이선스를 무시하고 key를 생성하기 때문에 중복되는 경우가 있음
- 					if(!dbPartnerList.contains(key)) {
+ 					if (!dbPartnerList.contains(key)) {
  						dbPartnerList.add(key);
  					}
- 				} else if(!dbSrcUseFlag && key.startsWith(CoConstDef.CD_DTL_COMPONENT_ID_SRC)) {
+ 				} else if (!dbSrcUseFlag && key.startsWith(CoConstDef.CD_DTL_COMPONENT_ID_SRC)) {
  					dbSrcList.add(key);
- 				} else if(!dbBinUseFlag && key.startsWith(CoConstDef.CD_DTL_COMPONENT_ID_BIN)) {
+ 				} else if (!dbBinUseFlag && key.startsWith(CoConstDef.CD_DTL_COMPONENT_ID_BIN)) {
  					dbBinList.add(key);
  				}
  			}
@@ -3672,43 +3672,43 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
  		
 		// 화면정보 비교 key로 convert
 		// 3rd party의 경우는 편집이 불가능하기 때문에 라이선스 정보를 제외하고 비교한다.
- 		if(!partnerUseFlag && partyData != null) {
+ 		if (!partnerUseFlag && partyData != null) {
  			partnerList = makeCompareKey(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER, partyData, null);
  			partnerList2 = makeCompareKey(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER, partyData, null, true);
  		}
  		
- 		if(!srcUseFlag && srcData != null && srcSubData != null) {
+ 		if (!srcUseFlag && srcData != null && srcSubData != null) {
  			srcList = makeCompareKey(CoConstDef.CD_DTL_COMPONENT_ID_SRC, srcData, srcSubData);
  			srcList2 = makeCompareKey(CoConstDef.CD_DTL_COMPONENT_ID_SRC, srcData, srcSubData, true);
  		}
  		
- 		if(!binUseFlag && binData != null && binSubData != null) {
+ 		if (!binUseFlag && binData != null && binSubData != null) {
  			binList = makeCompareKey(CoConstDef.CD_DTL_COMPONENT_ID_BIN, binData, binSubData);
  			binList2 = makeCompareKey(CoConstDef.CD_DTL_COMPONENT_ID_BIN, binData, binSubData, true);
  		}
  		
- 		if(partnerList == null) {
+ 		if (partnerList == null) {
  			partnerList = new ArrayList<>();
  			partnerList2 = new ArrayList<>();
  		}
  		
- 		if(srcList == null) {
+ 		if (srcList == null) {
  			srcList = new ArrayList<>();
  			srcList2 = new ArrayList<>();
  		}
  		
- 		if(binList == null) {
+ 		if (binList == null) {
  			binList = new ArrayList<>();
  			binList2 = new ArrayList<>();
  		}
  		
  		// 1) 건수 비교 
  		// 2) 건수가 동일하기 때문에 sort후 text 비교
- 		if(partnerList.size() != dbPartnerList.size() || !compareList(partnerList, partnerList2, dbPartnerList)) {
+ 		if (partnerList.size() != dbPartnerList.size() || !compareList(partnerList, partnerList2, dbPartnerList)) {
  			return getMessage("msg.project.checke.changed", new String[]{CoCodeManager.getCodeString(CoConstDef.CD_COMPONENT_DIVISION, CoConstDef.CD_DTL_COMPONENT_ID_PARTNER)});
- 		} else if(srcList.size() != dbSrcList.size() || !compareList(srcList, srcList2, dbSrcList)) {
+ 		} else if (srcList.size() != dbSrcList.size() || !compareList(srcList, srcList2, dbSrcList)) {
  			return getMessage("msg.project.checke.changed", new String[]{CoCodeManager.getCodeString(CoConstDef.CD_COMPONENT_DIVISION, CoConstDef.CD_DTL_COMPONENT_ID_SRC)});
- 		} else if(binList.size() != dbBinList.size() || !compareList(binList, binList2, dbBinList)) {
+ 		} else if (binList.size() != dbBinList.size() || !compareList(binList, binList2, dbBinList)) {
  			return getMessage("msg.project.checke.changed", new String[]{CoCodeManager.getCodeString(CoConstDef.CD_COMPONENT_DIVISION, CoConstDef.CD_DTL_COMPONENT_ID_BIN)});
  		}
  		
@@ -3716,7 +3716,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	}
 	
 	private boolean compareList(List<String> list, List<String> list2, List<String> dbList) {
-		if(list.size() != dbList.size()) {
+		if (list.size() != dbList.size()) {
 			return false;
 		}
 		
@@ -3724,8 +3724,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		Collections.sort(list2);
 		Collections.sort(dbList);
 		
-		for(int i=0; i<list.size(); i++) {
-			if(!list.get(i).equalsIgnoreCase(dbList.get(i)) && !list2.get(i).equalsIgnoreCase(dbList.get(i))) {
+		for (int i=0; i<list.size(); i++) {
+			if (!list.get(i).equalsIgnoreCase(dbList.get(i)) && !list2.get(i).equalsIgnoreCase(dbList.get(i))) {
 				return false;
 			}
 		}
@@ -3740,9 +3740,9 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	private List<String> makeCompareKey(String type, List<ProjectIdentification> data, List<List<ProjectIdentification>> subData, boolean convertShortLicenseName) {
 		List<String> list = new ArrayList<>();
 		
-		if(data != null) {
-			for(ProjectIdentification bean : data) {
-				if(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type)) {
+		if (data != null) {
+			for (ProjectIdentification bean : data) {
+				if (CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type)) {
 					String key = type;
 					key += "|" + avoidNull(bean.getOssName()).trim();
 					key += "|" + avoidNull(bean.getOssVersion()).trim();
@@ -3750,11 +3750,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 					key += "|" + avoidNull(bean.getExcludeYn(), CoConstDef.FLAG_NO);
 					key = key.toUpperCase();
 					
-					if(!list.contains(key)) {
+					if (!list.contains(key)) {
 						list.add(key);
 					}
 				} else if (subData != null) {
-					if(CoConstDef.LICENSE_DIV_SINGLE.equals(avoidNull(bean.getLicenseDiv(), CoConstDef.LICENSE_DIV_SINGLE))) {
+					if (CoConstDef.LICENSE_DIV_SINGLE.equals(avoidNull(bean.getLicenseDiv(), CoConstDef.LICENSE_DIV_SINGLE))) {
 						String key = type;
 						key += "|" + avoidNull(bean.getOssName()).trim();
 						key += "|" + avoidNull(bean.getOssVersion()).trim();
@@ -3765,8 +3765,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						
 						list.add(key);
 					} else {
-						if(bean.getComponentLicenseList() != null) {
-							for(ProjectIdentification license : bean.getComponentLicenseList()) {
+						if (bean.getComponentLicenseList() != null) {
+							for (ProjectIdentification license : bean.getComponentLicenseList()) {
 								String key = type;
 								key += "|" + avoidNull(bean.getOssName()).trim();
 								key += "|" + avoidNull(bean.getOssVersion()).trim();
@@ -3804,15 +3804,15 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	 * @return
 	 */
 	private String convertLicenseShortName(String licenseName, boolean convertShortLicenseName) {
-		if(convertShortLicenseName && !isEmpty(licenseName)) {
-			if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
+		if (convertShortLicenseName && !isEmpty(licenseName)) {
+			if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
 				LicenseMaster master = CoCodeManager.LICENSE_INFO_UPPER.get(licenseName.toUpperCase());
 				
-				if(master != null) {
+				if (master != null) {
 					// 현재 라이선스 명이 short identifier 이면 정식 명칭을 반환
-					if(licenseName.equals(master.getShortIdentifier())) {
+					if (licenseName.equals(master.getShortIdentifier())) {
 						licenseName = master.getLicenseNameTemp();
-					} else if(!isEmpty(master.getShortIdentifier())) {
+					} else if (!isEmpty(master.getShortIdentifier())) {
 						// 현재 라이선스 명이 정식 명칭 (또는 닉네임) 인 경우 short identifier를 반환
 						licenseName = master.getShortIdentifier();
 					}
@@ -3825,17 +3825,17 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	
 //	private List<ProjectIdentification> findLicense(String gridId, List<List<ProjectIdentification>> componentLicenseList) {
 //		List<ProjectIdentification> licenseList = new ArrayList<>();
-//		if(componentLicenseList != null && !componentLicenseList.isEmpty()) {
+//		if (componentLicenseList != null && !componentLicenseList.isEmpty()) {
 //			boolean breakFlag = false;
-//			for(List<ProjectIdentification> list : componentLicenseList) {
-//				for(ProjectIdentification bean : list) {
+//			for (List<ProjectIdentification> list : componentLicenseList) {
+//				for (ProjectIdentification bean : list) {
 //					String key = gridId;
-//					if(bean.getGridId().startsWith(key)) {
+//					if (bean.getGridId().startsWith(key)) {
 //						licenseList.add(bean);
 //						breakFlag = true;
 //					}
 //				}
-//				if(breakFlag) {
+//				if (breakFlag) {
 //					break;
 //				}
 //			}
@@ -3847,11 +3847,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	public Map<String, Map<String, String>> getProjectDownloadExpandInfo(Project param) {
 		Map<String, Map<String, String>> resultMap = new HashMap<>();
 		
-		if(param.getPrjIdList() != null && !param.getPrjIdList().isEmpty()) {
+		if (param.getPrjIdList() != null && !param.getPrjIdList().isEmpty()) {
 			List<Map<String, String>> list = projectMapper.getProjectDownloadExpandInfo(param);
 			
-			if(list != null) {
-				for(Map<String, String> map : list) {
+			if (list != null) {
+				for (Map<String, String> map : list) {
 					resultMap.put(String.valueOf(map.get("PRJ_ID")), map);
 				}
 			}
@@ -3862,7 +3862,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 	@Override
 	public void cancelFileDel(Project project) {
-		if(project.getCsvFile() != null) {
+		if (project.getCsvFile() != null) {
 			for (int i = 0; i < project.getCsvFile().size(); i++) {
 				projectMapper.deleteFileBySeq(project.getCsvFile().get(i));
 			}				
@@ -3930,42 +3930,42 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		List<OssMaster> ossNickNameList = null;
 		Map<String, OssMaster> ossNickNameConvertMap = new HashMap<>();
 		
-		for(ProjectIdentification bean : ossComponentList) {
+		for (ProjectIdentification bean : ossComponentList) {
 			String _ossName = avoidNull(bean.getOssName()).trim();
 			int isAdminCheck = projectMapper.selectAdminCheckCnt(bean);
 			
-			if(!isEmpty(_ossName) && !"-".equals(_ossName) && !ossCheckParam.contains(_ossName) && isAdminCheck < 1) {
+			if (!isEmpty(_ossName) && !"-".equals(_ossName) && !ossCheckParam.contains(_ossName) && isAdminCheck < 1) {
 				ossCheckParam.add(_ossName);
 			}
 		}
 		
-		if(!ossCheckParam.isEmpty()) {
+		if (!ossCheckParam.isEmpty()) {
 			OssMaster param = new OssMaster();
 			param.setOssNames(ossCheckParam.toArray(new String[ossCheckParam.size()]));
 			ossNickNameList = projectMapper.checkOssNickName(param);
 			
-			if(ossNickNameList != null) {
-				for(OssMaster bean : ossNickNameList) {
+			if (ossNickNameList != null) {
+				for (OssMaster bean : ossNickNameList) {
 					ossNickNameConvertMap.put(bean.getOssNickname().toUpperCase(), bean);
 				}
 			}
 		}
 
-		for(ProjectIdentification bean : ossComponentList) {
-			if(ossNickNameConvertMap.containsKey(avoidNull(bean.getOssName()).trim().toUpperCase())) {
+		for (ProjectIdentification bean : ossComponentList) {
+			if (ossNickNameConvertMap.containsKey(avoidNull(bean.getOssName()).trim().toUpperCase())) {
 				bean.setOssName(ossNickNameConvertMap.get(avoidNull(bean.getOssName()).trim().toUpperCase()).getOssName());
 			}
 			
 			// license nickname 체크
-			if(CoConstDef.LICENSE_DIV_SINGLE.equals(bean.getLicenseDiv())) {
+			if (CoConstDef.LICENSE_DIV_SINGLE.equals(bean.getLicenseDiv())) {
 				String _licenseName = avoidNull(bean.getLicenseName()).trim();
 				
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
 					LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(_licenseName.toUpperCase());
 					
-					if(licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
-						for(String s : licenseMaster.getLicenseNicknameList()) {
-							if(_licenseName.equalsIgnoreCase(s)) {
+					if (licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
+						for (String s : licenseMaster.getLicenseNicknameList()) {
+							if (_licenseName.equalsIgnoreCase(s)) {
 								bean.setLicenseName(avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseNameTemp()));
 								
 								break;
@@ -3982,16 +3982,16 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	@Override
 	public List<List<ProjectIdentification>> convertLicenseNickName(
 			List<List<ProjectIdentification>> ossComponentLicenseList) {
-		if(ossComponentLicenseList != null) {
-			for(List<ProjectIdentification> licenseList : ossComponentLicenseList) {
+		if (ossComponentLicenseList != null) {
+			for (List<ProjectIdentification> licenseList : ossComponentLicenseList) {
 				for (ProjectIdentification licenseBean : licenseList) {
 					String _licenseName = avoidNull(licenseBean.getLicenseName()).trim();
-					if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
+					if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
 						LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(_licenseName.toUpperCase());
 						
-						if(licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
-							for(String s : licenseMaster.getLicenseNicknameList()) {
-								if(_licenseName.equalsIgnoreCase(s)) {
+						if (licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
+							for (String s : licenseMaster.getLicenseNicknameList()) {
+								if (_licenseName.equalsIgnoreCase(s)) {
 									licenseBean.setLicenseName(avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseNameTemp()));
 									
 									break;
@@ -4008,8 +4008,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 	@Override
 	public void addWatcher(Project project) {
-		if(!isEmpty(project.getPrjEmail())) {
-			if(projectMapper.existsWatcherByEmail(project) == 0) { // 이미 추가된 watcher 체크
+		if (!isEmpty(project.getPrjEmail())) {
+			if (projectMapper.existsWatcherByEmail(project) == 0) { // 이미 추가된 watcher 체크
 				projectMapper.insertWatcher(project); // watcher 추가
 				
 				// email 발송
@@ -4025,7 +4025,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}
 			}
 		} else {
-			if(projectMapper.existsWatcherByUser(project) == 0) { // 이미 추가된 watcher 체크
+			if (projectMapper.existsWatcherByUser(project) == 0) { // 이미 추가된 watcher 체크
 				projectMapper.insertWatcher(project); // watcher 추가
 			}
 		}
@@ -4046,7 +4046,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		boolean result = false;
 		int i = projectMapper.existsWatcher(project);
 		
-		if(i > 0){
+		if (i > 0){
 			result = true;
 		}	
 		
@@ -4080,7 +4080,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		projectMapper.updateDistributeTarget(project);
 		projectMapper.deleteProjectModel(project);
 		if (project.getModelList().size() > 0) {
-			for(Project bean : project.getModelList()) {
+			for (Project bean : project.getModelList()) {
 				bean.setPrjId(project.getPrjId());
 				bean.setModelName(bean.getModelName().trim().toUpperCase().replaceAll("\t", ""));
 				projectMapper.insertProjectModel(bean);
@@ -4119,7 +4119,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		int i = projectMapper.existsAddList(project);
 
-		if(i > 0){
+		if (i > 0){
 			projectMapper.deleteAddList(project);
 			
 			result = true;
@@ -4130,7 +4130,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 	@Override
 	public void insertAddList(List<Project> project) {
-		for(Project p : project){
+		for (Project p : project){
 			projectMapper.insertAddList(p);
 		}
 	}
@@ -4156,17 +4156,17 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		String groupColumn = "";
 		boolean ossNameEmptyFlag = false;
 		
-		for(ProjectIdentification info : gridData) {
-			if(isEmpty(groupColumn)) {
+		for (ProjectIdentification info : gridData) {
+			if (isEmpty(groupColumn)) {
 				groupColumn = info.getOssName() + "-" + info.getOssVersion();
 			}
 			
-			if("-".equals(groupColumn)) {
-				if("NA".equals(info.getLicenseType())) {
+			if ("-".equals(groupColumn)) {
+				if ("NA".equals(info.getLicenseType())) {
 					ossNameEmptyFlag = true;
 				}
 			}
-			if(groupColumn.equals(info.getOssName() + "-" + info.getOssVersion()) // 같은 groupColumn이면 데이터를 쌓음
+			if (groupColumn.equals(info.getOssName() + "-" + info.getOssVersion()) // 같은 groupColumn이면 데이터를 쌓음
 					&& !("-".equals(info.getOssName()) 
 					&& !"NA".equals(info.getLicenseType()))
 					&& !ossNameEmptyFlag) { // 단, OSS Name: - 이면서, License Type: Proprietary이 아닌 경우 Row를 합치지 않음.
@@ -4187,11 +4187,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	}
 	
 	public static void setMergeData(List<ProjectIdentification> tempData, List<ProjectIdentification> resultGridData){
-		if(tempData.size() > 0) {
+		if (tempData.size() > 0) {
 			Collections.sort(tempData, new Comparator<ProjectIdentification>() {
 				@Override
 				public int compare(ProjectIdentification o1, ProjectIdentification o2) {
-					if(o1.getLicenseName().length() >= o2.getLicenseName().length()) { // license name이 같으면 bomList조회해온 순서 그대로 유지함. license name이 다르면 순서변경
+					if (o1.getLicenseName().length() >= o2.getLicenseName().length()) { // license name이 같으면 bomList조회해온 순서 그대로 유지함. license name이 다르면 순서변경
 						return 1;
 					}else {
 						return -1;
@@ -4201,16 +4201,16 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			ProjectIdentification rtnBean = null;
 			
-			for(ProjectIdentification temp : tempData) {
-				if(rtnBean == null) {
+			for (ProjectIdentification temp : tempData) {
+				if (rtnBean == null) {
 					rtnBean = temp;
 					continue;
 				}
 				
 				String key = temp.getOssName() + "-" + temp.getLicenseType();
 				
-				if("--NA".equals(key)) {
-					if(!rtnBean.getLicenseName().contains(temp.getLicenseName())) {
+				if ("--NA".equals(key)) {
+					if (!rtnBean.getLicenseName().contains(temp.getLicenseName())) {
 						resultGridData.add(rtnBean);
 						rtnBean = temp;
 						continue;
@@ -4218,77 +4218,77 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}
 				
 				// 동일한 oss name과 version일 경우 license 정보를 중복제거하여 merge 함.
-				for(String licenseName : temp.getLicenseName().split(",")) {
+				for (String licenseName : temp.getLicenseName().split(",")) {
 					boolean equalFlag = false;
 					
-					for(String rtnLicenseName : rtnBean.getLicenseName().split(",")) {
-						if(rtnLicenseName.equals(licenseName)) {
+					for (String rtnLicenseName : rtnBean.getLicenseName().split(",")) {
+						if (rtnLicenseName.equals(licenseName)) {
 							equalFlag = true;
 							break;
 						}
 					}
 					
-					if(!equalFlag) {
+					if (!equalFlag) {
 						rtnBean.setLicenseName(rtnBean.getLicenseName() + "," + licenseName);
 					}
 				}
 				
 				List<OssComponentsLicense> rtnComponentLicenseList = new ArrayList<OssComponentsLicense>();
 				
-				for(OssComponentsLicense list : temp.getOssComponentsLicenseList()) {
+				for (OssComponentsLicense list : temp.getOssComponentsLicenseList()) {
 					int equalsItemList = (int) rtnBean.getOssComponentsLicenseList()
 														.stream()
 														.filter(e -> list.getLicenseName().equals(e.getLicenseName())) // 동일한 licenseName을 filter
 														.collect(Collectors.toList()) // return을 list로변환
 														.size(); // 해당 list의 size
 					
-					if(equalsItemList == 0) {
+					if (equalsItemList == 0) {
 						rtnComponentLicenseList.add(list);
 					}
 				}
 				
 				rtnBean.getOssComponentsLicenseList().addAll(rtnComponentLicenseList);
 				
-				if(!rtnBean.getRefComponentId().contains(temp.getRefComponentId())) {
+				if (!rtnBean.getRefComponentId().contains(temp.getRefComponentId())) {
 					rtnBean.setRefComponentId(rtnBean.getRefComponentId() + "," + temp.getRefComponentId());
 				}
 				
-				if(!rtnBean.getRefDiv().contains(temp.getRefDiv())) {
+				if (!rtnBean.getRefDiv().contains(temp.getRefDiv())) {
 					rtnBean.setRefDiv(rtnBean.getRefDiv() + "," + temp.getRefDiv());
 				}
 
-				if(!isEmpty(temp.getRestriction())) {
-					for(String restriction : temp.getRestriction().split("\\n")) {
-						if(!rtnBean.getRestriction().contains(restriction)) {
+				if (!isEmpty(temp.getRestriction())) {
+					for (String restriction : temp.getRestriction().split("\\n")) {
+						if (!rtnBean.getRestriction().contains(restriction)) {
 							rtnBean.setRestriction(rtnBean.getRestriction() + "\\n" + restriction);
 						}
 					}
 				}
 				
 				// 특정 tab에 해당 Data가 공란이고, 다른 tab에 해당 Data가 값이 작성되어 있을 경우 첫번째 발견되는 data를 넣어줌. (대상 downloadLocation, homepage, copyrightText)
-				if(isEmpty(rtnBean.getDownloadLocation())) { 
-					if(!isEmpty(temp.getDownloadLocation())) {
+				if (isEmpty(rtnBean.getDownloadLocation())) { 
+					if (!isEmpty(temp.getDownloadLocation())) {
 						rtnBean.setDownloadLocation(temp.getDownloadLocation());
 					}
 				}
 				
-				if(isEmpty(rtnBean.getHomepage())) {
-					if(!isEmpty(temp.getHomepage())) {
+				if (isEmpty(rtnBean.getHomepage())) {
+					if (!isEmpty(temp.getHomepage())) {
 						rtnBean.setHomepage(temp.getHomepage());
 					}
 				}
 				
-				if(isEmpty(rtnBean.getCopyrightText())) {
-					if(!isEmpty(temp.getCopyrightText())) {
+				if (isEmpty(rtnBean.getCopyrightText())) {
+					if (!isEmpty(temp.getCopyrightText())) {
 						rtnBean.setCopyrightText(temp.getCopyrightText());
 					}
 				}
 				
-				if(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE.equals(temp.getObligationType())){
+				if (CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE.equals(temp.getObligationType())){
 					rtnBean.setObligationType(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
 					rtnBean.setObligationLicense(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
 					rtnBean.setPreObligationType(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE);
-				} else if(CoConstDef.CD_DTL_OBLIGATION_NOTICE.equals(temp.getObligationType())
+				} else if (CoConstDef.CD_DTL_OBLIGATION_NOTICE.equals(temp.getObligationType())
 						&& ("").equals(avoidNull(rtnBean.getObligationType(), ""))){
 					rtnBean.setObligationType(CoConstDef.CD_DTL_OBLIGATION_NOTICE);
 					rtnBean.setObligationLicense(CoConstDef.CD_DTL_OBLIGATION_NOTICE);
@@ -4312,14 +4312,14 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		int errCnt = 0;
 		int diffCnt = 0;
 		
-		if(mainData != null) {
+		if (mainData != null) {
 			emptyBinaryPathCnt = mainData.stream()
 											.filter(c -> isEmpty(c.getBinaryName()))
 											.collect(Collectors.toList())
 											.size();
 		}
 		
-		if(validData != null) {
+		if (validData != null) {
 			errCnt = validData.keySet().stream()
 								.filter(c -> c.toUpperCase().contains("OSS_NAME") 
 												|| c.toUpperCase().contains("OSS_VERSION") 
@@ -4328,12 +4328,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 								.size();
 		}
 		
-		if(diffData != null) {
+		if (diffData != null) {
 			Map<String, Object> diffDataMap = new HashMap<String, Object>();
-			for(String key : diffData.keySet()) {
-				if(key.toUpperCase().contains("LICENSENAME")) {
+			for (String key : diffData.keySet()) {
+				if (key.toUpperCase().contains("LICENSENAME")) {
 					String diffMsg = (String) diffData.get(key);
-					if(!diffMsg.contains("Declared")) {
+					if (!diffMsg.contains("Declared")) {
 						diffDataMap.put(key, diffData.get(key));
 					}
 				} else {
@@ -4341,7 +4341,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				}
 			}
 			
-			if(!diffDataMap.isEmpty()) {
+			if (!diffDataMap.isEmpty()) {
 				diffCnt = diffDataMap.keySet()
 						.stream()
 						.filter(c -> c.toUpperCase().contains("OSSNAME") 
@@ -4353,12 +4353,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 		
 		// OSS Name, OSS Version, License에 Warning message(빨간색, 파란색)가 있는 Row 또는 Binary Name이 공란인 Row
-		if(emptyBinaryPathCnt > 0 || errCnt > 0 || diffCnt > 0) {
+		if (emptyBinaryPathCnt > 0 || errCnt > 0 || diffCnt > 0) {
 			validMsg = "You can download NOTICE only if there is no warning message in OSS Name, OSS Version, License or Binary Name is not null.";
 		}
 		
 		// 출력할 Binary가 없는 경우(= 출력 조건에 해당하는 Row가 없는 경우)
-		if(mainData.size() == 0 || diffData.size() == 0) {
+		if (mainData.size() == 0 || diffData.size() == 0) {
 			validMsg = "There is no binary that meets the conditions for creating NOTICE.";
 		}
 		
@@ -4382,11 +4382,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		String filePath = CommonFunction.emptyCheckProperty("common.public_supplement_notice_path", "/supplement_notice") + "/" + project.getPrjId();
 		File dir = new File(filePath);
 		
-		if(dir.exists()) {  // 전체 삭제 예쩡( html file은 제외함)
-			for(File item : dir.listFiles()) {
-				if(!item.isDirectory() && item.getName().contains(".html")){
+		if (dir.exists()) {  // 전체 삭제 예쩡( html file은 제외함)
+			for (File item : dir.listFiles()) {
+				if (!item.isDirectory() && item.getName().contains(".html")){
 					item.delete();
-				} else if(item.isDirectory()) {
+				} else if (item.isDirectory()) {
 					CommonFunction.removeAll(item); // 하위폴더, file 전체 삭제
 				}
 			}
@@ -4399,16 +4399,16 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		Map<String, List<ProjectIdentification>> mergedBinaryData = getMergedBinaryData(paramMap);
 		List<String> ObligationNoticeLicenseList = new ArrayList<String>();
 		
-		for(List<ProjectIdentification> bean : mergedBinaryData.values()) { // Licenses proc
-			for(ProjectIdentification p : bean) {
-				for(String licenseName : p.getLicenseName().split(",")) {
-					if(!ObligationNoticeLicenseList.contains(licenseName)) {
+		for (List<ProjectIdentification> bean : mergedBinaryData.values()) { // Licenses proc
+			for (ProjectIdentification p : bean) {
+				for (String licenseName : p.getLicenseName().split(",")) {
+					if (!ObligationNoticeLicenseList.contains(licenseName)) {
 						LicenseMaster licenseBean = CoCodeManager.LICENSE_INFO_UPPER.get(licenseName.toUpperCase());
 						
-						if(CoConstDef.FLAG_YES.equals(licenseBean.getObligationNotificationYn())) {
+						if (CoConstDef.FLAG_YES.equals(licenseBean.getObligationNotificationYn())) {
 							String LICENSEFileName = avoidNull(licenseBean.getShortIdentifier(), "");
 							
-							if(isEmpty(LICENSEFileName)) {
+							if (isEmpty(LICENSEFileName)) {
 								LICENSEFileName = "LicenseRef-"+licenseBean.getLicenseName().replaceAll("\\(", "-").replaceAll("\\)", "").replaceAll(" ", "-").replaceAll("--", "-");
 							}
 							
@@ -4422,22 +4422,22 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		String binaryDirPath = filePath + "/needtoadd-notice";
 		
-		for(String binaryPath : mergedBinaryData.keySet()) { // Binary proc
+		for (String binaryPath : mergedBinaryData.keySet()) { // Binary proc
 			Map<String, Object> model = new HashMap<String, Object>();
 			model.put("templateURL", CoCodeManager.getCodeExpString(CoConstDef.CD_NOTICE_DEFAULT, CoConstDef.CD_DTL_SUPPLMENT_NOTICE_TXT_TEMPLATE));
 			model.put("noticeData", mergedBinaryData.get(binaryPath));
 			
 			String contents = CommonFunction.VelocityTemplateToString(model);
 			
-			for(String path : binaryPath.split(",")) {
+			for (String path : binaryPath.split(",")) {
 				String fileName = "";
 				String binaryFilePath = binaryDirPath;
 				
-				if(path.contains("/")) {
+				if (path.contains("/")) {
 					File f = new File(binaryFilePath + "/" + path);
 					fileName = f.getName();
 					File parentFile = f.getParentFile();
-					if(parentFile != null) {
+					if (parentFile != null) {
 						binaryFilePath = parentFile.toString();
 						f = new File(binaryFilePath);
 						f.mkdirs(); // path전체의 directory 생성
@@ -4471,10 +4471,10 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		File fileDir = new File(filePath);
 		
-		if(fileDir.exists()) {
-			for(File f : fileDir.listFiles()) {
-				if(f.getName().contains(".html")) {
-					if(f.delete()) {
+		if (fileDir.exists()) {
+			for (File f : fileDir.listFiles()) {
+				if (f.getName().contains(".html")) {
+					if (f.delete()) {
 						log.debug(filePath + "/" + f.getName() + " is delete success.");
 					} else {
 						log.debug(filePath + "/" + f.getName() + " is delete failed.");
@@ -4483,7 +4483,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			}
 		}
 		
-		if(FileUtil.writeFile(filePath, fileName, contents)) {
+		if (FileUtil.writeFile(filePath, fileName, contents)) {
 			// 파일 등록
 			fileId = fileService.registFileDownload(filePath, fileName, fileName);
 		}
@@ -4511,25 +4511,25 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		Map<String, List<ProjectIdentification>> binaryMergeData = new HashMap<String, List<ProjectIdentification>>();
 		Map<String, String> binaryOssKeyMap = new HashMap<String, String>();
 		
-		for(ProjectIdentification bean : mainData) {
+		for (ProjectIdentification bean : mainData) {
 			List<ProjectIdentification> _list = new ArrayList<>();
 			String _oldKey = null;
 			String key = bean.getOssName() + "|" + bean.getOssVersion() + "|" + bean.getLicenseName();
 			String licenseName = "";
 			
-			if(binaryMergeData.containsKey(bean.getBinaryName())) { // binaryPath 기준으로 merge
+			if (binaryMergeData.containsKey(bean.getBinaryName())) { // binaryPath 기준으로 merge
 				_list = binaryMergeData.get(bean.getBinaryName());
 				_oldKey = binaryOssKeyMap.get(bean.getBinaryName());
 				
-				if(_list != null) {
-					for(ProjectIdentification license : bean.getComponentLicenseList()) {
+				if (_list != null) {
+					for (ProjectIdentification license : bean.getComponentLicenseList()) {
 						LicenseMaster licenseBean = CoCodeManager.LICENSE_INFO_UPPER.get(license.getLicenseName().toUpperCase());
 						license.setLicenseText(avoidNull(licenseBean.getLicenseText()));
 						license.setAttribution(avoidNull(licenseBean.getAttribution()));
 						license.setObligationType(CoConstDef.FLAG_YES.equals(licenseBean.getObligationNotificationYn()) ? CoConstDef.CD_DTL_OBLIGATION_NOTICE : "");
 						
-						if(CoConstDef.FLAG_YES.equals(licenseBean.getObligationNotificationYn())) {
-							if(!isEmpty(licenseName)) {
+						if (CoConstDef.FLAG_YES.equals(licenseBean.getObligationNotificationYn())) {
+							if (!isEmpty(licenseName)) {
 								licenseName += ",";
 							}
 							
@@ -4548,14 +4548,14 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 					binaryOssKeyMap.put(bean.getBinaryName(), str);
 				}
 			} else {
-				for(ProjectIdentification license : bean.getComponentLicenseList()) {
+				for (ProjectIdentification license : bean.getComponentLicenseList()) {
 					LicenseMaster licenseBean = CoCodeManager.LICENSE_INFO_UPPER.get(license.getLicenseName().toUpperCase());
 					license.setLicenseText(avoidNull(licenseBean.getLicenseText()));
 					license.setAttribution(avoidNull(licenseBean.getAttribution()));
 					license.setObligationType(CoConstDef.FLAG_YES.equals(licenseBean.getObligationNotificationYn()) ? CoConstDef.CD_DTL_OBLIGATION_NOTICE : "");
 
-					if(CoConstDef.FLAG_YES.equals(licenseBean.getObligationNotificationYn())) {
-						if(!isEmpty(licenseName)) {
+					if (CoConstDef.FLAG_YES.equals(licenseBean.getObligationNotificationYn())) {
+						if (!isEmpty(licenseName)) {
 							licenseName += ",";
 						}
 						
@@ -4586,11 +4586,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 												.map(Map.Entry<String, String>::getKey)
 												.reduce("", (s1, s2) -> isEmpty(s1) ? s2 : s1 + "," + s2)));
 		
-		for(String binaryNameList : collect.values()) {
-			for(String binaryName : binaryMergeData.keySet()) {
+		for (String binaryNameList : collect.values()) {
+			for (String binaryName : binaryMergeData.keySet()) {
 				int matchCnt = Arrays.asList(binaryNameList.split(",")).stream().filter(s -> s.equals(binaryName)).collect(Collectors.toList()).size();
 				
-				if(matchCnt > 0) {
+				if (matchCnt > 0) {
 					resultData.put(binaryNameList, binaryMergeData.get(binaryName));
 					
 					break;
@@ -4639,11 +4639,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		
 		// status > add
 		int addchk = 0;
-		for(ProjectIdentification after : filteredAfterBomList) {
+		for (ProjectIdentification after : filteredAfterBomList) {
 			String ossName = after.getOssName();
 			int addTargetCnt = filteredBeforeBomList.stream().filter(before -> (before.getOssName()).equals(ossName)).collect(Collectors.toList()).size();
 			
-			if(addTargetCnt == 0) {
+			if (addTargetCnt == 0) {
 				Map<String, String> addMap = new HashMap<String, String>();
 				
 				String afterossname = after.getOssName();
@@ -4679,11 +4679,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				
 		// status > delete
 		int deletechk = 0;
-		for(ProjectIdentification before : filteredBeforeBomList) {
+		for (ProjectIdentification before : filteredBeforeBomList) {
 			String ossName = before.getOssName();
 			List<ProjectIdentification> afterList = filteredAfterBomList.stream().filter(after -> (after.getOssName()).equals(ossName)).collect(Collectors.toList());
 			
-			if(afterList.size() == 0) {
+			if (afterList.size() == 0) {
 				Map<String, String> deleteMap = new HashMap<String, String>();
 				
 				String beforeossname = before.getOssName();
@@ -4935,7 +4935,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			
 			// 최초 저장시에만 상태 변경
 			// row count가 0이어도 사용자가 한번이라도 저장하면 progress 상태로 인지되어야함
-			if(isEmpty(project.getIdentificationStatus())) {
+			if (isEmpty(project.getIdentificationStatus())) {
 				projectSubStatus.setIdentificationStatus(CoConstDef.CD_DTL_IDENTIFICATION_STATUS_PROGRESS);
 			}
 			
@@ -4954,7 +4954,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		partnerList = convertOssNickName3rd(partnerList);
 		
 		// Identification > 3rd Party Tab Insert
-		for(OssComponents bean : partnerList) {
+		for (OssComponents bean : partnerList) {
 			bean.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER);
 			bean.setReferenceId(project.getPrjId());
 			bean.setRefPartnerId(project.getRefPartnerId());
@@ -4975,13 +4975,13 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	public void insertCopyConfirmStatusBomList(Project project, ProjectIdentification identification) {
 		List<ProjectIdentification> bomList = projectMapper.selectBomList(identification);
 		
-		for(ProjectIdentification pi : bomList) {
+		for (ProjectIdentification pi : bomList) {
 			List<OssComponentsLicense> licenseList = projectMapper.selectBomLicense(pi);
 			pi.setReferenceId(project.getPrjId());
 			// 컴포넌트 마스터 인서트
 			projectMapper.registBomComponents(pi);
 			
-			for(OssComponentsLicense licenseBean : licenseList) {
+			for (OssComponentsLicense licenseBean : licenseList) {
 				licenseBean.setComponentId(pi.getComponentId());
 				projectMapper.registComponentLicense(licenseBean);
 			}
@@ -4993,7 +4993,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		Project prj = getProjectBasicInfo(project.getCopyPrjId());
 		List<String> fileSeqs = new ArrayList<>();
 		
-		if(!isEmpty(prj.getPackageFileId())) {
+		if (!isEmpty(prj.getPackageFileId())) {
 			List<UploadFile> uploadFile = fileService.setReusePackagingFile(prj.getPackageFileId());
 			
 			HashMap<String, Object> fileMap = new HashMap<>();
@@ -5003,28 +5003,28 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			fileMap.put("fileSeq", uploadFile.get(0).getRegistSeq());
 			boolean reuseCheck = verificationService.setReusePackagingFile(fileMap);
 			
-			if(reuseCheck) {
+			if (reuseCheck) {
 				fileSeqs.add(uploadFile.get(0).getRegistSeq());
 			}
 			
-			if(!isEmpty(prj.getPackageFileId2())) {
+			if (!isEmpty(prj.getPackageFileId2())) {
 				List<UploadFile> file2 = fileService.setReusePackagingFile(prj.getPackageFileId2());
 				fileMap.put("refFileSeq", prj.getPackageFileId2());
 				fileMap.put("fileSeq", file2.get(0).getRegistSeq());
 				reuseCheck = verificationService.setReusePackagingFile(fileMap);
 				
-				if(reuseCheck) {
+				if (reuseCheck) {
 					fileSeqs.add(file2.get(0).getRegistSeq());
 				}
 			}
 			
-			if(!isEmpty(prj.getPackageFileId3())) {
+			if (!isEmpty(prj.getPackageFileId3())) {
 				List<UploadFile> file3 = fileService.setReusePackagingFile(prj.getPackageFileId3());
 				fileMap.put("refFileSeq", prj.getPackageFileId3());
 				fileMap.put("fileSeq", file3.get(0).getRegistSeq());
 				reuseCheck = verificationService.setReusePackagingFile(fileMap);
 				
-				if(reuseCheck) {
+				if (reuseCheck) {
 					fileSeqs.add(file3.get(0).getRegistSeq());
 				}
 			}
@@ -5047,9 +5047,9 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	public void copySrcAndroidNoticeFile(Project project) {
 		Project prj = getProjectBasicInfo(project.getCopyPrjId());
 		
-		if(!isEmpty(prj.getSrcAndroidNoticeFileId())) {
+		if (!isEmpty(prj.getSrcAndroidNoticeFileId())) {
 			String fileId = fileService.copyPhysicalFile(prj.getSrcAndroidNoticeFileId());
-			if(!isEmpty(fileId)) {
+			if (!isEmpty(fileId)) {
 				project.setSrcAndroidNoticeFileId(fileId);
 				projectMapper.updateFileId(project);
 			}
@@ -5066,11 +5066,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		String division = project.getPrjDivision();
 		String comment = "";
 		
-		for(String prjId : project.getPrjIds()) {
+		for (String prjId : project.getPrjIds()) {
 			param.setPrjId(prjId);
 			Project beforeBean = getProjectDetail(param);
 			
-			if(!avoidNull(beforeBean.getDivision(), "").equals(division)) {
+			if (!avoidNull(beforeBean.getDivision(), "").equals(division)) {
 				Project afterBean = getProjectDetail(param);
 				afterBean.setDivision(division);
 				
@@ -5084,7 +5084,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				beforeBean.setModelList((List<Project>) modelMap.get("currentModelList"));
 				afterBean.setModelList((List<Project>) modelMap.get("currentModelList"));
 				
-				if(afterBean.getWatcherList() != null && !afterBean.getWatcherList().isEmpty()) {
+				if (afterBean.getWatcherList() != null && !afterBean.getWatcherList().isEmpty()) {
 					List<String> prjWatchers = afterBean.getWatcherList().stream().map(e -> e.getPrjDivision() + "/" + e.getPrjUserId()).collect(Collectors.toList());
 					afterBean.setWatchers(prjWatchers.toArray(new String[prjWatchers.size()]));
 				}
@@ -5094,11 +5094,11 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			}
 		}
 		
-		if(!beforeBeanList.isEmpty()) {
+		if (!beforeBeanList.isEmpty()) {
 			updateProjectDivMap.put("before", beforeBeanList);
 		}
 		
-		if(!afterBeanList.isEmpty()) {
+		if (!afterBeanList.isEmpty()) {
 			updateProjectDivMap.put("after", afterBeanList);
 		}
 		
@@ -5115,7 +5115,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		String referenceDivString = "";
 		List<ProjectIdentification> bomList = projectMapper.selectBomList(identification);
 		
-		if(bomList != null) {
+		if (bomList != null) {
 			List<ProjectIdentification> checkList = bomList.stream()
 																.filter(obj -> {
 																	String ossName = (avoidNull(obj.getOssName())).toUpperCase();
@@ -5124,27 +5124,27 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 																	return CoConstDef.FLAG_NO.equals(obj.getAdminCheckYn()) && !isEmpty(compareOssName) && !ossName.equals(compareOssName);
 																}).collect(Collectors.toList());
 			
-			if(checkList.size() > 0) {
-				for(ProjectIdentification row : checkList) {
-					if(CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(row.getOssName().toUpperCase())) {
+			if (checkList.size() > 0) {
+				for (ProjectIdentification row : checkList) {
+					if (CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(row.getOssName().toUpperCase())) {
 						switch(row.getReferenceDiv()) {
 						case CoConstDef.CD_DTL_COMPONENT_ID_PARTNER : 
-							if(!referenceDivString.contains("3rd")) {
+							if (!referenceDivString.contains("3rd")) {
 								referenceDivString += "3rd" + ","; 
 							}
 							break;
 						case CoConstDef.CD_DTL_COMPONENT_ID_SRC : 
-							if(!referenceDivString.contains("SRC")) {
+							if (!referenceDivString.contains("SRC")) {
 								referenceDivString += "SRC" + ","; 
 							}
 							break;
 						case CoConstDef.CD_DTL_COMPONENT_ID_BIN : 
-							if(!referenceDivString.contains("BIN")) {
+							if (!referenceDivString.contains("BIN")) {
 								referenceDivString += "BIN" + ","; 
 							}
 							break;
 						case CoConstDef.CD_DTL_COMPONENT_ID_ANDROID : 
-							if(!referenceDivString.contains("ANDROID")) {
+							if (!referenceDivString.contains("ANDROID")) {
 								referenceDivString += "ANDROID" + ","; 
 							}
 							break;

--- a/src/main/java/oss/fosslight/service/impl/SearchServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SearchServiceImpl.java
@@ -48,7 +48,7 @@ public class SearchServiceImpl extends CoTopComponent implements SearchService {
     @Override
     public OssMaster getOssSearchFilter(String userId) {
         String filterString = searchMapper.selectOssSearchFilter(userId);
-        if(filterString == null) {
+        if (filterString == null) {
             return null;
         }
         return new Gson().fromJson(filterString, OssMaster.class);
@@ -67,7 +67,7 @@ public class SearchServiceImpl extends CoTopComponent implements SearchService {
     @Override
     public Project getProjectSearchFilter(String userId) {
         String filterString = searchMapper.selectProjectSearchFilter(userId);
-        if(filterString == null) {
+        if (filterString == null) {
             return null;
         }
         return new Gson().fromJson(filterString, Project.class);
@@ -78,7 +78,7 @@ public class SearchServiceImpl extends CoTopComponent implements SearchService {
     public void saveLicenseSearchFilter(LicenseMaster licenseMaster, String userId) {
 
         try {
-            if(isEmpty(licenseMaster.getLicenseNameAllSearchFlag())) {
+            if (isEmpty(licenseMaster.getLicenseNameAllSearchFlag())) {
                 licenseMaster.setLicenseNameAllSearchFlag(CoConstDef.FLAG_NO);
             }
             licenseMaster.setTotListSize(licenseService.selectLicenseMasterTotalCount(licenseMaster));
@@ -97,7 +97,7 @@ public class SearchServiceImpl extends CoTopComponent implements SearchService {
     @Override
     public LicenseMaster getLicenseSearchFilter(String userId) {
         String filterString = searchMapper.selectLicenseSearchFilter(userId);
-        if(filterString == null) {
+        if (filterString == null) {
             return null;
         }
         return new Gson().fromJson(filterString, LicenseMaster.class);
@@ -116,7 +116,7 @@ public class SearchServiceImpl extends CoTopComponent implements SearchService {
     @Override
     public Project getSelfCheckSearchFilter(String userId) {
         String filterString = searchMapper.selectSelfCheckSearchFilter(userId);
-        if(filterString == null) {
+        if (filterString == null) {
             return null;
         }
         return new Gson().fromJson(filterString, Project.class);
@@ -142,7 +142,7 @@ public class SearchServiceImpl extends CoTopComponent implements SearchService {
     @Override
     public PartnerMaster getPartnerSearchFilter(String userId) {
         String filterString = searchMapper.selectPartnerSearchFilter(userId);
-        if(filterString == null) {
+        if (filterString == null) {
             return null;
         }
         return new Gson().fromJson(filterString, PartnerMaster.class);
@@ -206,9 +206,9 @@ public class SearchServiceImpl extends CoTopComponent implements SearchService {
 
 
     private String hasSearchCondition(Map<String, Object> params) {
-    	for(Object obj : params.values()) {
-    		if(obj instanceof String) {
-    			if(!StringUtil.isEmpty((String)obj)) {
+    	for (Object obj : params.values()) {
+    		if (obj instanceof String) {
+    			if (!StringUtil.isEmpty((String)obj)) {
     				return "Y";
     			}
     		}

--- a/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SelfCheckServiceImpl.java
@@ -122,9 +122,9 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			} else {
 				list = selfCheckMapper.selectProjectList(project);
 				
-				if(list != null) {
+				if (list != null) {
 					// 코드변환처리
-					for(Project bean : list) {
+					for (Project bean : list) {
 						// DISTRIBUTION Android Flag
 						// 이슈로 인해 android project가 좀더 세분화 되어 android project기준이 변경됨. 단 selfcheck에서는 해당 기준이 필요 없음으로 판단이 되어 주석처리함.
 						// DISTRIBUTION_TYPE
@@ -141,7 +141,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 						bean.setDivision(CoCodeManager.getCodeString(CoConstDef.CD_USER_DIVISION, bean.getDivision()));
 						
 						//OS_TYPE
-						if("999".equals(bean.getOsType())){
+						if ("999".equals(bean.getOsType())){
 							bean.setOsType(bean.getOsTypeEtc());
 						}else{
 							bean.setOsType(CoCodeManager.getCodeString(CoConstDef.CD_OS_TYPE, bean.getOsType()));
@@ -168,7 +168,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		project.setDestributionName(CoCodeManager.getCodeString(CoConstDef.CD_DISTRIBUTION_TYPE, project.getDistributionType()));
 		//OS_TYPE
-		if(!"999".equals(project.getOsType())){
+		if (!"999".equals(project.getOsType())){
 			project.setOsTypeEtc(CoCodeManager.getCodeString(CoConstDef.CD_OS_TYPE, project.getOsType()));
 		}
 
@@ -191,20 +191,20 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		boolean isLoadFromProject = isEmpty(identification.getReferenceId()) && !isEmpty(identification.getRefPrjId());
 		
-		if(isLoadFromProject) {
+		if (isLoadFromProject) {
 			identification.setReferenceId(identification.getRefPrjId());
 		}
 		
 		boolean isApplyFromBat = isEmpty(identification.getReferenceId()) && !isEmpty(identification.getRefBatId());
 		
-		if(isApplyFromBat) {
+		if (isApplyFromBat) {
 			identification.setReferenceId(identification.getRefBatId());
 		}
 			
 		HashMap<String, Object> subMap = new HashMap<String, Object>();
 			
 		list = selfCheckMapper.selectIdentificationGridList(identification);
-		if(list != null && !list.isEmpty()) {
+		if (list != null && !list.isEmpty()) {
 			
 			ProjectIdentification param = new ProjectIdentification();
 			param.setReferenceDiv(identification.getReferenceDiv());
@@ -212,15 +212,15 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			OssMaster ossParam = new OssMaster();
 			
 			// components license 정보를 한번에 가져온다
-			for(ProjectIdentification bean : list) {
+			for (ProjectIdentification bean : list) {
 				param.addComponentIdList(bean.getComponentId());
 				
-				if(!isEmpty(bean.getOssId())) {
+				if (!isEmpty(bean.getOssId())) {
 					ossParam.addOssIdList(bean.getOssId());
 				}
 				
 				// oss Name은 작성하고, oss Version은 작성하지 않은 case경우 해당 분기문에서 처리
-				if(isEmpty(bean.getCveId()) 
+				if (isEmpty(bean.getCveId()) 
 						&& isEmpty(bean.getOssVersion()) 
 						&& !isEmpty(bean.getCvssScoreMax())
 						&& !("-".equals(bean.getOssName()))){ 
@@ -233,7 +233,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			// oss id로 oss master에 등록되어 있는 라이선스 정보를 취득
 			Map<String, OssMaster> componentOssInfoMap = null;
 			
-			if(ossParam.getOssIdList() != null && !ossParam.getOssIdList().isEmpty()) {
+			if (ossParam.getOssIdList() != null && !ossParam.getOssIdList().isEmpty()) {
 				componentOssInfoMap = ossService.getBasicOssInfoListById(ossParam);
 			}
 				
@@ -243,8 +243,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			List<ProjectIdentification> reconstAddComponentLicenseList = null;
 			String licenseComponentId = "";
 			
-			for(ProjectIdentification liObj : licenseList) {
-				if(!licenseComponentId.equals(liObj.getComponentId())) {
+			for (ProjectIdentification liObj : licenseList) {
+				if (!licenseComponentId.equals(liObj.getComponentId())) {
 					licenseComponentId = liObj.getComponentId();
 					reconstAddComponentLicenseList = new ArrayList<>();
 				} else {
@@ -255,15 +255,15 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				reconstLicenseList.put(licenseComponentId, reconstAddComponentLicenseList);
 			}
 			
-			for(ProjectIdentification bean : list) {
-				if(reconstLicenseList.containsKey(bean.getComponentId())) {
+			for (ProjectIdentification bean : list) {
+				if (reconstLicenseList.containsKey(bean.getComponentId())) {
 					List<ProjectIdentification> reconstLicense = (List<ProjectIdentification>) reconstLicenseList.get(bean.getComponentId());
-					if(reconstLicense != null) {
-						for(ProjectIdentification reLi : reconstLicense) {
+					if (reconstLicense != null) {
+						for (ProjectIdentification reLi : reconstLicense) {
 							bean.addComponentLicenseList(reLi);
 							
-							if(!unconfirmedLicenseList.contains(avoidNull(reLi.getLicenseName()))) {
-								if(CoConstDef.FLAG_NO.equals(bean.getExcludeYn()) 
+							if (!unconfirmedLicenseList.contains(avoidNull(reLi.getLicenseName()))) {
+								if (CoConstDef.FLAG_NO.equals(bean.getExcludeYn()) 
 										&& isEmpty(reLi.getLicenseId())) {
 									unconfirmedLicenseList.add(reLi.getLicenseName());
 								}
@@ -277,32 +277,32 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			reconstAddComponentLicenseList.clear();
 			
 			// license 정보 등록
-			for(ProjectIdentification bean : list) {
-				if(bean.getComponentLicenseList()!=null){
+			for (ProjectIdentification bean : list) {
+				if (bean.getComponentLicenseList()!=null){
 					String licenseCopy = "";
 						
 					// multi dual 라이선스의 경우, main row에 표시되는 license 정보는 OSS List에 등록되어진 라이선스를 기준으로 표시한다.
 					// ossId가 없는 경우는 기본적으로 subGrid로 등록될 수 없다
 					// 이짓거리를 하는 두번째 이유는, subgrid 에서 사용자가 추가한 라이선스와 oss 에 등록되어 있는 라이선스를 구분하기 위함
-					if(componentOssInfoMap == null) {
+					if (componentOssInfoMap == null) {
 						componentOssInfoMap = new HashMap<>();
 					}
 					
 					OssMaster ossBean = componentOssInfoMap.get(bean.getOssId());
 						
-					if(ossBean != null
+					if (ossBean != null
 							&& CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv())
 							&& ossBean.getOssLicenses() != null && !ossBean.getOssLicenses().isEmpty()) {
-						for(OssLicense ossLicenseBean : ossBean.getOssLicenses()) {
-							if(!isEmpty(ossLicenseBean.getOssCopyright())) {
+						for (OssLicense ossLicenseBean : ossBean.getOssLicenses()) {
+							if (!isEmpty(ossLicenseBean.getOssCopyright())) {
 								licenseCopy += (!isEmpty(licenseCopy) ? "\r\n" : "") + ossLicenseBean.getOssCopyright();
 							}
 								
 							//삭제 불가 처리
-							for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+							for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
 								// license index 까지 비교하는 이유는
 								// multi dual 혼용인 경우, 동일한 라이선스가 두번 등록 될 수 있기 때문
-								if(ossLicenseBean.getLicenseId().equals(licenseBean.getLicenseId()) 
+								if (ossLicenseBean.getLicenseId().equals(licenseBean.getLicenseId()) 
 										&& ossLicenseBean.getOssLicenseIdx().equals(licenseBean.getRnum())) {
 									licenseBean.setEditable(CoConstDef.FLAG_NO);
 									break;
@@ -313,8 +313,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 						bean.setLicenseName(CommonFunction.makeLicenseExpressionIdentify(bean.getComponentLicenseList(), ","));
 					} else {
 						// license text는 표시하지 않기 때문에 설정할 필요는 없음
-						for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
-							if(!isEmpty(licenseBean.getCopyrightText())) {
+						for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+							if (!isEmpty(licenseBean.getCopyrightText())) {
 								licenseCopy += (!isEmpty(licenseCopy) ? "\r\n" : "") + licenseBean.getCopyrightText();
 							}
 						}
@@ -334,21 +334,21 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			}
 			
 			// 다른 프로젝트에서 load한 경우 component id 초기화
-			if(isLoadFromProject || isApplyFromBat) {
+			if (isLoadFromProject || isApplyFromBat) {
 				subMap = new HashMap<>();
 
 				// refproject id + "p" + componentid 로 component_id를 재생성 하고, 
 				// license 의 경우 재성생한 component_id + 기존 license grid_id의 component_license_id 부분을 결합
-				for(ProjectIdentification bean : list) {
-					if(isLoadFromProject) {
+				for (ProjectIdentification bean : list) {
+					if (isLoadFromProject) {
 						bean.setRefPrjId(identification.getRefPrjId());
-					} else if(isApplyFromBat) {
+					} else if (isApplyFromBat) {
 						bean.setRefBatId(identification.getRefBatId());
 					}
 						
 					String _compId = CoConstDef.GRID_NEWROW_DEFAULT_PREFIX;
 					
-					if(isLoadFromProject) {
+					if (isLoadFromProject) {
 						_compId += identification.getRefPrjId();
 					} else if (isApplyFromBat) {
 						_compId += identification.getRefBatId();
@@ -359,8 +359,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					bean.setComponentId("");
 					bean.setGridId(_compId);
 
-					if(bean.getComponentLicenseList()!=null){
-						for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+					if (bean.getComponentLicenseList()!=null){
+						for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
 							licenseBean.setComponentId("");
 							licenseBean.setGridId(_compId + "-"+ licenseBean.getComponentLicenseId());
 						}
@@ -373,13 +373,13 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			
 		// 편집중인 data 가 존재할 경우 append 한다.
 		{
-			if(identification.getMainDataGridList() != null) {
-				for(ProjectIdentification bean : identification.getMainDataGridList()) {
+			if (identification.getMainDataGridList() != null) {
+				for (ProjectIdentification bean : identification.getMainDataGridList()) {
 					//멀티라이센스일 경우
-					if(CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())){
+					if (CoConstDef.LICENSE_DIV_MULTI.equals(bean.getLicenseDiv())){
 						for (List<ProjectIdentification> comLicenseList : identification.getSubDataGridList()) {
 							for (ProjectIdentification comLicense : comLicenseList) {
-								if(bean.getComponentId().equals(comLicense.getComponentId())){
+								if (bean.getComponentId().equals(comLicense.getComponentId())){
 									bean.addComponentLicenseList(comLicense);
 								}
 							}
@@ -396,7 +396,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					}
 				}
 
-				for(ProjectIdentification bean : identification.getMainDataGridList()) {
+				for (ProjectIdentification bean : identification.getMainDataGridList()) {
 					list.add(0, bean);
 					subMap.put(bean.getGridId(), bean.getComponentLicenseList());
 				}
@@ -407,8 +407,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		List<ProjectIdentification> newSortList = new ArrayList<>();
 		List<ProjectIdentification> excludeList = new ArrayList<>();
 		
-		for(ProjectIdentification bean : list) {
-			if(CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+		for (ProjectIdentification bean : list) {
+			if (CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 				excludeList.add(bean);
 			} else {
 				newSortList.add(bean);
@@ -432,7 +432,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		boolean isNew = isEmpty(project.getPrjId());
 			
 		// admin이 아니라면 creator를 변경하지 않는다.
-		if(!CommonFunction.isAdmin()) {
+		if (!CommonFunction.isAdmin()) {
 			project.setCreator(null);
 		}
 			
@@ -444,7 +444,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		noticeParam.setPrjId(project.getPrjId());
 		noticeParam.setNoticeType(avoidNull(project.getNoticeType(), CoConstDef.CD_DTL_NOTICE_TYPE_GENERAL));
 
-		if(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(project.getNoticeType())) {
+		if (CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(project.getNoticeType())) {
 			noticeParam.setNoticeTypeEtc(project.getNoticeTypeEtc());
 		}
 
@@ -454,17 +454,17 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		ArrayList<Map<String, String>> divisionList = new ArrayList<Map<String, String>>();
 		ArrayList<Map<String, String>> emailList = new ArrayList<Map<String, String>>();
 
-		if(isNew) {
+		if (isNew) {
 			if (project.getWatchers()!= null) {
 				String[] arr;
 				for (String watcher : project.getWatchers()) {
 					Map<String, String> m = new HashMap<String, String>();
 					arr = watcher.split("\\/");
 					
-					if(!"Email".equals(arr[1])){
+					if (!"Email".equals(arr[1])){
 						project.setPrjDivision(arr[0]);
 						
-						if(arr.length > 1){
+						if (arr.length > 1){
 							project.setPrjUserId(arr[1]);
 						}else{
 							project.setPrjUserId("");
@@ -488,7 +488,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					
 					List<Project> watcherList = selfCheckMapper.selectWatchersCheck(project);
 					
-					if(watcherList.size() == 0){
+					if (watcherList.size() == 0){
 						selfCheckMapper.insertProjectWatcher(project);						
 					}
 				}
@@ -531,7 +531,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 //		}
 				
 		// 한건도 없을시 프로젝트 마스터 SRC 사용가능여부가 N이면 N 그외 null
-		if(ossComponent.size()==0){
+		if (ossComponent.size()==0){
 			Project projectSubStatus = new Project();
 			projectSubStatus.setPrjId(project.getPrjId());
 			projectSubStatus.setModifier(projectSubStatus.getLoginUserName());
@@ -547,12 +547,12 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		List<ProjectIdentification> reconstAddOssComponentLicenseList = null;
 		String licenseComponentId = "";
 		
-		for(List<ProjectIdentification> ocList : ossComponentLicense) {
-			for(ProjectIdentification pi : ocList) {
+		for (List<ProjectIdentification> ocList : ossComponentLicense) {
+			for (ProjectIdentification pi : ocList) {
 				licenseComponentId = isEmpty(pi.getComponentId()) ? pi.getGridId() : pi.getComponentId();
 				reconstAddOssComponentLicenseList = new ArrayList<>();
 				
-				if(reconstOssComponentLicenseList.containsKey(licenseComponentId)) {
+				if (reconstOssComponentLicenseList.containsKey(licenseComponentId)) {
 					reconstAddOssComponentLicenseList = (List<ProjectIdentification>) reconstOssComponentLicenseList.get(licenseComponentId);
 				}
 				
@@ -573,21 +573,21 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		for (int i = 0; i < ossComponent.size(); i++) {
 			String downloadLocation = ossComponent.get(i).getDownloadLocation();
 			
-			if(downloadLocation.endsWith("/")) {
+			if (downloadLocation.endsWith("/")) {
 				ossComponent.get(i).setDownloadLocation(downloadLocation.substring(0, downloadLocation.length()-1));
 			}
 			
 			int componentLicenseId = 1;
 			//update
-			if(!StringUtil.contains(ossComponent.get(i).getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
+			if (!StringUtil.contains(ossComponent.get(i).getGridId(), CoConstDef.GRID_NEWROW_DEFAULT_PREFIX)){
 				//ossComponents 등록
 //				selfCheckMapper.updateSrcOssList(ossComponent.get(i));
 				updateOssComponentList.add(ossComponent.get(i));
 				deleteRows.add(ossComponent.get(i).getComponentIdx());
 				
 				//멀티라이센스일 경우
-				if(CoConstDef.LICENSE_DIV_MULTI.equals(ossComponent.get(i).getLicenseDiv())){
-					if(reconstOssComponentLicenseList.containsKey(ossComponent.get(i).getComponentId())) {
+				if (CoConstDef.LICENSE_DIV_MULTI.equals(ossComponent.get(i).getLicenseDiv())){
+					if (reconstOssComponentLicenseList.containsKey(ossComponent.get(i).getComponentId())) {
 						List<ProjectIdentification> comLicenseList = (List<ProjectIdentification>) reconstOssComponentLicenseList.get(ossComponent.get(i).getComponentId());
 						for (ProjectIdentification comLicense : comLicenseList) {
 							OssComponentsLicense license = CommonFunction.reMakeLicenseBean(comLicense, CoConstDef.LICENSE_DIV_MULTI);
@@ -618,7 +618,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				
 				ossInfoKey = (ossComponent.get(i).getOssName() +"_"+ avoidNull(ossComponent.get(i).getOssVersion())).toUpperCase();
 				
-				if(CoCodeManager.OSS_INFO_UPPER.containsKey(ossInfoKey)) {
+				if (CoCodeManager.OSS_INFO_UPPER.containsKey(ossInfoKey)) {
 					OssMaster ossInfo = CoCodeManager.OSS_INFO_UPPER.get(ossInfoKey);
 					ossComponent.get(i).setObligationType(ossInfo.getObligationType());
 				}
@@ -628,19 +628,19 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				deleteRows.add(String.valueOf(componentIdx));
 				
 				//멀티라이센스일 경우
-				if(CoConstDef.LICENSE_DIV_MULTI.equals(ossComponent.get(i).getLicenseDiv())){
-					if(reconstOssComponentLicenseList.containsKey(exComponentId)) {
+				if (CoConstDef.LICENSE_DIV_MULTI.equals(ossComponent.get(i).getLicenseDiv())){
+					if (reconstOssComponentLicenseList.containsKey(exComponentId)) {
 						List<ProjectIdentification> comLicenseList = (List<ProjectIdentification>) reconstOssComponentLicenseList.get(exComponentId);
 						
 						for (ProjectIdentification comLicense : comLicenseList) {
 							// null point
-							if(isEmpty(comLicense.getGridId())) {
+							if (isEmpty(comLicense.getGridId())) {
 								continue;
 							}
 							
 							String gridId = comLicense.getGridId().split("-")[0];
 							
-							if(exComponentId.equals(comLicense.getComponentId())
+							if (exComponentId.equals(comLicense.getComponentId())
 									|| exComponentId.equals(gridId)){
 								OssComponentsLicense license = CommonFunction.reMakeLicenseBean(comLicense, CoConstDef.LICENSE_DIV_MULTI);
 								// 컴포넌트 ID 설정
@@ -688,7 +688,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		selfCheckMapper.deleteOssComponentsWithIds(param);
 		
 		// delete file
-		if(project.getCsvFile() != null && project.getCsvFile().size() > 0) {
+		if (project.getCsvFile() != null && project.getCsvFile().size() > 0) {
 			for (int i = 0; i < project.getCsvFile().size(); i++) {
 				selfCheckMapper.deleteFileBySeq(project.getCsvFile().get(i));
 				fileService.deletePhysicalFile(project.getCsvFile().get(i), "SELF");
@@ -696,10 +696,10 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		}
 		
 		// 파일 등록
-		if(!isEmpty(project.getSrcCsvFileId())){
+		if (!isEmpty(project.getSrcCsvFileId())){
 			selfCheckMapper.updateFileId(project);
 			
-			if(project.getCsvFileSeq() != null) {
+			if (project.getCsvFileSeq() != null) {
 				for (int i = 0; i < project.getCsvFileSeq().size(); i++) {
 					selfCheckMapper.updateFileBySeq(project.getCsvFileSeq().get(i));
 				}				
@@ -713,12 +713,12 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			String max_vuln_ossVersion = null;
 			List<ProjectIdentification> _ossList = selfCheckMapper.selectIdentificationGridList(prj);
 			
-			if(_ossList != null) {
-				for(ProjectIdentification targetBean : _ossList) {
-					if(targetBean != null && !CoConstDef.FLAG_YES.equals(targetBean.getExcludeYn()) && !isEmpty(targetBean.getCvssScore())) {
+			if (_ossList != null) {
+				for (ProjectIdentification targetBean : _ossList) {
+					if (targetBean != null && !CoConstDef.FLAG_YES.equals(targetBean.getExcludeYn()) && !isEmpty(targetBean.getCvssScore())) {
 						double _currentSccore = Double.parseDouble(targetBean.getCvssScore());
 						
-						if(Double.compare(_currentSccore, max_cvss_score) > 0) {
+						if (Double.compare(_currentSccore, max_cvss_score) > 0) {
 							max_cvss_score = _currentSccore;
 							max_vuln_ossName = targetBean.getOssName();
 							max_vuln_ossVersion = targetBean.getOssVersion();
@@ -729,10 +729,10 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			
 			Project vnlnUpdBean = new Project();
 			
-			if(!isEmpty(max_vuln_ossName)) {
+			if (!isEmpty(max_vuln_ossName)) {
 				vnlnUpdBean.setOssName(max_vuln_ossName);
 				vnlnUpdBean.setOssVersion(avoidNull(max_vuln_ossVersion));
-				if(max_vuln_ossName.contains(" ")) {
+				if (max_vuln_ossName.contains(" ")) {
 					vnlnUpdBean.setOssNameTemp(max_vuln_ossName.replaceAll(" ", "_"));
 				}
 				vnlnUpdBean = selfCheckMapper.getMaxVulnByOssName(vnlnUpdBean);				
@@ -759,12 +759,12 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			conn.setAutoCommit(false);
 			
 			int idx = 1;
-			if(updateOssComponentList != null && updateOssComponentList.size() > 0) {
+			if (updateOssComponentList != null && updateOssComponentList.size() > 0) {
 				query = "UPDATE PRE_OSS_COMPONENTS SET OSS_ID = (CASE WHEN ? = '' THEN NULL ELSE ? END), OSS_NAME = ?, OSS_VERSION = REPLACE(?, 'N/A',''), FILE_PATH = ?, DOWNLOAD_LOCATION = ?, COPYRIGHT = ?, EXCLUDE_YN = ?, OBLIGATION_TYPE = ?"
 						+ " WHERE REFERENCE_ID = ? AND REFERENCE_DIV = ? AND COMPONENT_IDX = ?";
 				stmt = conn.prepareStatement(query);
 				
-				for(ProjectIdentification item : updateOssComponentList) {
+				for (ProjectIdentification item : updateOssComponentList) {
 					stmt.setString(1, item.getOssId());
 					stmt.setString(2, item.getOssId());
 					stmt.setString(3, item.getOssName());
@@ -780,7 +780,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					stmt.addBatch();
 					stmt.clearParameters();
 					
-					if((idx % 1000) == 0) {
+					if ((idx % 1000) == 0) {
 						stmt.executeBatch();
 						stmt.clearBatch();
 			            conn.commit();
@@ -793,14 +793,14 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				conn.commit();
 			}
 			
-			if(insertOssComponentList != null && insertOssComponentList.size() > 0) {
+			if (insertOssComponentList != null && insertOssComponentList.size() > 0) {
 				query = "INSERT INTO PRE_OSS_COMPONENTS (REFERENCE_ID, REFERENCE_DIV, COMPONENT_IDX, OSS_ID, OSS_NAME, OSS_VERSION, DOWNLOAD_LOCATION, HOMEPAGE, FILE_PATH, EXCLUDE_YN, COPYRIGHT, BINARY_NAME, BINARY_SIZE, BINARY_NOTICE, CUSTOM_BINARY_YN, REF_PARTNER_ID"
 						+ ", REF_PRJ_ID, REF_BAT_ID, REF_COMPONENT_ID, REPORT_FILE_ID, BAT_STRING_MATCH_PERCENTAGE, BAT_PERCENTAGE, BAT_SCORE, OBLIGATION_TYPE) "
 						+ "VALUES (?,?,?,(CASE WHEN ? = '' THEN NULL ELSE ? END),?, REPLACE(?, 'N/A',''),?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);";
 				stmt2 = conn.prepareStatement(query);
 				
 				idx = 1;
-				for(ProjectIdentification item : insertOssComponentList) {
+				for (ProjectIdentification item : insertOssComponentList) {
 					stmt2.setString(1, item.getReferenceId());
 					stmt2.setString(2, item.getReferenceDiv());
 					stmt2.setString(3, item.getComponentIdx());
@@ -829,7 +829,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					stmt2.addBatch();
 					stmt2.clearParameters();
 					
-					if((idx % 1000) == 0) {
+					if ((idx % 1000) == 0) {
 						stmt2.executeBatch();
 						stmt2.clearBatch();
 			            conn.commit();
@@ -843,12 +843,12 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			}
 
 			
-			if(insertOssComponentLicenseList != null && insertOssComponentLicenseList.size() > 0) {
+			if (insertOssComponentLicenseList != null && insertOssComponentLicenseList.size() > 0) {
 				query = "INSERT INTO PRE_OSS_COMPONENTS_LICENSE (COMPONENT_ID, COMPONENT_LICENSE_IDX, LICENSE_ID, LICENSE_NAME, COPYRIGHT_TEXT, EXCLUDE_YN) VALUES (?,?,?,?,?,'N');";
 				stmt3 = conn.prepareStatement(query);
 				
 				idx = 1;
-				for(OssComponentsLicense item : insertOssComponentLicenseList) {
+				for (OssComponentsLicense item : insertOssComponentLicenseList) {
 					stmt3.setString(1, item.getComponentId());
 					stmt3.setString(2, item.getComponentLicenseId());
 					stmt3.setString(3, item.getLicenseId());
@@ -857,7 +857,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					stmt3.addBatch();
 					stmt3.clearParameters();
 					
-					if((idx % 1000) == 0) {
+					if ((idx % 1000) == 0) {
 						stmt3.executeBatch();
 						stmt3.clearBatch();
 			            conn.commit();
@@ -889,7 +889,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				}
 			} catch(SQLException se) {}
 			
-			if(conn != null) {
+			if (conn != null) {
 				try {
 					conn.rollback();
 					conn.close();
@@ -937,12 +937,12 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			stmt = conn.prepareStatement(query);
 			
 			int idx = 1;
-			for(OssComponents item : componentIdList) {
+			for (OssComponents item : componentIdList) {
 				stmt.setString(1, item.getComponentId());
 				stmt.addBatch();
 				stmt.clearParameters();
 				
-				if((idx % 1000) == 0) {
+				if ((idx % 1000) == 0) {
 					stmt.executeBatch();
 					stmt.clearBatch();
 					conn.commit();
@@ -961,7 +961,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				}
 			} catch(SQLException e1) {}
 			
-			if(conn != null) {
+			if (conn != null) {
 				try {
 					conn.rollback();
 					conn.close();
@@ -990,55 +990,55 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		Map<String, OssMaster> ossNickNameConvertMap = new HashMap<>();
 		String ossInfoKey = "";
 		
-		for(ProjectIdentification bean : ossComponentList) {
+		for (ProjectIdentification bean : ossComponentList) {
 			String _ossName = avoidNull(bean.getOssName()).trim();
-			if("N/A".equals(bean.getOssVersion())) {
+			if ("N/A".equals(bean.getOssVersion())) {
 				bean.setOssVersion("");
 			}
 			
 			ossInfoKey = (bean.getOssName().trim() + "_" + avoidNull(bean.getOssVersion()).trim()).toUpperCase();
 			OssMaster masterBean = CoCodeManager.OSS_INFO_UPPER.get(ossInfoKey);
-			if(masterBean != null) {
+			if (masterBean != null) {
 				bean.setOssId(masterBean.getOssId());
 				bean.setOssName(masterBean.getOssName());
 			}
 			
-			if(!isEmpty(_ossName) && !"-".equals(_ossName) && !ossCheckParam.contains(_ossName)) {
+			if (!isEmpty(_ossName) && !"-".equals(_ossName) && !ossCheckParam.contains(_ossName)) {
 				ossCheckParam.add(_ossName);
 			}
 			
-			if(!isEmpty(ossInfoKey)) {
+			if (!isEmpty(ossInfoKey)) {
 				ossInfoKey = "";
 			}
 		}
-		if(!ossCheckParam.isEmpty()) {
+		if (!ossCheckParam.isEmpty()) {
 			OssMaster param = new OssMaster();
 			
 			param.setOssNames(ossCheckParam.toArray(new String[ossCheckParam.size()]));
 			ossNickNameList = projectMapper.checkOssNickName(param);
 			
-			if(ossNickNameList != null) {
-				for(OssMaster bean : ossNickNameList) {
+			if (ossNickNameList != null) {
+				for (OssMaster bean : ossNickNameList) {
 					ossNickNameConvertMap.put(bean.getOssNickname().toUpperCase(), bean);
 				}
 			}
 		}
 
-		for(ProjectIdentification bean : ossComponentList) {
-			if(ossNickNameConvertMap.containsKey(avoidNull(bean.getOssName()).trim().toUpperCase())) {
+		for (ProjectIdentification bean : ossComponentList) {
+			if (ossNickNameConvertMap.containsKey(avoidNull(bean.getOssName()).trim().toUpperCase())) {
 				bean.setOssName(ossNickNameConvertMap.get(avoidNull(bean.getOssName()).trim().toUpperCase()).getOssName());
 			}
 			
 			// license nickname 체크
-			if(CoConstDef.LICENSE_DIV_SINGLE.equals(bean.getLicenseDiv())) {
+			if (CoConstDef.LICENSE_DIV_SINGLE.equals(bean.getLicenseDiv())) {
 				String _licenseName = avoidNull(bean.getLicenseName()).trim();
 				
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
 					LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(_licenseName.toUpperCase());
 					
-					if(licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
-						for(String s : licenseMaster.getLicenseNicknameList()) {
-							if(_licenseName.equalsIgnoreCase(s)) {
+					if (licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
+						for (String s : licenseMaster.getLicenseNicknameList()) {
+							if (_licenseName.equalsIgnoreCase(s)) {
 								bean.setLicenseName(avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseNameTemp()));
 							
 								break;
@@ -1054,17 +1054,17 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 	
 	private List<List<ProjectIdentification>> convertLicenseNickName(
 			List<List<ProjectIdentification>> ossComponentLicenseList) {
-		if(ossComponentLicenseList != null) {
-			for(List<ProjectIdentification> licenseList : ossComponentLicenseList) {
+		if (ossComponentLicenseList != null) {
+			for (List<ProjectIdentification> licenseList : ossComponentLicenseList) {
 				for (ProjectIdentification licenseBean : licenseList) {
 					String _licenseName = avoidNull(licenseBean.getLicenseName()).trim();
 					
-					if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
+					if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(_licenseName.toUpperCase())) {
 						LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(_licenseName.toUpperCase());
 						
-						if(licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
-							for(String s : licenseMaster.getLicenseNicknameList()) {
-								if(_licenseName.equalsIgnoreCase(s)) {
+						if (licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
+							for (String s : licenseMaster.getLicenseNicknameList()) {
+								if (_licenseName.equalsIgnoreCase(s)) {
 									licenseBean.setLicenseName(avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseNameTemp()));
 									
 									break;
@@ -1090,12 +1090,12 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		List<String> vulnList = selfCheckMapper.getAllVulnList(param);
 		List<Vulnerability> list1 = selfCheckMapper.getAllVulnListWithProject(param);
 			
-		if(list1 != null) {
-			for(Vulnerability bean : list1) {
-				if(vulnList.contains(bean.getProduct())) {
+		if (list1 != null) {
+			for (Vulnerability bean : list1) {
+				if (vulnList.contains(bean.getProduct())) {
 					String key = avoidNull(avoidNull(bean.getVendor()) + "_" + avoidNull(bean.getProduct()) + "_" + avoidNull(bean.getVersion()) + "_" + bean.getCveId());
 					
-					if(!duplCheck.containsKey(key)) {
+					if (!duplCheck.containsKey(key)) {
 						duplCheck.put(key, bean);
 					}
 				}
@@ -1104,10 +1104,10 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 
 		List<Vulnerability> list2 = selfCheckMapper.getAllVulnListWithProjectByNickName(param);
 		
-		if(list2 != null) {
-			for(Vulnerability bean : list2) {
+		if (list2 != null) {
+			for (Vulnerability bean : list2) {
 				String key = avoidNull(avoidNull(bean.getVendor()) + "_" + avoidNull(bean.getProduct()) + "_" + avoidNull(bean.getVersion()) + "_" + bean.getCveId());
-				if(!duplCheck.containsKey(key)) {
+				if (!duplCheck.containsKey(key)) {
 					duplCheck.put(key, bean);
 				}
 			}
@@ -1115,12 +1115,12 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		List<Vulnerability> list3 = selfCheckMapper.getAllVulnListWithProject2(param);
 		
-		if(list3 != null) {
-			for(Vulnerability bean : list3) {
-				if(vulnList.contains(bean.getProduct())) {
+		if (list3 != null) {
+			for (Vulnerability bean : list3) {
+				if (vulnList.contains(bean.getProduct())) {
 					String key = avoidNull(avoidNull(bean.getVendor()) + "_" + avoidNull(bean.getProduct()) + "_" + avoidNull(bean.getVersion()) + "_" + bean.getCveId());
 					
-					if(!duplCheck.containsKey(key)) {
+					if (!duplCheck.containsKey(key)) {
 						duplCheck.put(key, bean);
 					}
 				}
@@ -1129,10 +1129,10 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		List<Vulnerability> list4 = selfCheckMapper.getAllVulnListWithProjectByNickName2(param);
 		
-		if(list4 != null) {
-			for(Vulnerability bean : list4) {
+		if (list4 != null) {
+			for (Vulnerability bean : list4) {
 				String key = avoidNull(avoidNull(bean.getVendor()) + "_" + avoidNull(bean.getProduct()) + "_" + avoidNull(bean.getVersion()) + "_" + bean.getCveId());
-				if(!duplCheck.containsKey(key)) {
+				if (!duplCheck.containsKey(key)) {
 					duplCheck.put(key, bean);
 				}
 			}
@@ -1140,12 +1140,12 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		List<Vulnerability> list5 = selfCheckMapper.getAllVulnListWithProject3(param);
 		
-		if(list3 != null) {
-			for(Vulnerability bean : list5) {
-				if(vulnList.contains(bean.getProduct())) {
+		if (list3 != null) {
+			for (Vulnerability bean : list5) {
+				if (vulnList.contains(bean.getProduct())) {
 					String key = avoidNull(avoidNull(bean.getVendor()) + "_" + avoidNull(bean.getProduct()) + "_" + avoidNull(bean.getVersion()) + "_" + bean.getCveId());
 					
-					if(!duplCheck.containsKey(key)) {
+					if (!duplCheck.containsKey(key)) {
 						duplCheck.put(key, bean);
 					}
 				}
@@ -1154,10 +1154,10 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		List<Vulnerability> list6 = selfCheckMapper.getAllVulnListWithProjectByNickName3(param);
 		
-		if(list4 != null) {
-			for(Vulnerability bean : list6) {
+		if (list4 != null) {
+			for (Vulnerability bean : list6) {
 				String key = avoidNull(avoidNull(bean.getVendor()) + "_" + avoidNull(bean.getProduct()) + "_" + avoidNull(bean.getVersion()) + "_" + bean.getCveId());
-				if(!duplCheck.containsKey(key)) {
+				if (!duplCheck.containsKey(key)) {
 					duplCheck.put(key, bean);
 				}
 			}
@@ -1173,9 +1173,9 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 	
 	@Override
 	public void addWatcher(Project project) {
-		if(!isEmpty(project.getPrjEmail())) {
+		if (!isEmpty(project.getPrjEmail())) {
 			// 이미 추가된 watcher 체크
-			if(selfCheckMapper.existsWatcherByEmail(project) == 0) {
+			if (selfCheckMapper.existsWatcherByEmail(project) == 0) {
 				// watcher 추가
 				selfCheckMapper.insertWatcher(project);
 				
@@ -1193,7 +1193,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			}
 		} else {
 			// 이미 추가된 watcher 체크
-			if(selfCheckMapper.existsWatcherByUser(project) == 0) {
+			if (selfCheckMapper.existsWatcherByUser(project) == 0) {
 				// watcher 추가
 				selfCheckMapper.insertWatcher(project);
 			}
@@ -1216,7 +1216,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		int i = selfCheckMapper.existsWatcher(project);
 		
-		if(i > 0){
+		if (i > 0){
 			result = true;
 		}	
 		
@@ -1231,7 +1231,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			String prjId = project.getPrjId();
 			notice = selectOssNoticeOne(prjId);
 			
-			if(isEmpty(notice.getCompanyNameFull()) 
+			if (isEmpty(notice.getCompanyNameFull()) 
 					&& isEmpty(notice.getDistributionSiteUrl()) 
 					&& isEmpty(notice.getEmail())
 					&& isEmpty(notice.getAppended())
@@ -1255,46 +1255,46 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				String distributeType = avoidNull(project.getDistributeTarget(), CoConstDef.CD_DISTRIBUTE_SITE_SKS); // LGE, NA => LGE로 표기, SKS => SKS로 표기함.
 				String distributeCode = CoConstDef.CD_DISTRIBUTE_SITE_SKS.equals(distributeType) ? CoConstDef.CD_NOTICE_DEFAULT_SKS : CoConstDef.CD_NOTICE_DEFAULT;
 				
-				if(isEmpty(notice.getCompanyNameFull())) {
+				if (isEmpty(notice.getCompanyNameFull())) {
 					notice.setCompanyNameFull(CoCodeManager.getCodeExpString(distributeCode, CoConstDef.CD_DTL_NOTICE_DEFAULT_FULLNAME));
 				}
 				
-				if(isEmpty(notice.getDistributionSiteUrl())) {
+				if (isEmpty(notice.getDistributionSiteUrl())) {
 					notice.setDistributionSiteUrl(CoCodeManager.getCodeExpString(distributeCode, CoConstDef.CD_DTL_NOTICE_DEFAULT_DISTRIBUTE_SITE));
 				}
 				
-				if(isEmpty(notice.getEmail())) {
+				if (isEmpty(notice.getEmail())) {
 					notice.setEmail(CoCodeManager.getCodeExpString(distributeCode, CoConstDef.CD_DTL_NOTICE_DEFAULT_EMAIL));
 				}
 				
-				if(isEmpty(notice.getAppended())){
+				if (isEmpty(notice.getAppended())){
 					notice.setAppended(CoCodeManager.getCodeExpString(distributeCode, CoConstDef.CD_DTL_NOTICE_DEFAULT_APPENDED));
 				}
-			} else if(CoConstDef.FLAG_YES.equals(notice.getEditNoticeYn())
+			} else if (CoConstDef.FLAG_YES.equals(notice.getEditNoticeYn())
 					&& CoConstDef.CD_NOTICE_TYPE_GENERAL.equals(notice.getNoticeType())) {
 				
 			} else {
-				if(!isEmpty(notice.getCompanyNameFull())){
+				if (!isEmpty(notice.getCompanyNameFull())){
 					notice.setEditCompanyYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
 				
-				if(!isEmpty(notice.getDistributionSiteUrl())){
+				if (!isEmpty(notice.getDistributionSiteUrl())){
 					notice.setEditDistributionSiteUrlYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
 				
-				if(!isEmpty(notice.getEmail())){
+				if (!isEmpty(notice.getEmail())){
 					notice.setEditEmailYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
 				
-				if(!isEmpty(notice.getAppended())){
+				if (!isEmpty(notice.getAppended())){
 					notice.setEditAppendedYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
 				
-				if(CoConstDef.CD_NOTICE_TYPE_GENERAL_WITHOUT_OSS_VERSION.equals(project.getNoticeType())){
+				if (CoConstDef.CD_NOTICE_TYPE_GENERAL_WITHOUT_OSS_VERSION.equals(project.getNoticeType())){
 					notice.setHideOssVersionYn(CoConstDef.FLAG_YES);
 					notice.setEditNoticeYn(CoConstDef.FLAG_YES);
 				}
@@ -1317,7 +1317,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 	@Override
 	public List<OssComponents> getVerifyOssList(Project projectMaster) {
 		List<OssComponents> componentList = selfCheckMapper.selectVerifyOssList(projectMaster);
-		if(componentList != null && !componentList.isEmpty() && componentList.get(0) == null) {
+		if (componentList != null && !componentList.isEmpty() && componentList.get(0) == null) {
 			componentList = new ArrayList<>();
 		}
 		
@@ -1359,7 +1359,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		Project prjInfo = getProjectBasicInfo(ossNotice.getPrjId());
 		
 		// OSS Notice가 N/A이면 고지문을 생성하지 않는다.
-		if(CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType())) {
+		if (CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType())) {
 			return true;
 		}
 		
@@ -1386,8 +1386,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			String filePath = NOTICE_PATH + "/" + project.getPrjId();
 			// 이전에 생성된 파일은 모두 삭제한다.
 			Path rootPath = Paths.get(filePath);
-			if(rootPath.toFile().exists()) {
-				for(String _fName : rootPath.toFile().list()) {
+			if (rootPath.toFile().exists()) {
+				for (String _fName : rootPath.toFile().list()) {
 					Files.deleteIfExists(rootPath.resolve(_fName));
 					
 					T2File file = new T2File();
@@ -1396,7 +1396,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					
 					int returnSuccess = fileMapper.updateFileDelYnByFilePathNm(file);
 					
-					if(returnSuccess > 0){
+					if (returnSuccess > 0){
 						log.debug(filePath + "/" + _fName + " is delete success.");
 					}else{
 						log.debug(filePath + "/" + _fName + " is delete failed.");
@@ -1406,7 +1406,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			
 			String fileName = CommonFunction.getNoticeFileName("Self-Check_"+project.getPrjId(), project.getPrjName(), project.getPrjVersion(), CommonFunction.getCurrentDateTime("yyMMdd"), "html");
 			
-			if(oss.fosslight.util.FileUtil.writeFile(filePath, fileName, contents)) {
+			if (oss.fosslight.util.FileUtil.writeFile(filePath, fileName, contents)) {
 				// 파일 등록
 				String FileSeq = fileService.registFileWithFileName(filePath, fileName);
 				
@@ -1447,20 +1447,20 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		project = selfCheckMapper.getProjectBasicInfo(project);
 		
-		if(project != null){
-			if(isEmpty(prjName)) {
+		if (project != null){
+			if (isEmpty(prjName)) {
 				prjName = project.getPrjName();
 			}
 			
-			if(isEmpty(prjId)) {
+			if (isEmpty(prjId)) {
 				prjId = project.getPrjId();
 			}
 			
-			if(isEmpty(prjVersion)) {
+			if (isEmpty(prjVersion)) {
 				prjVersion = project.getPrjVersion();
 			}
 			
-			if(isEmpty(distributeSite)) {
+			if (isEmpty(distributeSite)) {
 				distributeSite = project.getDistributeTarget();
 			}
 		}
@@ -1477,9 +1477,9 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		OssComponents ossComponent;
 		String ossInfoUpperKey = "";
 		
-		for(OssComponents bean : ossComponentList) {
+		for (OssComponents bean : ossComponentList) {
 			ossInfoUpperKey = (bean.getOssName() + "_" + avoidNull(bean.getOssVersion())).toUpperCase();
-			if(CoCodeManager.OSS_INFO_UPPER.containsKey(ossInfoUpperKey) && isEmpty(bean.getHomepage())) {
+			if (CoCodeManager.OSS_INFO_UPPER.containsKey(ossInfoUpperKey) && isEmpty(bean.getHomepage())) {
 				bean.setHomepage(CoCodeManager.OSS_INFO_UPPER.get(ossInfoUpperKey).getHomepage());
 			}
 			
@@ -1487,7 +1487,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 									? bean.getOssName() 
 									: bean.getOssName() + "|" + bean.getOssVersion()).toUpperCase();
 			
-			if("-".equals(bean.getOssName())) {
+			if ("-".equals(bean.getOssName())) {
 				componentKey += dashSeq++;
 			}
 			
@@ -1498,14 +1498,14 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			// confirm 처리에서 obligation이 고지의무가 있거나 소스코드 공개의무가 있는 경우만 '50'으로 copy되도록 수정하였으나, 여기서 한번도 필터링함
 			boolean isNotice = CoConstDef.CD_DTL_OBLIGATION_NOTICE.equals(bean.getObligationType());
 			
-			if(!isDisclosure && !isNotice) {
+			if (!isDisclosure && !isNotice) {
 				continue;
 			}
 			
 			// 2017.07.05
 			// Accompanied with source code 의 경우
 			// 소스공개여부와 상관없이 모두 소스공개가 필요한 oss table에 표시
-			if(CoConstDef.CD_DTL_NOTICE_TYPE_ACCOMPANIED.equals(ossNotice.getNoticeType())) {
+			if (CoConstDef.CD_DTL_NOTICE_TYPE_ACCOMPANIED.equals(ossNotice.getNoticeType())) {
 				isDisclosure = true;
 			}
 			
@@ -1513,15 +1513,15 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			boolean addDisclosure = isDisclosure && srcInfo.containsKey(componentKey);
 			boolean addNotice = !isDisclosure && noticeInfo.containsKey(componentKey);
 			
-			if(addDisclosure) {
+			if (addDisclosure) {
 				ossComponent = srcInfo.get(componentKey);
-			} else if(addNotice) {
+			} else if (addNotice) {
 				ossComponent = noticeInfo.get(componentKey);
 			} else {
 				ossComponent = bean;
 			}
 			
-			if(hideOssVersionFlag) {
+			if (hideOssVersionFlag) {
 				List<String> copyrightList = componentCopyright.containsKey(componentKey) 
 						? (List<String>) componentCopyright.get(componentKey) 
 						: new ArrayList<>();
@@ -1530,13 +1530,13 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 						? (List<String>) componentAttribution.get(componentKey) 
 						: new ArrayList<>();
 						
-				if(!isEmpty(bean.getCopyrightText())) {
-					for(String copyright : bean.getCopyrightText().split("\n")) {
+				if (!isEmpty(bean.getCopyrightText())) {
+					for (String copyright : bean.getCopyrightText().split("\n")) {
 						copyrightList.add(copyright);
 					}
 				}
 				
-				if(!isEmpty(bean.getOssAttribution())) {
+				if (!isEmpty(bean.getOssAttribution())) {
 					attributionList.add(bean.getOssAttribution());
 				}
 
@@ -1547,7 +1547,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				license.setLicenseText(bean.getLicenseText());
 				license.setAttribution(bean.getAttribution());
 
-				if(!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
+				if (!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
 					ossComponent.addOssComponentsLicense(license);
 				}
 				
@@ -1555,8 +1555,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				String ossCopyright = findAddedOssCopyright(bean.getOssId(), bean.getLicenseId(), bean.getOssCopyright());
 				
 				// multi license 추가 copyright
-				if(!isEmpty(ossCopyright)) {
-					for(String copyright : ossCopyright.split("\n")) {
+				if (!isEmpty(ossCopyright)) {
+					for (String copyright : ossCopyright.split("\n")) {
 						copyrightList.add(copyright);
 					}
 				}
@@ -1575,21 +1575,21 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				ossComponent.setOssAttribution(String.join("\r\n", attributionList));
 				componentAttribution.put(componentKey, attributionList);
 				
-				if(isDisclosure) {
-					if(addDisclosure) {
+				if (isDisclosure) {
+					if (addDisclosure) {
 						srcInfo.replace(componentKey, ossComponent);
 					} else {
 						srcInfo.put(componentKey, ossComponent);
 					}
 				} else {
-					if(addNotice) {
+					if (addNotice) {
 						noticeInfo.replace(componentKey, ossComponent);
 					} else {
 						noticeInfo.put(componentKey, ossComponent);
 					}
 				}
 				
-				if(!licenseInfo.containsKey(license.getLicenseName())) {
+				if (!licenseInfo.containsKey(license.getLicenseName())) {
 					licenseInfo.put(license.getLicenseName(), license);
 				}
 			} else {
@@ -1603,7 +1603,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				
 				// 하나의 oss에 대해서 동일한 LICENSE가 복수 표시되는 현상 
 				// 일단 여기서 막는다. (쿼리가 잘못된 건지, DATA가 꼬이는건지 모르겠음)
-				if(!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
+				if (!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
 					ossComponent.addOssComponentsLicense(license);
 					
 					// OSS의 Copyright text를 수정하였음에도 Packaging > Notice Preview에 업데이트 안 됨.
@@ -1614,10 +1614,10 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					bean.setOssCopyright(findAddedOssCopyright(bean.getOssId(), bean.getLicenseId(), bean.getOssCopyright()));
 					
 					// multi license 추가 copyright
-					if(!isEmpty(bean.getOssCopyright())) {
+					if (!isEmpty(bean.getOssCopyright())) {
 						String addCopyright = avoidNull(ossComponent.getCopyrightText());
 						
-						if(!isEmpty(ossComponent.getCopyrightText())) {
+						if (!isEmpty(ossComponent.getCopyrightText())) {
 							addCopyright += "\r\n";
 						}
 						 
@@ -1626,33 +1626,33 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					}
 				}
 				
-				if(isDisclosure) {
-					if(addDisclosure) {
+				if (isDisclosure) {
+					if (addDisclosure) {
 						srcInfo.replace(componentKey, ossComponent);
 					} else {
 						srcInfo.put(componentKey, ossComponent);
 					}
 				} else {
-					if(addNotice) {
+					if (addNotice) {
 						noticeInfo.replace(componentKey, ossComponent);
 					} else {
 						noticeInfo.put(componentKey, ossComponent);
 					}
 				}
 				
-				if(!licenseInfo.containsKey(license.getLicenseName())) {
+				if (!licenseInfo.containsKey(license.getLicenseName())) {
 					licenseInfo.put(license.getLicenseName(), license);
 				}
 			}
 		}
 		
 		// copyleft에 존재할 경우 notice에서는 출력하지 않고 copyleft로 merge함.
-		if(hideOssVersionFlag) {
+		if (hideOssVersionFlag) {
 			Map<String, OssComponents> hideOssVersionMergeNoticeInfo = new HashMap<>();
 			Set<String> noticeKeyList = noticeInfo.keySet();
 			
-			for(String key : noticeKeyList) {
-				if(!srcInfo.containsKey(key)) {
+			for (String key : noticeKeyList) {
+				if (!srcInfo.containsKey(key)) {
 					hideOssVersionMergeNoticeInfo.put(key, noticeInfo.get(key));
 				}
 			}
@@ -1664,11 +1664,11 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		// OSS NAME을 하이픈 ('-') 으로 등록한 경우 (고지문구에 라이선스만 추가)
 		List<OssComponents> addOssComponentList = selfCheckMapper.selectVerificationNoticeClassAppend(ossNotice);
 		
-		if(addOssComponentList != null) {
+		if (addOssComponentList != null) {
 			ossComponent = null;
 			Map<String, List<String>> addOssComponentCopyright = new HashMap<>();
 			
-			for(OssComponents bean : addOssComponentList) {
+			for (OssComponents bean : addOssComponentList) {
 				String componentKey = (hideOssVersionFlag
 						? bean.getOssName() 
 						: bean.getOssName() + "|" + bean.getOssVersion()).toUpperCase();
@@ -1677,8 +1677,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 						? (List<String>) addOssComponentCopyright.get(componentKey) 
 						: new ArrayList<>();
 				
-				if(!isEmpty(bean.getCopyrightText())) {
-					for(String copyright : bean.getCopyrightText().split("\n")) {
+				if (!isEmpty(bean.getCopyrightText())) {
+					for (String copyright : bean.getCopyrightText().split("\n")) {
 						copyrightList.add(copyright);
 					}
 				}
@@ -1686,22 +1686,22 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				boolean addSrcInfo = srcInfo.containsKey(componentKey);
 				boolean addNoticeInfo = noticeInfo.containsKey(componentKey);
 				
-				if(addSrcInfo) {
+				if (addSrcInfo) {
 					ossComponent = srcInfo.get(componentKey);
-				} else if(addNoticeInfo) {
+				} else if (addNoticeInfo) {
 					ossComponent = noticeInfo.get(componentKey);
 				} else {
 					ossComponent = bean;
 				}
 				
-				if("-".equals(bean.getOssName()) || !CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(bean.getOssName().toUpperCase())
+				if ("-".equals(bean.getOssName()) || !CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(bean.getOssName().toUpperCase())
 						|| !CoCodeManager.OSS_INFO_UPPER.containsKey((bean.getOssName() + "_" + avoidNull(bean.getOssVersion())).toUpperCase())) {
-					if(!isEmpty(bean.getDownloadLocation()) && isEmpty(bean.getHomepage())) {
+					if (!isEmpty(bean.getDownloadLocation()) && isEmpty(bean.getHomepage())) {
 						ossComponent.setHomepage(bean.getDownloadLocation());
 					}
 				}
 				
-				if("-".equals(bean.getOssName())) {
+				if ("-".equals(bean.getOssName())) {
 					componentKey += dashSeq++;
 				}
 				
@@ -1711,7 +1711,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				license.setLicenseText(bean.getLicenseText());
 				license.setAttribution(bean.getAttribution());
 				
-				if(!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
+				if (!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
 					ossComponent.addOssComponentsLicense(license);
 				}
 				
@@ -1723,8 +1723,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				
 				switch(CommonFunction.checkObligationSelectedLicense(ossComponent.getOssComponentsLicense())){
 					case CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE: 
-						if(hideOssVersionFlag) {
-							if(!srcInfo.containsKey(componentKey)) {
+						if (hideOssVersionFlag) {
+							if (!srcInfo.containsKey(componentKey)) {
 								srcInfo.put(componentKey, ossComponent);
 							}
 						} else {
@@ -1733,8 +1733,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 						
 						break;
 					case CoConstDef.CD_DTL_OBLIGATION_NOTICE: 
-						if(hideOssVersionFlag) {
-							if(!noticeInfo.containsKey(componentKey)) {
+						if (hideOssVersionFlag) {
+							if (!noticeInfo.containsKey(componentKey)) {
 								noticeInfo.put(componentKey, ossComponent);
 							}
 						} else {
@@ -1744,7 +1744,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 						break;
 				}
 				
-				if(!licenseInfo.containsKey(license.getLicenseName())) {
+				if (!licenseInfo.containsKey(license.getLicenseName())) {
 					licenseInfo.put(componentKey, license);
 				}
 			}
@@ -1756,8 +1756,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		// 개행처리 및 velocity용 list 생성
 		List<OssComponents> noticeList = new ArrayList<>();
 		
-		for(OssComponents bean : noticeInfo.values()) {
-			if(isTextNotice) {
+		for (OssComponents bean : noticeInfo.values()) {
+			if (isTextNotice) {
 				bean.setCopyrightText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getCopyrightText()))));
 				bean.setLicenseText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getLicenseText()))));
 				bean.setOssAttribution(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getOssAttribution()))));
@@ -1767,11 +1767,11 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				bean.setOssAttribution(CommonFunction.lineReplaceToBR(StringEscapeUtils.escapeHtml(avoidNull(bean.getOssAttribution()))));
 			}
 
-			if(!isEmpty(bean.getOssAttribution()) && !ossAttributionMap.containsKey(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()))) {
+			if (!isEmpty(bean.getOssAttribution()) && !ossAttributionMap.containsKey(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()))) {
 				ossAttributionMap.put(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()), avoidNull(bean.getOssName(), "") + "__" + bean.getOssAttribution());
 			}
 			
-			if(!isEmpty(bean.getOssName())) {
+			if (!isEmpty(bean.getOssName())) {
 				bean.setOssName(StringUtil.replaceHtmlEscape(bean.getOssName()));
 			}
 			
@@ -1787,8 +1787,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		
 		List<OssComponents> srcList = new ArrayList<>();
 		
-		for(OssComponents bean : srcInfo.values()) {
-			if(isTextNotice) {
+		for (OssComponents bean : srcInfo.values()) {
+			if (isTextNotice) {
 				bean.setCopyrightText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getCopyrightText()))));
 				bean.setLicenseText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getLicenseText()))));
 				bean.setOssAttribution(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getOssAttribution()))));
@@ -1799,11 +1799,11 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			}
 			
 
-			if(!isEmpty(bean.getOssAttribution()) && !ossAttributionMap.containsKey(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()))) {
+			if (!isEmpty(bean.getOssAttribution()) && !ossAttributionMap.containsKey(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()))) {
 				ossAttributionMap.put(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()), avoidNull(bean.getOssName(), "") + "__" + bean.getOssAttribution());
 			}
 			
-			if(!isEmpty(bean.getOssName())) {
+			if (!isEmpty(bean.getOssName())) {
 				bean.setOssName(StringUtil.replaceHtmlEscape(bean.getOssName()));
 			}
 			
@@ -1825,8 +1825,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		// 정렬
 		TreeMap<String, OssComponentsLicense> licenseTreeMap = new TreeMap<>( licenseInfo );
 		
-		for(OssComponentsLicense bean : licenseTreeMap.values()) {
-			if(isTextNotice) {
+		for (OssComponentsLicense bean : licenseTreeMap.values()) {
+			if (isTextNotice) {
 				bean.setCopyrightText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getCopyrightText()))));
 				bean.setLicenseText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getLicenseText()))));
 			} else {
@@ -1837,10 +1837,10 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			// 배포사이트 license text url
 			licenseList.add(bean);
 			
-			if(CoConstDef.FLAG_YES.equals(ossNotice.getSimpleNoticeFlag())) {
+			if (CoConstDef.FLAG_YES.equals(ossNotice.getSimpleNoticeFlag())) {
 				LicenseMaster licenseBean = CoCodeManager.LICENSE_INFO_BY_ID.get(bean.getLicenseId());
 				
-				if(licenseBean != null) {
+				if (licenseBean != null) {
 //					String simpleLicenseFileName = !isEmpty(licenseBean.getShortIdentifier()) ? licenseBean.getShortIdentifier() : licenseBean.getLicenseNameTemp();
 //					String distributeUrl = CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTE_CODE, CoConstDef.CD_DTL_DISTRIBUTE_LGE);
 //					simpleLicenseFileName = simpleLicenseFileName.replaceAll(" ", "_").replaceAll("/", "_") + ".html";
@@ -1853,7 +1853,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				}
 			}
 
-			if(!isEmpty(bean.getAttribution())) {
+			if (!isEmpty(bean.getAttribution())) {
 				bean.setAttribution(CommonFunction.lineReplaceToBR(StringEscapeUtils.escapeHtml(avoidNull(bean.getAttribution()))));
 				attributionList.add(bean);
 			}
@@ -1873,7 +1873,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		String appendedContentsTEXT = ossNotice.getAppendedTEXT();
 		String appendedContents = ossNotice.getAppended();
 		
-		if(!isEmpty(distributionSiteUrl) && !(distributionSiteUrl.startsWith("http://") || distributionSiteUrl.startsWith("https://") || distributionSiteUrl.startsWith("ftp://"))) {
+		if (!isEmpty(distributionSiteUrl) && !(distributionSiteUrl.startsWith("http://") || distributionSiteUrl.startsWith("https://") || distributionSiteUrl.startsWith("ftp://"))) {
 			distributionSiteUrl = "http://" + distributionSiteUrl;
 		}
 		model.put("noticeType", noticeType);
@@ -1894,7 +1894,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		model.put("editAppendedYn", ossNotice.getEditAppendedYn());
 		
 		/*//ui 개선버전으로 신규 추가된 flag */
-		if(CoConstDef.FLAG_YES.equals(ossNotice.getSimpleNoticeFlag())) {
+		if (CoConstDef.FLAG_YES.equals(ossNotice.getSimpleNoticeFlag())) {
 			model.put("licenseListUrls", licenseListUrls);
 		} else {
 			model.put("licenseList", licenseList);
@@ -1903,13 +1903,13 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		model.put("attributionList", attributionList.isEmpty() ? null : attributionList);
 		model.put("ossAttributionList", ossAttributionList.isEmpty() ? null : ossAttributionList);
 		
-		if("text".equals(ossNotice.getFileType())){
+		if ("text".equals(ossNotice.getFileType())){
 			model.put("appended", avoidNull(appendedContentsTEXT, "").replaceAll("&nbsp;", " "));
 		} else {
 			model.put("appended", appendedContents);
 		}
 
-		if("text".equals(ossNotice.getFileType())){
+		if ("text".equals(ossNotice.getFileType())){
 			model.put("templateURL", CoCodeManager.getCodeExpString(noticeInfoCode, CoConstDef.CD_DTL_SELFCHECK_NOTICE_TEXT_TEMPLATE));
 		} else {
 			model.put("templateURL", CoCodeManager.getCodeExpString(noticeInfoCode, CoConstDef.CD_DTL_SELFCHECK_NOTICE_DEFAULT_TEMPLATE));
@@ -1923,9 +1923,9 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 
 	private boolean checkLicenseDuplicated(List<OssComponentsLicense> ossComponentsLicense,
 			OssComponentsLicense license) {
-		if(ossComponentsLicense != null) {
-			for(OssComponentsLicense bean : ossComponentsLicense) {
-				if(bean.getLicenseId().equals(license.getLicenseId())) {
+		if (ossComponentsLicense != null) {
+			for (OssComponentsLicense bean : ossComponentsLicense) {
+				if (bean.getLicenseId().equals(license.getLicenseId())) {
 					return true;
 				}
 			}
@@ -1937,39 +1937,39 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 	public int allowDownloadMultiFlagToBitFlag(Project project) {
 		int bitFlag = 1;
 		
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeHTMLYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeHTMLYn())) {
 			bitFlag |= CoConstDef.FLAG_A;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeTextYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeTextYn())) {
 			bitFlag |= CoConstDef.FLAG_B;
 		}
 		
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleHTMLYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleHTMLYn())) {
 			bitFlag |= CoConstDef.FLAG_C;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleTextYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleTextYn())) {
 			bitFlag |= CoConstDef.FLAG_D;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXSheetYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXSheetYn())) {
 			bitFlag |= CoConstDef.FLAG_E;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXRdfYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXRdfYn())) {
 			bitFlag |= CoConstDef.FLAG_F;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXTagYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXTagYn())) {
 			bitFlag |= CoConstDef.FLAG_G;
 		}
 
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXJsonYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXJsonYn())) {
 			bitFlag |= CoConstDef.FLAG_H;
 		}
 
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXYamlYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXYamlYn())) {
 			bitFlag |= CoConstDef.FLAG_I;
 		}
 		
@@ -1977,11 +1977,11 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 	}
 
 	private String findAddedOssCopyright(String ossId, String licenseId, String ossCopyright) {
-		if(!isEmpty(ossId) && !isEmpty(licenseId)) {
+		if (!isEmpty(ossId) && !isEmpty(licenseId)) {
 			OssMaster bean = CoCodeManager.OSS_INFO_BY_ID.get(ossId);
 			if (bean != null) {
-				for(OssLicense license : bean.getOssLicenses()) {
-					if(licenseId.equals(license.getLicenseId()) && !isEmpty(license.getOssCopyright())) {
+				for (OssLicense license : bean.getOssLicenses()) {
+					if (licenseId.equals(license.getLicenseId()) && !isEmpty(license.getOssCopyright())) {
 						return license.getOssCopyright();
 					}
 				}
@@ -2009,7 +2009,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		// Text 형식 OSS 고지문 생성 시 개행문자 변경
 		// System.getProperty("line.separator") => "\n" => "\r\n" 변경 
 		String line = "\r\n";
-		if(fileType == "text"){
+		if (fileType == "text"){
 			fileId = "";
 			filePath = NOTICE_PATH + ( isConfirm ? "/" : "/preview/") + project.getPrjId();
 			fileName = (CoConstDef.FLAG_YES.equals(simpleFlag) ? "simple_" : "") + CommonFunction.getNoticeFileName("Self-Check_"+project.getPrjId(), project.getPrjName(), project.getPrjVersion(), ( isConfirm ? CommonFunction.getCurrentDateTime("yyMMdd") : DateUtil.getCurrentDateTime(DateUtil.DATE_HMS_PATTERN) ), fileType);
@@ -2021,13 +2021,13 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			
 			// custom edit를 사용하고, packaging confirm 인 경우 이면서 simple인 경우
 			// license text 부분만 다시 변경한다.
-			if(isConfirm && CoConstDef.FLAG_YES.equals(simpleFlag) && CoConstDef.FLAG_YES.equals(project.getUseCustomNoticeYn())) {
+			if (isConfirm && CoConstDef.FLAG_YES.equals(simpleFlag) && CoConstDef.FLAG_YES.equals(project.getUseCustomNoticeYn())) {
 				// 이미 생성된 고지문구 파일의 내용을 가져온다.
 				T2File defaultNoticeFileInfo = fileService.selectFileInfo(project.getNoticeFileId());
 				
-				if(defaultNoticeFileInfo != null) {
+				if (defaultNoticeFileInfo != null) {
 					File noticeFile = new File(defaultNoticeFileInfo.getLogiPath() + "/" + defaultNoticeFileInfo.getLogiNm());
-					if(noticeFile.exists()) {
+					if (noticeFile.exists()) {
 						Document doc = Jsoup.parse(noticeFile, "UTF8");
 						Document doc2 = Jsoup.parse(contents);
 						
@@ -2040,7 +2040,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				}
 			}
 		}
-		if(FileUtil.writeFile(filePath, fileName, contents)) {
+		if (FileUtil.writeFile(filePath, fileName, contents)) {
 			// 파일 등록
 			fileId = fileService.registFileDownload(filePath, fileName, fileName);
 		}
@@ -2064,7 +2064,7 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 	@Override
 	@Transactional
 	public void registOssNotice(OssNotice ossNotice) throws Exception {
-		if(CoConstDef.FLAG_YES.equals(ossNotice.getEditNoticeYn())){
+		if (CoConstDef.FLAG_YES.equals(ossNotice.getEditNoticeYn())){
 			selfCheckMapper.insertOssNotice(ossNotice);
 		} else {
 			selfCheckMapper.updateOssNotice(ossNotice);
@@ -2081,12 +2081,12 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 		final Comparator<OssComponents> comp = Comparator.comparing((OssComponents o) -> o.getOssName()+"|"+o.getOssVersion());
 		gridData = gridData.stream().sorted(comp).collect(Collectors.toList());
 		
-		for(OssComponents info : gridData) {
-			if(isEmpty(groupColumn)) {
+		for (OssComponents info : gridData) {
+			if (isEmpty(groupColumn)) {
 				groupColumn = info.getOssName() + "-" + info.getOssVersion();
 			}
 						
-			if(groupColumn.equals(info.getOssName() + "-" + info.getOssVersion()) // 같은 groupColumn이면 데이터를 쌓음
+			if (groupColumn.equals(info.getOssName() + "-" + info.getOssVersion()) // 같은 groupColumn이면 데이터를 쌓음
 					&& !("-".equals(info.getOssName()) 
 					&& !"NA".equals(info.getLicenseType()))) { // 단, OSS Name: - 이면서, License Type: Proprietary이 아닌 경우 Row를 합치지 않음.
 				tempData.add(info);
@@ -2105,11 +2105,11 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 	}	
 	
 	public static void setMergeData(List<OssComponents> tempData, List<OssComponents> resultGridData){
-		if(tempData.size() > 0) {
+		if (tempData.size() > 0) {
 			Collections.sort(tempData, new Comparator<OssComponents>() {
 				@Override
 				public int compare(OssComponents o1, OssComponents o2) {
-					if(o1.getLicenseName().length() >= o2.getLicenseName().length()) {
+					if (o1.getLicenseName().length() >= o2.getLicenseName().length()) {
 						return 1;
 					}else {
 						return -1;
@@ -2119,8 +2119,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 			
 			OssComponents rtnBean = null;
 			
-			for(OssComponents temp : tempData) {
-				if(rtnBean == null) {
+			for (OssComponents temp : tempData) {
+				if (rtnBean == null) {
 					rtnBean = temp;
 					
 					continue;
@@ -2128,8 +2128,8 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 				
 				String key = temp.getOssName() + "-" + temp.getLicenseType();
 				
-				if("--NA".equals(key)) {
-					if(!rtnBean.getLicenseName().contains(temp.getLicenseName())) {
+				if ("--NA".equals(key)) {
+					if (!rtnBean.getLicenseName().contains(temp.getLicenseName())) {
 						resultGridData.add(rtnBean);
 						rtnBean = temp;
 						
@@ -2137,18 +2137,18 @@ public class SelfCheckServiceImpl extends CoTopComponent implements SelfCheckSer
 					}
 				}
 				
-				for(String licenseName : temp.getLicenseName().split(",")) {
+				for (String licenseName : temp.getLicenseName().split(",")) {
 					boolean equalFlag = false;
 					
-					for(String rtnLicenseName : rtnBean.getLicenseName().split(",")) {
-						if(rtnLicenseName.equals(licenseName)) {
+					for (String rtnLicenseName : rtnBean.getLicenseName().split(",")) {
+						if (rtnLicenseName.equals(licenseName)) {
 							equalFlag = true;
 							
 							break;
 						}
 					}
 					
-					if(!equalFlag) {
+					if (!equalFlag) {
 						rtnBean.setLicenseName(rtnBean.getLicenseName() + "," + licenseName);
 					}
 				}

--- a/src/main/java/oss/fosslight/service/impl/SentMailServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SentMailServiceImpl.java
@@ -28,13 +28,13 @@ public class SentMailServiceImpl extends CoTopComponent implements SentMailServi
 		
 		String filterCondition = CommonFunction.getFilterToString(vo.getFilters());
 		
-		if(!isEmpty(filterCondition)) {
+		if (!isEmpty(filterCondition)) {
 			vo.setFilterCondition(filterCondition);
 		}
 		
 		int records = sentMailMapper.selectSentMailTotalCount(vo);
 		
-		if(records > 0) {
+		if (records > 0) {
 			vo.setTotListSize(records);
 			
 			// Grid paging 처리를 위한 기본 param 설정 Map 생성(반드시 totlistsize를 set 하고 나서 생성해야함)

--- a/src/main/java/oss/fosslight/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/StatisticsServiceImpl.java
@@ -43,41 +43,41 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		List<Statistics> titleList = new ArrayList<Statistics>();
 		List<String> titleArray = new ArrayList<String>();
 		
-		if(!"NET".equals(statistics.getCategoryType())) {
+		if (!"NET".equals(statistics.getCategoryType())) {
 			titleList = statisticsMapper.getChartTitle(statistics);
 		}
 		
-		if("REV".equals(statistics.getCategoryType())) {
+		if ("REV".equals(statistics.getCategoryType())) {
 			titleArray.add("unassigned");
 			statistics.setNoneUser(statisticsMapper.getNoneUser());
 		}
 		
-		for(Statistics title : titleList) {
+		for (Statistics title : titleList) {
 			titleArray.add(title.getTitleNm());
 		}
 		
-		if("NET".equals(statistics.getCategoryType())) {
+		if ("NET".equals(statistics.getCategoryType())) {
 			titleArray.add("Network Service");
 			titleArray.add("Others");
 		} 
 		
 		titleArray = titleArray.stream().distinct().collect(Collectors.toList());
-		if("REV".equals(statistics.getCategoryType())) {
+		if ("REV".equals(statistics.getCategoryType())) {
 			statistics.setCategorySize(titleArray.size());
 		}
 		statistics.setTitleArray(titleArray); // Chart Title
 		
 		List<Statistics> list = statisticsMapper.getDivisionalProjectChartData(statistics);
 		
-		if("REV".equals(statistics.getCategoryType())) {
+		if ("REV".equals(statistics.getCategoryType())) {
 			// Reviewer None Statistic Sum Check
 			if (noneCheck(titleArray, list) > 0) {
 				titleArray.add("NONE");
 			}
 		}
 				
-		if(CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
-			for(Statistics stat : list) {
+		if (CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
+			for (Statistics stat : list) {
 				stat.setTotal();
 			}
 			
@@ -85,42 +85,42 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 			result.put("chartData", list);
 			result.put("titleArray", titleArray);
 		} else {
-			for(Statistics data : list) {
+			for (Statistics data : list) {
 				int categoryIdx = 0;
 				
-				if(data.getCategory0Cnt() > -1) {
+				if (data.getCategory0Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory0Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory1Cnt() > -1) {
+				if (data.getCategory1Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory1Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory2Cnt() > -1) {
+				if (data.getCategory2Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory2Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory3Cnt() > -1) {
+				if (data.getCategory3Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory3Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory4Cnt() > -1) {
+				if (data.getCategory4Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory4Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory5Cnt() > -1) {
+				if (data.getCategory5Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory5Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory6Cnt() > -1) {
+				if (data.getCategory6Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory6Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory7Cnt() > -1) {
+				if (data.getCategory7Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory7Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory8Cnt() > -1) {
+				if (data.getCategory8Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory8Cnt(), categoryIdx++);
 				}
 			}
@@ -137,9 +137,9 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		List<Statistics> list = statisticsMapper.getMostUsedChartData(statistics);
 		
 		/*
-		if("OSS".equals(statistics.getChartType())) {
+		if ("OSS".equals(statistics.getChartType())) {
 			list = statisticsMapper.getMostUsedOssChartData(statistics);
-		} else if("LICENSE".equals(statistics.getChartType())) {			
+		} else if ("LICENSE".equals(statistics.getChartType())) {			
 			list = statisticsMapper.getMostUsedLicenseChartData(statistics);
 		}
 		*/
@@ -157,7 +157,7 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		
 		List<String> titleArray = new ArrayList<String>();
 		
-		for(Statistics title : titleList) {
+		for (Statistics title : titleList) {
 			titleArray.add(title.getTitleNm());
 		}
 		
@@ -181,8 +181,8 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 			titleArray.add("NONE");
 		}
 		
-		if(CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
-			for(Statistics stat : list) {
+		if (CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
+			for (Statistics stat : list) {
 				stat.setTotal();
 			}
 			
@@ -190,43 +190,43 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 			result.put("chartData", list);
 			result.put("titleArray", titleArray);
 		} else {
-			for(Statistics data : list) {
+			for (Statistics data : list) {
 				int categoryIdx = 0;
 				chartData.addCategoryList(data.getColumnName());
 				
-				if(data.getCategory0Cnt() > -1) {
+				if (data.getCategory0Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory0Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory1Cnt() > -1) {
+				if (data.getCategory1Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory1Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory2Cnt() > -1) {
+				if (data.getCategory2Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory2Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory3Cnt() > -1) {
+				if (data.getCategory3Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory3Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory4Cnt() > -1) {
+				if (data.getCategory4Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory4Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory5Cnt() > -1) {
+				if (data.getCategory5Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory5Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory6Cnt() > -1) {
+				if (data.getCategory6Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory6Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory7Cnt() > -1) {
+				if (data.getCategory7Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory7Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory8Cnt() > -1) {
+				if (data.getCategory8Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory8Cnt(), categoryIdx++);
 				}
 			}
@@ -246,7 +246,7 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		List<Statistics> titleList = statisticsMapper.getChartTitle(statistics);
 		List<String> titleArray = new ArrayList<String>();
 		
-		for(Statistics title : titleList) {
+		for (Statistics title : titleList) {
 			titleArray.add(title.getTitleNm());
 		}
 		
@@ -270,8 +270,8 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 			titleArray.add("NONE");
 		}
 		
-		if(CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
-			for(Statistics stat : list) {
+		if (CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
+			for (Statistics stat : list) {
 				stat.setTotal();
 			}
 			
@@ -279,43 +279,43 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 			result.put("chartData", list);
 			result.put("titleArray", titleArray);
 		} else {
-			for(Statistics data : list) {
+			for (Statistics data : list) {
 				int categoryIdx = 0;
 				chartData.addCategoryList(data.getColumnName());
 				
-				if(data.getCategory0Cnt() > -1) {
+				if (data.getCategory0Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory0Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory1Cnt() > -1) {
+				if (data.getCategory1Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory1Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory2Cnt() > -1) {
+				if (data.getCategory2Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory2Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory3Cnt() > -1) {
+				if (data.getCategory3Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory3Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory4Cnt() > -1) {
+				if (data.getCategory4Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory4Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory5Cnt() > -1) {
+				if (data.getCategory5Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory5Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory6Cnt() > -1) {
+				if (data.getCategory6Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory6Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory7Cnt() > -1) {
+				if (data.getCategory7Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory7Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory8Cnt() > -1) {
+				if (data.getCategory8Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory8Cnt(), categoryIdx++);
 				}
 			}
@@ -335,12 +335,12 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		List<Statistics> titleList = statisticsMapper.getChartTitle(statistics);
 		List<String> titleArray = new ArrayList<String>();
 		
-		if("REV".equals(statistics.getCategoryType())) {
+		if ("REV".equals(statistics.getCategoryType())) {
 			titleArray.add("unassigned");
 			statistics.setNoneUser(statisticsMapper.getNoneUser());
 		}
 		
-		for(Statistics title : titleList) {
+		for (Statistics title : titleList) {
 			titleArray.add(title.getTitleNm());
 		}
 		
@@ -351,15 +351,15 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		
 		List<Statistics> list = statisticsMapper.getTrdPartyRelatedChartData(statistics);
 		
-		if("REV".equals(statistics.getCategoryType())) {
+		if ("REV".equals(statistics.getCategoryType())) {
 			// Reviewer None Statistic Sum Check
 			if (noneCheck(titleArray, list) > 0) {
 				titleArray.add("NONE");
 			}
 		}
 		
-		if(CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
-			for(Statistics stat : list) {
+		if (CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
+			for (Statistics stat : list) {
 				stat.setTotal();
 			}
 			
@@ -367,42 +367,42 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 			result.put("chartData", list);
 			result.put("titleArray", titleArray);
 		} else {
-			for(Statistics data : list) {
+			for (Statistics data : list) {
 				int categoryIdx = 0;
 				
-				if(data.getCategory0Cnt() > -1) {
+				if (data.getCategory0Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory0Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory1Cnt() > -1) {
+				if (data.getCategory1Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory1Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory2Cnt() > -1) {
+				if (data.getCategory2Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory2Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory3Cnt() > -1) {
+				if (data.getCategory3Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory3Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory4Cnt() > -1) {
+				if (data.getCategory4Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory4Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory5Cnt() > -1) {
+				if (data.getCategory5Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory5Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory6Cnt() > -1) {
+				if (data.getCategory6Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory6Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory7Cnt() > -1) {
+				if (data.getCategory7Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory7Cnt(), categoryIdx++);
 				}
 				
-				if(data.getCategory8Cnt() > -1) {
+				if (data.getCategory8Cnt() > -1) {
 					chartData.addCategoryCnt(data.getCategory8Cnt(), categoryIdx++);
 				}
 			}
@@ -425,8 +425,8 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 		titleList.add("Total");
 		titleList.add("Activator");
 		
-		if(CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
-			for(Statistics stat : list) {
+		if (CoConstDef.FLAG_YES.equals(statistics.getIsRawData())) {
+			for (Statistics stat : list) {
 				stat.setTotal();
 			}
 			
@@ -434,7 +434,7 @@ public class StatisticsServiceImpl extends CoTopComponent implements StatisticsS
 			result.put("chartData", list);
 			result.put("titleArray", titleList);
 		} else {
-			for(Statistics data : list) {
+			for (Statistics data : list) {
 				int categoryIdx = 0;
 				chartData.addCategoryCnt(data.getCategory0Cnt()-data.getCategory1Cnt(), categoryIdx++); // total Cnt = 부서원 - activator
 				chartData.addCategoryCnt(data.getCategory1Cnt(), categoryIdx++); // activator Cnt

--- a/src/main/java/oss/fosslight/service/impl/SystemConfigurationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/SystemConfigurationServiceImpl.java
@@ -92,7 +92,7 @@ public class SystemConfigurationServiceImpl extends CoTopComponent implements Sy
 		// login detail setting
 		Map<String, Object> loginDetailMap = (Map<String, Object>) configurationMap.get("loginDetail");
 		
-		if(loginDetailMap != null) {
+		if (loginDetailMap != null) {
 			loginAuthList.stream().map(c -> {
 				switch (c.getCdDtlNo()) {
 					case CoConstDef.CD_LDAP_SERVER_URL:
@@ -110,7 +110,7 @@ public class SystemConfigurationServiceImpl extends CoTopComponent implements Sy
 		// smtp detail setting
 //		Map<String, Object> smtpDetailMap = (Map<String, Object>) configurationMap.get("smtpDetail");
 //		
-//		if(smtpDetailMap != null) {
+//		if (smtpDetailMap != null) {
 //			smtpAuthList.stream().map(c -> {
 //				switch(c.getCdDtlNo()) {
 //					case CoConstDef.CD_SMTP_SERVICE_HOST:
@@ -135,14 +135,14 @@ public class SystemConfigurationServiceImpl extends CoTopComponent implements Sy
 //						break;
 //					case CoConstDef.CD_SMTP_SERVICE_PASSWORD:
 //						String _pw = (String) smtpDetailMap.get(CoConstDef.CD_SMTP_SERVICE_PASSWORD);
-//						if(!StringUtil.isEmpty(_pw)) {
+//						if (!StringUtil.isEmpty(_pw)) {
 //							String _encPw = null;
 //							try {
 //								_encPw = CryptUtil.encryptAES256(_pw, CoConstDef.ENCRYPT_DEFAULT_SALT_KEY);
 //							} catch (Exception e) {
 //								log.error(e.getMessage());
 //							}
-//							if(!StringUtil.isEmpty(_encPw)) {
+//							if (!StringUtil.isEmpty(_encPw)) {
 //								c.setCdDtlExp(_encPw);
 //							}
 //						}
@@ -158,12 +158,12 @@ public class SystemConfigurationServiceImpl extends CoTopComponent implements Sy
 		// External Service setting
 //		Map<String, Object> tokenDetailMap = (Map<String, Object>) configurationMap.get("externalServiceDetail");
 //
-//		if(tokenDetailMap != null) {
+//		if (tokenDetailMap != null) {
 //			tokenAuthList.stream().map(c -> {
 //				switch (c.getCdDtlNo()) {
 //					case CoConstDef.CD_DTL_GITHUB_TOKEN:
 //						String token = (String) tokenDetailMap.get(CoConstDef.CD_DTL_GITHUB_TOKEN);
-//						if(!token.isEmpty()) {
+//						if (!token.isEmpty()) {
 //							c.setCdDtlExp(token);
 //						}
 //						break;
@@ -178,7 +178,7 @@ public class SystemConfigurationServiceImpl extends CoTopComponent implements Sy
 		// External Analysis detail setting
 		Map<String, Object> externalAnalysisDetailMap = (Map<String, Object>) configurationMap.get("externalAnalysisDetail");
 
-		if(externalAnalysisDetailMap != null) {
+		if (externalAnalysisDetailMap != null) {
 			externalAnalysisAuthList.stream().map(c -> {
 				switch(c.getCdDtlNo()) {
 
@@ -232,7 +232,7 @@ public class SystemConfigurationServiceImpl extends CoTopComponent implements Sy
 		
 		Map<String, Object> projectDetailMap = (Map<String, Object>) configurationMap.get("projectDetail");
 		
-		if(projectDetailMap != null) {
+		if (projectDetailMap != null) {
 			projectDetailList.stream().map(c -> {
 				switch(c.getCdDtlNo()) {
 					case CoConstDef.CD_AUTO_ANALYSIS_FLAG:
@@ -258,7 +258,7 @@ public class SystemConfigurationServiceImpl extends CoTopComponent implements Sy
 		
 		Map<String, Object> noticeDetailMap = (Map<String, Object>) configurationMap.get("noticeDetail");
 		
-		if(noticeDetailMap != null) {
+		if (noticeDetailMap != null) {
 			noticeDetailList.stream().map(c -> {
 				switch(c.getCdDtlNo()) {
 					case CoConstDef.CD_DTL_NOTICE_HTML:
@@ -284,10 +284,10 @@ public class SystemConfigurationServiceImpl extends CoTopComponent implements Sy
 		Map<String, Object> externalDetailMap = (Map<String, Object>) configurationMap.get("externalDetail");
 		List<T2CodeDtl> externalList = new ArrayList<T2CodeDtl>();
 		
-		if(externalDetailMap != null) {
+		if (externalDetailMap != null) {
 			int seq = 1;
 			
-			for(String key : externalDetailMap.keySet()) {
+			for (String key : externalDetailMap.keySet()) {
 				T2CodeDtl externalItem = new T2CodeDtl();
 				Map<String, Object> value = (Map<String, Object>) externalDetailMap.get((String) key);
 				

--- a/src/main/java/oss/fosslight/service/impl/T2UserServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/T2UserServiceImpl.java
@@ -141,20 +141,20 @@ public class T2UserServiceImpl implements T2UserService {
 			List<PartnerMaster> partnerList = null;
 //			List<Map<String, Object>> batList = null;
 			
-			if(CommonFunction.propertyFlagCheck("menu.project.use.flag", CoConstDef.FLAG_YES)) {
+			if (CommonFunction.propertyFlagCheck("menu.project.use.flag", CoConstDef.FLAG_YES)) {
 				// project watcher 초대여부
 				prjList = projectMapper.getWatcherListByEmail(t2Users.getEmail());
 				userMapper.updateProjectWatcherUserInfo(t2Users);		
 			}
 			
-			if(CommonFunction.propertyFlagCheck("menu.partner.use.flag", CoConstDef.FLAG_YES)) {
+			if (CommonFunction.propertyFlagCheck("menu.partner.use.flag", CoConstDef.FLAG_YES)) {
 				partnerList = partnerMapper.getWatcherListByEmail(t2Users.getEmail());
 				userMapper.updatePartnerWatcherUserInfo(t2Users);
 			}
 			
-			if(prjList != null) {
+			if (prjList != null) {
 				// 진행중인 프로젝트에 대해서 creator에세 메일을 발송
-				for(Project bean : prjList) {
+				for (Project bean : prjList) {
 					CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PROJECT_WATCHER_REGISTED);
 					mailBean.setParamPrjId(bean.getPrjId());
 					mailBean.setParamUserId(t2Users.getUserId());
@@ -163,9 +163,9 @@ public class T2UserServiceImpl implements T2UserService {
 				}
 			}
 			
-			if(partnerList != null) {
+			if (partnerList != null) {
 				// 진행중인 프로젝트에 대해서 creator에세 메일을 발송
-				for(PartnerMaster bean : partnerList) {
+				for (PartnerMaster bean : partnerList) {
 					CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_PARTER_WATCHER_REGISTED);
 					mailBean.setParamPartnerId(bean.getPartnerId());
 					mailBean.setParamUserId(t2Users.getUserId());
@@ -174,9 +174,9 @@ public class T2UserServiceImpl implements T2UserService {
 				}
 			}
 			
-//			if(batList != null) {
+//			if (batList != null) {
 //				// 진행중인 프로젝트에 대해서 creator에세 메일을 발송
-//				for(Map<String, Object> bean : batList) {
+//				for (Map<String, Object> bean : batList) {
 //					String batId = (String) bean.get("baId");
 //					CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_BAT_WATCHER_REGISTED);
 //					mailBean.setParamBatId(batId);
@@ -282,7 +282,7 @@ public class T2UserServiceImpl implements T2UserService {
 	public String getPassword(T2Users user) {
 		T2Users result = userMapper.getPassword(user);
 		
-		if(result != null) {
+		if (result != null) {
 			return result.getPassword();
 		}
 		
@@ -326,16 +326,16 @@ public class T2UserServiceImpl implements T2UserService {
 
 	@Override
 	public void modUser(List<T2Users> vo) {
-		for(int i = 0;i<vo.size();i++) {
+		for (int i = 0;i<vo.size();i++) {
 			vo.get(i).setModifier(vo.get(i).getUserId());
 			vo.get(i).setPassword("");
-			if(vo.get(i).getDivision().trim().equals("")){
+			if (vo.get(i).getDivision().trim().equals("")){
 				vo.get(i).setDivision(CoConstDef.CD_USER_DIVISION_EMPTY);
 			}
 			
 			userMapper.updateUsers(vo.get(i));	
 			
-			if("V".equals(vo.get(i).getAuthority())) {
+			if ("V".equals(vo.get(i).getAuthority())) {
 				vo.get(i).setAuthority("ROLE_ADMIN");
 				userMapper.updateAuthorities(vo.get(i));
 			} else {
@@ -357,11 +357,11 @@ public class T2UserServiceImpl implements T2UserService {
 	public List<T2Users> getUserListExcel() throws Exception {
 		List<T2Users> result = userMapper.selectUserList();
 		
-		for(int i = 0; i< result.size(); i++){
+		for (int i = 0; i< result.size(); i++){
 			String userId = result.get(i).getUserId();
 			String userAuth = userMapper.selectAuthority(userId);
 			
-			if("ROLE_ADMIN".equals(userAuth)){
+			if ("ROLE_ADMIN".equals(userAuth)){
 				userAuth = "V";
 			} else {
 				userAuth = "";
@@ -378,7 +378,7 @@ public class T2UserServiceImpl implements T2UserService {
 		String duplicate = userMapper.checkDuplicateId(vo);
 		boolean result;
 		
-		if("DUPLICATE".equals(duplicate)) {
+		if ("DUPLICATE".equals(duplicate)) {
 			result = true;
 		} else {
 			result = false;
@@ -419,7 +419,7 @@ public class T2UserServiceImpl implements T2UserService {
 		properties.put(Context.SECURITY_CREDENTIALS, userPw);
 		
 		String[] attrIDs = { "cn", "mail" };
-		if(StringUtil.isEmpty(filter)) {
+		if (StringUtil.isEmpty(filter)) {
 			filter = "(cn=" + userId + ")";
 		}
 		
@@ -433,7 +433,7 @@ public class T2UserServiceImpl implements T2UserService {
 			
 			constraints.setSearchScope(SearchControls.SUBTREE_SCOPE);
 			
-			if(attrIDs != null) {
+			if (attrIDs != null) {
 				constraints.setReturningAttributes(attrIDs);
 			}
 			
@@ -442,7 +442,7 @@ public class T2UserServiceImpl implements T2UserService {
 		} catch (NamingException e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(con != null) {
+			if (con != null) {
 				try {
 					con.close();
 				} catch (NamingException e) {}
@@ -454,10 +454,10 @@ public class T2UserServiceImpl implements T2UserService {
 
 			while (m_ne.hasMoreElements()) {
 				sr = (SearchResult) m_ne.next();
-				if(sr != null) {
+				if (sr != null) {
 					String email = (String) sr.getAttributes().get("mail").get();
 					
-					if(!StringUtil.isEmpty(email)) {
+					if (!StringUtil.isEmpty(email)) {
 						userInfo.put("EMAIL", email);
 					}
 				}
@@ -517,13 +517,13 @@ public class T2UserServiceImpl implements T2UserService {
 		params.setToken(_token);
 		params = getUser(params); // 등록된 token 여부 확인
 		
-		if(params == null) {
+		if (params == null) {
 			// 미등록 token
 			throw new CUserNotFoundException();
 		}
 		
 		// Token 인증
-		if(checkToken(params, _token)) { // 추출된 USER 정보로 동일한 token이 생성이 되는지 확인.
+		if (checkToken(params, _token)) { // 추출된 USER 정보로 동일한 token이 생성이 되는지 확인.
             return getUserAndAuthorities(params);
         } else {
             throw new CSigninFailedException();
@@ -538,8 +538,8 @@ public class T2UserServiceImpl implements T2UserService {
 	@Transactional
 	public boolean procToken(T2Users vo) {
 		try {
-			if(CoConstDef.CD_TOKEN_CREATE_TYPE.equals(vo.getTokenType())) {
-				if(StringUtil.isEmpty(vo.getExpireDate())) {
+			if (CoConstDef.CD_TOKEN_CREATE_TYPE.equals(vo.getTokenType())) {
+				if (StringUtil.isEmpty(vo.getExpireDate())) {
 					vo.setExpireDate(CoConstDef.CD_TOKEN_END_DATE);
 				}
 				
@@ -550,7 +550,7 @@ public class T2UserServiceImpl implements T2UserService {
 				vo.setToken(tokenKey);
 			}
 			
-			if(!StringUtil.isEmpty(vo.getToken())) {
+			if (!StringUtil.isEmpty(vo.getToken())) {
 				int successCnt = userMapper.procToken(vo);
 				
 				return successCnt != 1 ? false : true;
@@ -574,7 +574,7 @@ public class T2UserServiceImpl implements T2UserService {
 	
 	public boolean checkPassword(String rawPassword, T2Users bean) {
 		T2Users userInfo = userMapper.getPassword(bean);
-		if(userInfo == null) {
+		if (userInfo == null) {
 			return false;
 		}
 		String encPassword = userInfo.getPassword();
@@ -628,7 +628,7 @@ public class T2UserServiceImpl implements T2UserService {
 			con = new InitialDirContext(property);
 			constraints.setSearchScope(SearchControls.SUBTREE_SCOPE);
 
-			if(attrIDs != null) {
+			if (attrIDs != null) {
 				constraints.setReturningAttributes(attrIDs);
 			}
 
@@ -637,7 +637,7 @@ public class T2UserServiceImpl implements T2UserService {
 		} catch (NamingException e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(con != null) {
+			if (con != null) {
 				try {
 					con.close();
 				} catch (NamingException e) {}
@@ -649,18 +649,18 @@ public class T2UserServiceImpl implements T2UserService {
 			int cnt = 1;
 			while (m_ne.hasMoreElements()) {
 				sr = (SearchResult) m_ne.next();
-				if(sr != null) {
+				if (sr != null) {
 					// 이름/직책/부서(email)
 					String displayName = (String) sr.getAttributes().get("displayName").get();
 					String email = (String) sr.getAttributes().get("mail").get();
-					if(StringUtil.isEmptyTrimmed(displayName)) {
+					if (StringUtil.isEmptyTrimmed(displayName)) {
 						result[0] = email.split("@")[0];
 					} else{
 						result[0] = displayName.replaceAll("\\("+email+"\\)", "").trim();
 					}
 					
-					if(!StringUtil.isEmptyTrimmed(userInfo.getEmail())) {
-						if(email.equals(userInfo.getEmail().trim())) {
+					if (!StringUtil.isEmptyTrimmed(userInfo.getEmail())) {
+						if (email.equals(userInfo.getEmail().trim())) {
 							result[1] = email;
 							result[2] = String.valueOf(cnt);
 							break;

--- a/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
@@ -116,7 +116,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	public List<OssComponents> getVerifyOssList(Project projectMaster) {
 		List<OssComponents> componentList = verificationMapper.selectVerifyOssList(projectMaster);
 		
-		if(componentList != null && !componentList.isEmpty() && componentList.get(0) == null) {
+		if (componentList != null && !componentList.isEmpty() && componentList.get(0) == null) {
 			componentList = new ArrayList<>();
 		}
 		
@@ -131,7 +131,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		
 		int result = verificationMapper.checkPackagingFileId(prjId,packageFileId, packageFileId2, packageFileId3);
 		
-		if(result > 0){
+		if (result > 0){
 			return false;
 		}else{
 			return true;
@@ -154,15 +154,15 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			String uploadComment = "";
 			
 			// verify 버튼 클릭시 file path를 저장한다.
-			if(gridComponentIds != null && !gridComponentIds.isEmpty()) {
+			if (gridComponentIds != null && !gridComponentIds.isEmpty()) {
 				int idx = 0;
 				
-				for(String s : gridComponentIds){
+				for (String s : gridComponentIds){
 					OssComponents param = new OssComponents();
 					param.setComponentId(s);
 					param.setFilePath(gridFilePaths.get(idx++));
 					
-					if(verifyFlag.equals(CoConstDef.FLAG_YES)){
+					if (verifyFlag.equals(CoConstDef.FLAG_YES)){
 						param.setVerifyFileCount("");
 						
 						verificationMapper.updateVerifyFileCount(param);
@@ -172,7 +172,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				}
 			}
 			
-			if(!isEmpty(prjId)) {
+			if (!isEmpty(prjId)) {
 				Project prjParam = new Project();
 				prjParam.setPrjId(prjId);
 				ArrayList<String> newPackagingFileIdList = new ArrayList<String>();
@@ -183,7 +183,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				prjParam.setPackageFileId2(newPackagingFileIdList.get(1));
 				prjParam.setPackageFileId3(newPackagingFileIdList.get(2));
 				
-				if(deleteFiles.equals(CoConstDef.FLAG_YES)){
+				if (deleteFiles.equals(CoConstDef.FLAG_YES)){
 					prjParam.setStatusVerifyYn(CoConstDef.FLAG_NO);
 				}			
 				
@@ -199,22 +199,22 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 					
 					int idx = 0;
 					
-					for(String fileId : origPackagingFileIdList){
+					for (String fileId : origPackagingFileIdList){
 						T2File fileInfo = new T2File();
 						
-						if(!isEmpty(fileId) && !fileId.equals(newPackagingFileIdList.get(idx))){
+						if (!isEmpty(fileId) && !fileId.equals(newPackagingFileIdList.get(idx))){
 							fileInfo.setFileSeq(fileId);
 							fileInfo = fileMapper.getFileInfo(fileInfo);
 							deleteComment += "Packaging file, "+fileInfo.getOrigNm()+", was deleted by "+loginUserName()+". <br>";
 							deleteFileList.add(fileInfo);
 						}
 						
-						if(!isEmpty(newPackagingFileIdList.get(idx)) && !newPackagingFileIdList.get(idx).equals(fileId)){
+						if (!isEmpty(newPackagingFileIdList.get(idx)) && !newPackagingFileIdList.get(idx).equals(fileId)){
 							fileInfo.setFileSeq(newPackagingFileIdList.get(idx));
 							fileInfo = fileMapper.getFileInfo(fileInfo);
 							oss.fosslight.domain.File result = verificationMapper.selectVerificationFile(newPackagingFileIdList.get(idx));
 							
-							if(CoConstDef.FLAG_YES.equals(result.getReuseFlag())){
+							if (CoConstDef.FLAG_YES.equals(result.getReuseFlag())){
 								uploadComment += "Packaging file, "+fileInfo.getOrigNm()+", was loaded from Project ID: "+result.getRefPrjId()+" by "+loginUserName()+". <br>";
 							}else{
 								uploadComment += "Packaging file, "+fileInfo.getOrigNm()+", was uploaded by "+loginUserName()+". <br>";
@@ -238,11 +238,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				verificationMapper.updatePackageFile(prjParam);
 				
 				// delete physical file
-				for(T2File delFile : deleteFileList){
+				for (T2File delFile : deleteFileList){
 					fileService.deletePhysicalFile(delFile, "VERIFY");
 				}
 				
-				if(CoConstDef.FLAG_YES.equals(deleteFlag)){
+				if (CoConstDef.FLAG_YES.equals(deleteFlag)){
 					projectMapper.updateReadmeContent(prjParam); // README Clear
 					projectMapper.updateVerifyContents(prjParam); // File List, Banned List Clear
 				}
@@ -262,14 +262,14 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		Project prjInfo = projectService.getProjectBasicInfo(ossNotice.getPrjId());
 		
 		// OSS Notice가 N/A이면 고지문을 생성하지 않는다.
-		if(CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType())) {
+		if (CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType())) {
 			return true;
 		}
 		
 		prjInfo.setUseCustomNoticeYn(!isEmpty(contents) ? CoConstDef.FLAG_YES : CoConstDef.FLAG_NO);
 		contents = avoidNull(contents, getNoticeHtml(ossNotice));
 		
-		if("binAndroid".equals(contents)) {
+		if ("binAndroid".equals(contents)) {
 			return getAndroidNoticeVelocityTemplateFile(prjInfo); // file Content 옮기는 기능에서 files.copy로 변경
 		} else {
 			return getNoticeVelocityTemplateFile(contents, prjInfo);	
@@ -286,14 +286,14 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		Project prjInfo = projectService.getProjectBasicInfo(ossNotice.getPrjId());
 
 		// OSS Notice가 N/A이면 고지문을 생성하지 않는다.
-		if(CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType())) {
+		if (CoConstDef.CD_NOTICE_TYPE_NA.equals(prjInfo.getNoticeType())) {
 			return true;
 		}
 
 		prjInfo.setUseCustomNoticeYn(!isEmpty(contents) ? CoConstDef.FLAG_YES : CoConstDef.FLAG_NO);
 		contents = avoidNull(contents, PdfUtil.getInstance().getReviewReportHtml(ossNotice.getPrjId()));
 
-		if("binAndroid".equals(contents)) {
+		if ("binAndroid".equals(contents)) {
 			return getAndroidNoticeVelocityTemplateFile(prjInfo); // file Content 옮기는 기능에서 files.copy로 변경
 		} else {
 			return getReviewReportVelocityTemplateFile(contents, prjInfo);
@@ -310,7 +310,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			T2File baseFile = null;
 			String basePath = null;
 			
-			if(isEmpty(project.getSrcAndroidNoticeXmlId()) && !isEmpty(project.getSrcAndroidNoticeFileId())) {
+			if (isEmpty(project.getSrcAndroidNoticeXmlId()) && !isEmpty(project.getSrcAndroidNoticeFileId())) {
 				baseFile = fileMapper.selectFileInfoById(project.getSrcAndroidNoticeFileId());
 				basePath = CommonFunction.emptyCheckProperty("upload.path", "/upload") + "/" + baseFile.getLogiNm();
 			} else {
@@ -321,8 +321,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			// 이전에 생성된 파일은 모두 삭제한다.
 			Path rootPath = Paths.get(filePath);
 			
-			if(rootPath.toFile().exists()) {
-				for(String _fName : rootPath.toFile().list()) {
+			if (rootPath.toFile().exists()) {
+				for (String _fName : rootPath.toFile().list()) {
 					Files.deleteIfExists(rootPath.resolve(_fName));
 					
 					T2File file = new T2File();
@@ -331,7 +331,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 					
 					int returnSuccess = fileMapper.updateFileDelYnByFilePathNm(file);
 					
-					if(returnSuccess > 0){
+					if (returnSuccess > 0){
 						log.debug(filePath + "/" + _fName + " is delete success.");
 					}else{
 						log.debug(filePath + "/" + _fName + " is delete failed.");
@@ -341,7 +341,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			String fileName = CommonFunction.getNoticeFileName(project.getPrjId(), project.getPrjName(), project.getPrjVersion(), CommonFunction.getCurrentDateTime("yyMMdd"), "html");
 			
-			if(oss.fosslight.util.FileUtil.copyFile(basePath, filePath, fileName)) {
+			if (oss.fosslight.util.FileUtil.copyFile(basePath, filePath, fileName)) {
 				// 파일 등록
 				String FileSeq = fileService.registFileWithFileName(filePath, fileName);
 				
@@ -374,8 +374,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			String filePath = NOTICE_PATH + "/" + project.getPrjId();
 			// 이전에 생성된 html 파일은 모두 삭제한다.
 			Path rootPath = Paths.get(filePath);
-			if(rootPath.toFile().exists()) {
-				for(String _fName : rootPath.toFile().list()) {
+			if (rootPath.toFile().exists()) {
+				for (String _fName : rootPath.toFile().list()) {
 					String[] fNameList = _fName.split("\\.");
 					if (fNameList[fNameList.length - 1].equals("html")) {
 						Files.deleteIfExists(rootPath.resolve(_fName));
@@ -397,7 +397,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			String fileName = CommonFunction.getNoticeFileName(project.getPrjId(), project.getPrjName(), project.getPrjVersion(), CommonFunction.getCurrentDateTime("yyMMdd"), "html");
 			
-			if(oss.fosslight.util.FileUtil.writeFile(filePath, fileName, contents)) {
+			if (oss.fosslight.util.FileUtil.writeFile(filePath, fileName, contents)) {
 				// 파일 등록
 				String FileSeq = fileService.registFileWithFileName(filePath, fileName);
 				
@@ -431,8 +431,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 
 			// 이전에 생성된 pdf 파일은 모두 삭제한다.
 			Path rootPath = Paths.get(filePath);
-			if(rootPath.toFile().exists()) {
-				for(String _fName : rootPath.toFile().list()) {
+			if (rootPath.toFile().exists()) {
+				for (String _fName : rootPath.toFile().list()) {
 					String[] fNameList = _fName.split("\\.");
 					if (fNameList[fNameList.length - 1].equals("pdf")) {
 						Files.deleteIfExists(rootPath.resolve(_fName));
@@ -443,7 +443,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 
 						int returnSuccess = fileMapper.updateFileDelYnByFilePathNm(file);
 
-						if(returnSuccess > 0){
+						if (returnSuccess > 0){
 							log.debug(filePath + "/" + _fName + " is delete success.");
 						}else{
 							log.debug(filePath + "/" + _fName + " is delete failed.");
@@ -454,7 +454,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 
 			String fileName = CommonFunction.getReviewReportFileName(project.getPrjId(), project.getPrjName(), project.getPrjVersion(), CommonFunction.getCurrentDateTime("yyMMdd"), ".pdf");
 
-			if(oss.fosslight.util.FileUtil.writeReviewReportFile(filePath, fileName, contents)) {
+			if (oss.fosslight.util.FileUtil.writeReviewReportFile(filePath, fileName, contents)) {
 				// 파일 등록
 				String FileSeq = fileService.registFileWithFileName(filePath, fileName);
 
@@ -481,10 +481,10 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		Project prjInfo = projectService.getProjectBasicInfo(ossNotice.getPrjId());
 		String androidNoticeContents = getAndroidNotice(prjInfo);
 		
-		if(CoConstDef.FLAG_YES.equals(ossNotice.getPreviewOnly()) && !isEmpty(androidNoticeContents)) {
+		if (CoConstDef.FLAG_YES.equals(ossNotice.getPreviewOnly()) && !isEmpty(androidNoticeContents)) {
 			return androidNoticeContents;
 		} else {
-			if(!isEmpty(androidNoticeContents)) {
+			if (!isEmpty(androidNoticeContents)) {
 				return "binAndroid"; 
 			} else {
 				ossNotice.setNetworkServerFlag(prjInfo.getNetworkServerType());
@@ -502,7 +502,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		// 이슈로 인해 android project 기준이 변경이 되었으며 NoticeType이 20인 경우는 전부 Android Project형태를 띄고 있도록 변경이 되었음.
 		Map<String, Object> NoticeInfo = projectMapper.getNoticeType(prjInfo.getPrjId());
 		
-		if(prjInfo != null 
+		if (prjInfo != null 
 				&& CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equals(avoidNull((String) NoticeInfo.get("noticeType"), CoConstDef.CD_DTL_NOTICE_TYPE_GENERAL)) 
 				&& !isEmpty(prjInfo.getSrcAndroidNoticeFileId())) {
 			T2File androidFile = fileService.selectFileInfoById(prjInfo.getSrcAndroidNoticeFileId());
@@ -548,14 +548,14 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			{
 				prjInfo = projectService.getProjectBasicInfo(prjId);
 				
-				if(prjInfo != null && CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(prjInfo.getVerificationStatus())) {
+				if (prjInfo != null && CoConstDef.CD_DTL_IDENTIFICATION_STATUS_CONFIRM.equals(prjInfo.getVerificationStatus())) {
 					doUpdate = false;
 				}
 			}
 			
 			File chk_list_file = new File(VERIFY_PATH_OUTPUT+"/"+prjId+"/verify_chk_list_"+packagingFileIdx);
 			
-			if(!chk_list_file.exists()) {
+			if (!chk_list_file.exists()) {
 				isChangedPackageFile = true;
 			}
 			
@@ -565,16 +565,16 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			log.debug("VERIFY TARGET FILE : " + filePath);
 			
-			if(packagingFileIdx == 1 && isChangedPackageFile) {
+			if (packagingFileIdx == 1 && isChangedPackageFile) {
 				ShellCommander.shellCommandWaitFor(new String[]{"/bin/bash", "-c", "find " + VERIFY_PATH_OUTPUT + " -maxdepth 1 -name "+prjId+" -type d -exec rm -rf {} \\;"});
 			}
 			
 			String exceptionWordsPatten = "proprietary\\|commercial";
-			if(checkExceptionWordsList != null && !checkExceptionWordsList.isEmpty()) {
+			if (checkExceptionWordsList != null && !checkExceptionWordsList.isEmpty()) {
 				exceptionWordsPatten = "";
 				
-				for(String s : checkExceptionWordsList) {
-					if(!isEmpty(exceptionWordsPatten)) {
+				for (String s : checkExceptionWordsList) {
+					if (!isEmpty(exceptionWordsPatten)) {
 						exceptionWordsPatten += "\\|";
 					}
 					
@@ -586,7 +586,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			log.info("VERIFY OrigNm : " + file.getOrigNm());
 			String projectNm = (prjInfo.getPrjName()).replace(" ", "@@");
 			
-			if(!isEmpty(prjInfo.getPrjVersion())){
+			if (!isEmpty(prjInfo.getPrjVersion())){
 				projectNm +="_"+(prjInfo.getPrjVersion()).replace(" ", "@@");
 			}
 			
@@ -597,7 +597,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 
 			log.info("VERIFY START : " + prjId);
 			
-			if(isChangedPackageFile){ // packageFile을 변경하지 않고 다시 verify할 경우 아래 shellCommander는 중복 동작 하지 않음.
+			if (isChangedPackageFile){ // packageFile을 변경하지 않고 다시 verify할 경우 아래 shellCommander는 중복 동작 하지 않음.
 				ShellCommander.shellCommandWaitFor(commandStr);
 			}
 			
@@ -607,14 +607,14 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			//STEP 3 : 결과 문자열 리스트값을 배열로 변환 		
 			String chk_list_file_path = null;
 			
-			if(packagingFileIdx == 1) {
+			if (packagingFileIdx == 1) {
 				chk_list_file_path = VERIFY_PATH_OUTPUT+"/"+prjId+"/verify_chk_list_1";
 			} else {
 				chk_list_file_path = VERIFY_PATH_OUTPUT+"/"+prjId+"/verify_chk_list";
 			}
 			
 			String verify_chk_list = CommonFunction.getStringFromFile(chk_list_file_path).replaceAll(VERIFY_PATH_DECOMP +"/"+ prjId + "/", "");
-			if(verify_chk_list.contains(VERIFY_PATH_DECOMP +"/"+ prjId)) {
+			if (verify_chk_list.contains(VERIFY_PATH_DECOMP +"/"+ prjId)) {
 				verify_chk_list = verify_chk_list.replaceAll(VERIFY_PATH_DECOMP +"/"+ prjId, "");
 			}
 			log.info("VERIFY Read verify_chk_list END : " + prjId);
@@ -637,7 +637,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			log.debug("rePath : " + rePath);
 			
-			if(rePath.indexOf(".tar") > -1){
+			if (rePath.indexOf(".tar") > -1){
 				rePath = rePath.substring(0, rePath.lastIndexOf(".tar"));
 			}
 			
@@ -650,34 +650,34 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			// 분석 결과를 격납 (dir or file n	ame : count)
 			Map<String, Integer> deCompResultMap = new HashMap<>();
 			List<String> readmePathList = new ArrayList<String>();
-			if(result != null) {
+			if (result != null) {
 				boolean isFirst = true;
 				
-				for(String s : result) {
-					if(s.contains("?")) {
+				for (String s : result) {
+					if (s.contains("?")) {
 						s = s.replaceAll("[?]", "0x3F");
 					}
-					if(!isEmpty(s) && !(s.contains("(") && s.contains(")"))) {
+					if (!isEmpty(s) && !(s.contains("(") && s.contains(")"))) {
 						// packaging file name의 경우 Path로 인식하지 못하도록 처리함.
 
 						boolean isFile = s.endsWith("*");
 						s = s.replace(VERIFY_PATH_DECOMP +"/" + prjId + "/", "");
 						s = s.replaceAll("//", "/");
 						
-						if(s.startsWith("/")) {
+						if (s.startsWith("/")) {
 							s = s.substring(1);
 						}
 						
-						if(s.endsWith("*")) {
+						if (s.endsWith("*")) {
 							s = s.substring(0, s.length()-1);
 						}
 						
-						if(s.endsWith("/")) {
+						if (s.endsWith("/")) {
 							s = s.substring(0, s.length() -1);
 						}
 						
-						if(isFirst) {
-							if(!isFile) {
+						if (isFirst) {
+							if (!isFile) {
 								// 첫번째 path를 압축을 푼 처번째 dir로 사용
 								decompressionRootPath = s;
 								
@@ -688,18 +688,18 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 						int cnt = 0;
 						
 						//파일 path인 경우, 상위 dir의 파일 count를 +1 한다.
-						if(isFile){
+						if (isFile){
 							String _dir = s;
 							
-							if(s.toUpperCase().indexOf("README") > -1) {
+							if (s.toUpperCase().indexOf("README") > -1) {
 								readmePathList.add(s);
 							}
 							
-							if(s.indexOf("/") > -1) {
+							if (s.indexOf("/") > -1) {
 								_dir = s.substring(0, s.lastIndexOf("/"));
 							}
 							
-							if(deCompResultMap.containsKey(_dir)) {
+							if (deCompResultMap.containsKey(_dir)) {
 								cnt = deCompResultMap.get(_dir);
 							}
 							
@@ -715,8 +715,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			List<String> paths = sortByValue(deCompResultMap);
 			
-			for(String path : paths){
-				if(deCompResultMap.get(path) != null){
+			for (String path : paths){
+				if (deCompResultMap.get(path) != null){
 					deCompResultMap = setAddFileCount(deCompResultMap, path, (int)deCompResultMap.get(path));
 				}
 			}
@@ -770,11 +770,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 
 				String replaceFilePath = path.substring(0, path.endsWith("*") ? path.length()-1 : path.length());
 				
-				if(replaceFilePath.startsWith("/")) {
+				if (replaceFilePath.startsWith("/")) {
 					replaceFilePath = replaceFilePath.substring(1);
 				}
 				
-				if(replaceFilePath.endsWith("/")) {
+				if (replaceFilePath.endsWith("/")) {
 					replaceFilePath = replaceFilePath.substring(0, replaceFilePath.length()-1);
 				}
 				
@@ -785,11 +785,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				
 				String addRootDir = decompressionDirName + "/" + path;
 				
-				if(addRootDir.startsWith("/")) {
+				if (addRootDir.startsWith("/")) {
 					addRootDir = addRootDir.substring(1);
 				}
 				
-				if(addRootDir.endsWith("/")) {
+				if (addRootDir.endsWith("/")) {
 					addRootDir = addRootDir.substring(0, addRootDir.length()-1);
 				}
 				
@@ -800,11 +800,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				
 				String addRootDirReplaceFilePath = decompressionDirName + "/" + path.substring(0, path.endsWith("*") ? path.length()-1 : path.length());
 				
-				if(addRootDirReplaceFilePath.startsWith("/")) {
+				if (addRootDirReplaceFilePath.startsWith("/")) {
 					addRootDirReplaceFilePath = addRootDirReplaceFilePath.substring(1);
 				}
 				
-				if(addRootDirReplaceFilePath.endsWith("/")) {
+				if (addRootDirReplaceFilePath.endsWith("/")) {
 					addRootDirReplaceFilePath = addRootDirReplaceFilePath.substring(0, addRootDirReplaceFilePath.length());
 				}
 				
@@ -814,11 +814,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				pathCheckList43.add("/"+addRootDirReplaceFilePath + "/");
 
 				String replaceRootDir = path.replaceFirst(packageFileName, "").replaceAll("//", "/");
-				if(replaceRootDir.startsWith("/")) {
+				if (replaceRootDir.startsWith("/")) {
 					replaceRootDir = replaceRootDir.substring(1);
 				}
 				
-				if(replaceRootDir.endsWith("/")) {
+				if (replaceRootDir.endsWith("/")) {
 					replaceRootDir = replaceRootDir.substring(0, replaceRootDir.length()-1);
 				}
 				
@@ -829,11 +829,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				
 				String replaceRootDirReplaceFilePath = replaceRootDir;
 				
-				if(replaceRootDirReplaceFilePath.endsWith("*")) {
+				if (replaceRootDirReplaceFilePath.endsWith("*")) {
 					replaceRootDirReplaceFilePath = replaceRootDirReplaceFilePath.substring(0, replaceRootDirReplaceFilePath.length()-1);
 				}
 				
-				if(replaceRootDirReplaceFilePath.endsWith("/")) {
+				if (replaceRootDirReplaceFilePath.endsWith("/")) {
 					replaceRootDirReplaceFilePath = replaceRootDirReplaceFilePath.substring(0, replaceRootDirReplaceFilePath.length()-1);
 				}
 				
@@ -844,11 +844,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				
 				String replaceDecomFileRootDir = path.replaceFirst(decompressionRootPath, "").replaceAll("//", "/");
 				
-				if(replaceDecomFileRootDir.startsWith("/")) {
+				if (replaceDecomFileRootDir.startsWith("/")) {
 					replaceDecomFileRootDir = replaceDecomFileRootDir.substring(1);
 				}
 				
-				if(replaceDecomFileRootDir.endsWith("/")) {
+				if (replaceDecomFileRootDir.endsWith("/")) {
 					replaceDecomFileRootDir = replaceDecomFileRootDir.substring(0, replaceDecomFileRootDir.length()-1);
 				}
 				
@@ -861,7 +861,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			// 통합 Map 에 모든 허용 패턴을 저장
 			int idx = 0;
 			
-			for(String s : pathCheckList1) {
+			for (String s : pathCheckList1) {
 				checkResultMap.put(s, deCompResultMap.containsKey(s) ? deCompResultMap.get(s) : 0);
 				checkResultMap.put(pathCheckList2.get(idx), deCompResultMap.containsKey(pathCheckList2.get(idx)) ? deCompResultMap.get(pathCheckList2.get(idx)) : 0);
 				checkResultMap.put(pathCheckList3.get(idx), deCompResultMap.containsKey(pathCheckList3.get(idx)) ? deCompResultMap.get(pathCheckList3.get(idx)) : 0);
@@ -913,28 +913,28 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			log.info("VERIFY Path Check START -----------------");
 			
-			for(String gridPath : gridFilePaths){
+			for (String gridPath : gridFilePaths){
 				if (gridPath.contains("?")) {
 					gridPath = gridPath.replaceAll("[?]", "0x3F");
 				}
 				
-				if(!separatorErrFlag) {
+				if (!separatorErrFlag) {
 					separatorErrFlag = gridPath.contains("\\") ? true : false;
 				}
 				
 				//사용자가 * 입력했을때
-				if(!gridPath.trim().equals("/*") && !gridPath.trim().equals("/")){
-					if(gridPath.endsWith("*")) {
+				if (!gridPath.trim().equals("/*") && !gridPath.trim().equals("/")){
+					if (gridPath.endsWith("*")) {
 						gridPath = gridPath.substring(0, gridPath.length()-1);
 					}
-					if(gridPath.startsWith(".")) {
+					if (gridPath.startsWith(".")) {
 						gridPath = gridPath.substring(1, gridPath.length());
 					}
 					// 앞뒤 path구분 제거
-					if(gridPath.endsWith("/")) {
+					if (gridPath.endsWith("/")) {
 						gridPath = gridPath.substring(0, gridPath.length()-1);
 					}
-					if(gridPath.startsWith("/")) {
+					if (gridPath.startsWith("/")) {
 						gridPath = gridPath.substring(1);
 					}
 					
@@ -946,17 +946,17 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 					 */
 					boolean resultFlag = false;
 					
-					if(checkResultMap.containsKey(gridPath)) {
+					if (checkResultMap.containsKey(gridPath)) {
 						resultFlag = true;
 						gFileCount = checkResultMap.get(gridPath);
 					}
 					
-					if(!resultFlag) {//path가 존재하지않을 때
+					if (!resultFlag) {//path가 존재하지않을 때
 						gValidIdxlist.add(gridComponentIds.get(gridIdx));
 					} else {//path가 존재할 때
 						// file을 직접 비교하는 경우 count되지 않기 때문에, 1로 고정
 						// resultFlag == true 인경우는 존재하기 해당 path or file 대상이 존재한다는 의미이기 때문에 0이 될 수 없다.
-						if(gFileCount == 0) {
+						if (gFileCount == 0) {
 							gFileCount = 1;
 						}
 						gFileCountMap.put(gridComponentIds.get(gridIdx), Integer.toString(gFileCount));
@@ -973,15 +973,15 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			//STEP 4 : README 파일 존재 유무 확인(README 여러개 일경우도 생각해야함 ---차후)
 			
 			// depth가 낮은 readme 파일을 구하기 위해 sort
-			if(packagingFileIdx == 1){ // packageFile에서 readMe File은 첫번째 file에서만 찾음.
+			if (packagingFileIdx == 1){ // packageFile에서 readMe File은 첫번째 file에서만 찾음.
 //				List<String> sortList = new ArrayList<>(deCompResultMap.keySet());
 				Collections.sort(readmePathList, new Comparator<String>() {
 
 					@Override
 					public int compare(String arg1, String arg2) {
-						if(arg1.split("\\/").length > arg2.split("\\/").length) {
+						if (arg1.split("\\/").length > arg2.split("\\/").length) {
 							return 1;
-						} else if(arg1.split("\\/").length < arg2.split("\\/").length) {
+						} else if (arg1.split("\\/").length < arg2.split("\\/").length) {
 							return -1;
 						} else {
 							return arg1.compareTo(arg2);
@@ -990,33 +990,33 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				});
 				
 //				String lastReadmeFilePath = "";
-				for(String r : readmePathList) {
+				for (String r : readmePathList) {
 					String _upperPath = avoidNull(r).toUpperCase();
 					
-					if(_upperPath.endsWith("/")) {
+					if (_upperPath.endsWith("/")) {
 						continue;
 					}
 					
 //					String _currentReadmeFilePath = _upperPath.indexOf("/") < 0 ? _upperPath : _upperPath.substring(0,_upperPath.lastIndexOf("/"));
 //					
-//					if(!lastReadmeFilePath.equals(_currentReadmeFilePath)) {
-//						if(!isEmpty(readmePath)) {
+//					if (!lastReadmeFilePath.equals(_currentReadmeFilePath)) {
+//						if (!isEmpty(readmePath)) {
 //							break;
 //						}
 //						
 //						lastReadmeFilePath = _currentReadmeFilePath;
 //					}
 					
-					if(_upperPath.indexOf("/") > -1) {
+					if (_upperPath.indexOf("/") > -1) {
 						_upperPath = _upperPath.substring(_upperPath.lastIndexOf("/"), _upperPath.length());
 					}
 					
-					if(_upperPath.indexOf("README") > -1){
+					if (_upperPath.indexOf("README") > -1){
 						String _readmePath = r.replaceAll("\\n", "");
 						
 						int afterDepthCnt = StringUtils.countMatches(_readmePath, "/");
 						int beforeDepthCnt = StringUtils.countMatches(readmePath, "/");
-						if(isEmpty(readmePath) || beforeDepthCnt > afterDepthCnt) {
+						if (isEmpty(readmePath) || beforeDepthCnt > afterDepthCnt) {
 							readmePath = _readmePath;
 						}
 					}
@@ -1026,18 +1026,18 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			String readmeFileName = "";
 			//STEP 6 : README 파일 내용 출력
-			if(!StringUtil.isEmpty(readmePath)){
-				if(readmePath.indexOf("*") > -1){
+			if (!StringUtil.isEmpty(readmePath)){
+				if (readmePath.indexOf("*") > -1){
 					readmePath = readmePath.substring(0, readmePath.length()-1);
 				}
 				
 				readmeFileName = readmePath;
 				
-				if(readmeFileName.indexOf("/") > -1) {
+				if (readmeFileName.indexOf("/") > -1) {
 					readmeFileName = readmeFileName.substring(readmeFileName.lastIndexOf("/") + 1);
 				}
 				
-				if(readmePath.indexOf(" ") > -1) {
+				if (readmePath.indexOf(" ") > -1) {
 					log.info("do space replase ok");
 					
 					readmePath = readmePath.replaceAll(" ", "*");
@@ -1048,7 +1048,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				log.info("VERIFY Copy Readme file START -----------------");
 				log.info("VERIFY README MV PATH : " + VERIFY_PATH_DECOMP +"/" + prjId +"/" + readmePath);
 				
-				if(isChangedPackageFile){
+				if (isChangedPackageFile){
 					ShellCommander.shellCommandWaitFor(new String[]{"/bin/bash", "-c", "cp "+VERIFY_PATH_DECOMP +"/" + prjId +"/" + readmePath+ " " + VERIFY_PATH_OUTPUT +"/" + prjId +"/"});
 				}
 				
@@ -1056,7 +1056,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			}
 			
 			//STEP 7 : README 파일 내용 DB 에 저장
-			if(doUpdate && packagingFileIdx == 1) {
+			if (doUpdate && packagingFileIdx == 1) {
 				log.debug("VERIFY readme 등록");
 				
 				project.setPrjId(prjId);
@@ -1079,14 +1079,14 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			project.setExceptFileContent(!isEmpty(exceptFileContent) ? CoConstDef.FLAG_YES : "");
 			project.setVerifyFileContent(!isEmpty(verify_chk_list) ? CoConstDef.FLAG_YES : "");
 			
-			if(doUpdate) {
+			if (doUpdate) {
 				projectService.registVerifyContents(project);
 			}
 			
 			log.debug("VERIFY 파일내용 등록 완료");
 			
 			// 서버 디렉토리를 replace한 내용으로 새로운 파일로 다시 쓴다.
-			if(!isEmpty(exceptFileContent)) {
+			if (!isEmpty(exceptFileContent)) {
 				log.info("VERIFY writeFile exceptFileContent file START -----------------");
 				
 				FileUtil.writeFile(VERIFY_PATH_OUTPUT +"/" + prjId, CoConstDef.PACKAGING_VERIFY_FILENAME_PROPRIETARY, exceptFileContent.replaceAll(VERIFY_PATH_DECOMP +"/" + prjId +"/", ""));
@@ -1094,7 +1094,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				log.info("VERIFY writeFile exceptFileContent file END -----------------");
 			}
 			
-			if(!isEmpty(verify_chk_list)) {
+			if (!isEmpty(verify_chk_list)) {
 				log.info("VERIFY writeFile verify_chk_list file START -----------------");
 				
 				FileUtil.writeFile(VERIFY_PATH_OUTPUT +"/" + prjId, CoConstDef.PACKAGING_VERIFY_FILENAME_FILE_LIST, verify_chk_list.replaceAll(VERIFY_PATH_DECOMP +"/" + prjId +"/", ""));
@@ -1103,7 +1103,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			}
 			
 			resCd="10";
-			if(separatorErrFlag) {
+			if (separatorErrFlag) {
 				resMsg = getMessage("verify.path.error");
 			} else {
 				resMsg= getMessage(gValidIdxlist.isEmpty() ? "msg.common.success" : "msg.common.valid");
@@ -1118,12 +1118,12 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			//path not found.가 1건이라도 있으면 status_verify_yn의 flag는 N으로 저장함.
 			// packagingFileId, filePath는 1번만 저장하며, gValidIdxlist의 값때문에 마지막 fileSeq일때 저장함.
-			if(doUpdate && packagingFileIdx == fileSeqs.size()) {
+			if (doUpdate && packagingFileIdx == fileSeqs.size()) {
 				// verify 버튼 클릭시 file path를 저장한다.
-				if(gridComponentIds != null && !gridComponentIds.isEmpty()) {
+				if (gridComponentIds != null && !gridComponentIds.isEmpty()) {
 					int seq = 0;
 					
-					for(String s : gridComponentIds){
+					for (String s : gridComponentIds){
 						OssComponents param = new OssComponents();
 						param.setComponentId(s);
 						param.setFilePath(gridFilePaths.get(seq++));
@@ -1139,7 +1139,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 					prjParam.setPackageFileId2(fileSeqs.size() >= 2 ? fileSeqs.get(1) : null);
 					prjParam.setPackageFileId3(fileSeqs.size() >= 3 ? fileSeqs.get(2) : null);
 
-					if(!isEmpty(prjInfo.getDestributionStatus())){
+					if (!isEmpty(prjInfo.getDestributionStatus())){
 						prjParam.setStatusVerifyYn("C");
 					} else {
 						prjParam.setStatusVerifyYn(CoConstDef.FLAG_YES);
@@ -1162,7 +1162,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			resMsg="process failed. (server error)";
 		} finally {
 			try {
-				if(isChangedPackageFile){
+				if (isChangedPackageFile){
 					ShellCommander.shellCommandWaitFor(new String[]{"/bin/bash", "-c", "find " + VERIFY_PATH_DECOMP + " -maxdepth 1 -name "+prjId+" -type d -exec rm -rf {} \\;"});
 				}
 				
@@ -1187,7 +1187,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 
 	@Override
 	public void updateVerifyFileCount(HashMap<String,Object> fileCounts) {
-		for(String componentId : fileCounts.keySet()){
+		for (String componentId : fileCounts.keySet()){
 			OssComponents param = new OssComponents();
 			param.setComponentId(componentId);
 			param.setVerifyFileCount((String) fileCounts.get(componentId));
@@ -1198,7 +1198,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	
 	@Override
 	public void updateVerifyFileCount(ArrayList<String> fileCounts) {
-		for(String componentId : fileCounts){
+		for (String componentId : fileCounts){
 			OssComponents param = new OssComponents();
 			param.setComponentId(componentId);
 			param.setVerifyFileCount(" ");
@@ -1234,7 +1234,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	@Override
 	@Transactional
 	public void updateStatusWithConfirm(Project project, OssNotice ossNotice, boolean copyConfirmFlag) throws Exception {
-		if(copyConfirmFlag) {
+		if (copyConfirmFlag) {
 			projectMapper.updateConfirmCopyVerificationDestributionStatus(project);
 		}else {
 			updateProjectStatus(project);
@@ -1244,7 +1244,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		String spdxComment = "";
 		
 		// html simple
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleHTMLYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleHTMLYn())) {
 			ossNotice.setSimpleNoticeFlag(CoConstDef.FLAG_YES);
 			ossNotice.setFileType("html");
 			project.setSimpleHtmlFileId(getNoticeTextFileForPreview(ossNotice, true));
@@ -1252,7 +1252,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		}
 
 		// text
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeTextYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeTextYn())) {
 			ossNotice.setSimpleNoticeFlag(CoConstDef.FLAG_NO);
 			ossNotice.setFileType("text");
 			project.setNoticeTextFileId(getNoticeTextFileForPreview(ossNotice, true));
@@ -1260,7 +1260,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		}
 		
 		// text simple
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleTextYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleTextYn())) {
 			ossNotice.setSimpleNoticeFlag(CoConstDef.FLAG_YES);
 			ossNotice.setFileType("text");
 			project.setSimpleTextFileId(getNoticeTextFileForPreview(ossNotice, true));
@@ -1269,11 +1269,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		
 		// SPDX
 		String spdxSheetFileId = null;
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXSheetYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXSheetYn())) {
 			Map<String, String> data = new HashMap<>(); data.put("prjId", project.getPrjId());
 			String dataStr = toJson(data);
 			spdxSheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, EXPORT_TEMPLATE_PATH);
-			if(!isEmpty(spdxSheetFileId)) {
+			if (!isEmpty(spdxSheetFileId)) {
 				T2File spdxFileInfo = fileService.selectFileInfo(spdxSheetFileId);
 				Project prjInfo = projectService.getProjectBasicInfo(ossNotice.getPrjId());
 				String fileName = "spdx_" + CommonFunction.getNoticeFileName(prjInfo.getPrjId(), prjInfo.getPrjName(), prjInfo.getPrjVersion(), CommonFunction.getCurrentDateTime("yyMMdd"), "");
@@ -1287,18 +1287,18 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 
 		}
 		
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXRdfYn())) {
-			if(isEmpty(spdxSheetFileId)) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXRdfYn())) {
+			if (isEmpty(spdxSheetFileId)) {
 				Map<String, String> data = new HashMap<>(); data.put("prjId", project.getPrjId());
 				String dataStr = toJson(data);
 				spdxSheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, EXPORT_TEMPLATE_PATH);
 			}
 			
-			if(!isEmpty(spdxSheetFileId)) {
+			if (!isEmpty(spdxSheetFileId)) {
 				T2File spdxFileInfo = fileService.selectFileInfo(spdxSheetFileId);
 				String sheetFullPath = spdxFileInfo.getLogiPath();
 				
-				if(!sheetFullPath.endsWith("/")) {
+				if (!sheetFullPath.endsWith("/")) {
 					sheetFullPath += "/";
 				}
 				
@@ -1307,7 +1307,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				String resultFileName = FilenameUtils.getBaseName(spdxFileInfo.getOrigNm())+".rdf";
 				String tagFullPath = spdxFileInfo.getLogiPath();
 				
-				if(!tagFullPath.endsWith("/")) {
+				if (!tagFullPath.endsWith("/")) {
 					tagFullPath += "/";
 				}
 				
@@ -1315,8 +1315,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				SPDXUtil2.convert(project.getPrjId(), sheetFullPath, tagFullPath);
 				File spdxRdfFile = new File(tagFullPath);
 				
-				if(spdxRdfFile.exists() && spdxRdfFile.length() <= 0) {
-					if(!isEmpty(spdxComment)) {
+				if (spdxRdfFile.exists() && spdxRdfFile.length() <= 0) {
+					if (!isEmpty(spdxComment)) {
 						spdxComment += "<br>";
 					}
 					
@@ -1331,19 +1331,19 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			}
 		}
 		
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXTagYn())) {
-			if(isEmpty(spdxSheetFileId)) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXTagYn())) {
+			if (isEmpty(spdxSheetFileId)) {
 				Map<String, String> data = new HashMap<>(); data.put("prjId", project.getPrjId());
 				String dataStr = toJson(data);
 				spdxSheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, EXPORT_TEMPLATE_PATH);
 			}
 			
-			if(!isEmpty(spdxSheetFileId)) {
+			if (!isEmpty(spdxSheetFileId)) {
 				T2File spdxFileInfo = fileService.selectFileInfo(spdxSheetFileId);
 				
 				String sheetFullPath = spdxFileInfo.getLogiPath();
 				
-				if(!sheetFullPath.endsWith("/")) {
+				if (!sheetFullPath.endsWith("/")) {
 					sheetFullPath += "/";
 				}
 				
@@ -1352,7 +1352,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				String resultFileName = FilenameUtils.getBaseName(spdxFileInfo.getOrigNm())+".tag";
 				String tagFullPath = spdxFileInfo.getLogiPath();
 				
-				if(!tagFullPath.endsWith("/")) {
+				if (!tagFullPath.endsWith("/")) {
 					tagFullPath += "/";
 				}
 				
@@ -1361,8 +1361,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				
 				File spdxTafFile = new File(tagFullPath);
 				
-				if(spdxTafFile.exists() && spdxTafFile.length() <= 0) {
-					if(!isEmpty(spdxComment)) {
+				if (spdxTafFile.exists() && spdxTafFile.length() <= 0) {
+					if (!isEmpty(spdxComment)) {
 						spdxComment += "<br>";
 					}
 					
@@ -1377,18 +1377,18 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			}
 		}
 
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXJsonYn())) {
-			if(isEmpty(spdxSheetFileId)) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXJsonYn())) {
+			if (isEmpty(spdxSheetFileId)) {
 				Map<String, String> data = new HashMap<>(); data.put("prjId", project.getPrjId());
 				String dataStr = toJson(data);
 				spdxSheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, EXPORT_TEMPLATE_PATH);
 			}
 
-			if(!isEmpty(spdxSheetFileId)) {
+			if (!isEmpty(spdxSheetFileId)) {
 				T2File spdxFileInfo = fileService.selectFileInfo(spdxSheetFileId);
 				String sheetFullPath = spdxFileInfo.getLogiPath();
 
-				if(!sheetFullPath.endsWith("/")) {
+				if (!sheetFullPath.endsWith("/")) {
 					sheetFullPath += "/";
 				}
 
@@ -1397,7 +1397,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				String resultFileName = FilenameUtils.getBaseName(spdxFileInfo.getOrigNm())+".json";
 				String tagFullPath = spdxFileInfo.getLogiPath();
 
-				if(!tagFullPath.endsWith("/")) {
+				if (!tagFullPath.endsWith("/")) {
 					tagFullPath += "/";
 				}
 
@@ -1405,8 +1405,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				SPDXUtil2.convert(project.getPrjId(), sheetFullPath, tagFullPath);
 				File spdxJsonFile = new File(tagFullPath);
 
-				if(spdxJsonFile.exists() && spdxJsonFile.length() <= 0) {
-					if(!isEmpty(spdxComment)) {
+				if (spdxJsonFile.exists() && spdxJsonFile.length() <= 0) {
+					if (!isEmpty(spdxComment)) {
 						spdxComment += "<br>";
 					}
 
@@ -1421,18 +1421,18 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			}
 		}
 
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXYamlYn())) {
-			if(isEmpty(spdxSheetFileId)) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXYamlYn())) {
+			if (isEmpty(spdxSheetFileId)) {
 				Map<String, String> data = new HashMap<>(); data.put("prjId", project.getPrjId());
 				String dataStr = toJson(data);
 				spdxSheetFileId = ExcelDownLoadUtil.getExcelDownloadId("spdx", dataStr, EXPORT_TEMPLATE_PATH);
 			}
 
-			if(!isEmpty(spdxSheetFileId)) {
+			if (!isEmpty(spdxSheetFileId)) {
 				T2File spdxFileInfo = fileService.selectFileInfo(spdxSheetFileId);
 				String sheetFullPath = spdxFileInfo.getLogiPath();
 
-				if(!sheetFullPath.endsWith("/")) {
+				if (!sheetFullPath.endsWith("/")) {
 					sheetFullPath += "/";
 				}
 
@@ -1441,7 +1441,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				String resultFileName = FilenameUtils.getBaseName(spdxFileInfo.getOrigNm())+".yaml";
 				String tagFullPath = spdxFileInfo.getLogiPath();
 
-				if(!tagFullPath.endsWith("/")) {
+				if (!tagFullPath.endsWith("/")) {
 					tagFullPath += "/";
 				}
 
@@ -1449,8 +1449,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				SPDXUtil2.convert(project.getPrjId(), sheetFullPath, tagFullPath);
 				File spdxYamlFile = new File(tagFullPath);
 
-				if(spdxYamlFile.exists() && spdxYamlFile.length() <= 0) {
-					if(!isEmpty(spdxComment)) {
+				if (spdxYamlFile.exists() && spdxYamlFile.length() <= 0) {
+					if (!isEmpty(spdxComment)) {
 						spdxComment += "<br>";
 					}
 
@@ -1466,7 +1466,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		}
 		
 		// zip파일 생성
-		if(makeZipFile) {
+		if (makeZipFile) {
 			String noticeRootDir = NOTICE_PATH;
 			ossNotice.setFileType(".zip");
 			Project prjInfo = projectService.getProjectBasicInfo(ossNotice.getPrjId());
@@ -1479,7 +1479,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		
 		verificationMapper.updateNoticeFileInfoEtc(project); // file info update
 		
-		if(!isEmpty(spdxComment)) { // spdx failure => comment regist
+		if (!isEmpty(spdxComment)) { // spdx failure => comment regist
 			try {
 				CommentsHistory commHisBean = new CommentsHistory();
 				commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS);
@@ -1502,26 +1502,26 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		prjBean = projectMapper.selectProjectMaster2(prjBean);
 		List<String> packageFileIds = new ArrayList<String>();
 		
-		if(!isEmpty(prjBean.getPackageFileId())) {
+		if (!isEmpty(prjBean.getPackageFileId())) {
 			packageFileIds.add(prjBean.getPackageFileId());
 		}
 		
-		if(!isEmpty(prjBean.getPackageFileId2())) {
+		if (!isEmpty(prjBean.getPackageFileId2())) {
 			packageFileIds.add(prjBean.getPackageFileId2());
 		}
 		
-		if(!isEmpty(prjBean.getPackageFileId3())) {
+		if (!isEmpty(prjBean.getPackageFileId3())) {
 			packageFileIds.add(prjBean.getPackageFileId3());
 		}
 		
 		int fileSeq = 1;
 		
-		for(String packageFileId : packageFileIds){
+		for (String packageFileId : packageFileIds){
 			T2File packageFileInfo = new T2File();
 			packageFileInfo.setFileSeq(packageFileId);
 			packageFileInfo = fileMapper.getFileInfo(packageFileInfo);
 			
-			if(packageFileInfo != null) {
+			if (packageFileInfo != null) {
 				String orgFileName = packageFileInfo.getOrigNm();
 				// Packaging > Confirm시 Packaging 파일명 변경 건
 				String paramSeq = (packageFileIds.size() > 1 ? Integer.toString(fileSeq++) : ""); 
@@ -1545,30 +1545,30 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	private String getPackageFileName(String prjName, String prjVersion, String orgFileName, String fileSeq) {
 		String fileName = prjName;
 		
-		if(!isEmpty(prjVersion)) {
+		if (!isEmpty(prjVersion)) {
 			fileName += "_" + prjVersion;
 		}
 		
-		if(!isEmpty(fileSeq)){
+		if (!isEmpty(fileSeq)){
 			fileName += "_" + fileSeq;
 		}
 		
 		// file명에 사용할 수 없는 특수문자 체크
-		if(!FileUtil.isValidFileName(fileName)) {
+		if (!FileUtil.isValidFileName(fileName)) {
 			fileName = FileUtil.makeValidFileName(fileName, "_");
 		}
 		
 		String fileExt = FilenameUtils.getExtension(orgFileName);
 		
-		if(orgFileName.toLowerCase().endsWith(".tgz.gz")) {
+		if (orgFileName.toLowerCase().endsWith(".tgz.gz")) {
 			fileExt = "tgz.gz";
-		} else if(orgFileName.toLowerCase().endsWith(".tar.bz2")) {
+		} else if (orgFileName.toLowerCase().endsWith(".tar.bz2")) {
 			fileExt = "tar.bz2";
-		} else if(orgFileName.toLowerCase().endsWith(".tar.gz")) {
+		} else if (orgFileName.toLowerCase().endsWith(".tar.gz")) {
 			fileExt = "tar.gz";
 		}
 		
-		if(fileExt.startsWith(".")) {
+		if (fileExt.startsWith(".")) {
 			fileExt = fileExt.substring(1);
 		}
 		
@@ -1590,10 +1590,10 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			Map<String, Object> result = projectMapper.getNoticeType(ossNotice.getPrjId());
 			
 			// android project는 notice를 사용하지 않음.
-			if(!CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equalsIgnoreCase(avoidNull((String) result.get("noticeType")))) {
-				if(CoConstDef.FLAG_YES.equals(ossNotice.getEditNoticeYn())){
+			if (!CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equalsIgnoreCase(avoidNull((String) result.get("noticeType")))) {
+				if (CoConstDef.FLAG_YES.equals(ossNotice.getEditNoticeYn())){
 					verificationMapper.insertOssNotice(ossNotice);
-				}else if(CoConstDef.FLAG_NO.equals(ossNotice.getEditNoticeYn())){
+				}else if (CoConstDef.FLAG_NO.equals(ossNotice.getEditNoticeYn())){
 					verificationMapper.updateOssNotice(ossNotice);
 				}
 			}
@@ -1601,7 +1601,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			projectMapper.updateWithoutVerifyYn(ossNotice);
 			
 			
-			if(isEmpty(project.getVerificationStatus())){
+			if (isEmpty(project.getVerificationStatus())){
 				verificationMapper.updateVerificationStatusProgress(ossNotice);
 			}
 			
@@ -1637,7 +1637,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		// System.getProperty("line.separator") => "\n" => "\r\n" 변경 
 		String line = "\r\n";
 		
-		if(fileType == "text"){
+		if (fileType == "text"){
 			fileId = "";
 			filePath = NOTICE_PATH + ( isConfirm ? "/" : "/preview/") + project.getPrjId();
 			fileName = (CoConstDef.FLAG_YES.equals(simpleFlag) ? "simple_" : "") + CommonFunction.getNoticeFileName(project.getPrjId(), project.getPrjName(), project.getPrjVersion(), ( isConfirm ? CommonFunction.getCurrentDateTime("yyMMdd") : DateUtil.getCurrentDateTime(DateUtil.DATE_HMS_PATTERN) ), fileType);
@@ -1649,13 +1649,13 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			// custom edit를 사용하고, packaging confirm 인 경우 이면서 simple인 경우
 			// license text 부분만 다시 변경한다.
-			if(isConfirm && CoConstDef.FLAG_YES.equals(simpleFlag) && CoConstDef.FLAG_YES.equals(project.getUseCustomNoticeYn())) {
+			if (isConfirm && CoConstDef.FLAG_YES.equals(simpleFlag) && CoConstDef.FLAG_YES.equals(project.getUseCustomNoticeYn())) {
 				// 이미 생성된 고지문구 파일의 내용을 가져온다.
 				T2File defaultNoticeFileInfo = fileService.selectFileInfo(project.getNoticeFileId());
 				
-				if(defaultNoticeFileInfo != null) {
+				if (defaultNoticeFileInfo != null) {
 					File noticeFile = new File(defaultNoticeFileInfo.getLogiPath() + "/" + defaultNoticeFileInfo.getLogiNm());
-					if(noticeFile.exists()) {
+					if (noticeFile.exists()) {
 						Document doc = Jsoup.parse(noticeFile, "UTF8");
 						Document doc2 = Jsoup.parse(contents);
 						
@@ -1669,7 +1669,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			}
 		}
 
-		if(FileUtil.writeFile(filePath, fileName, contents)) {
+		if (FileUtil.writeFile(filePath, fileName, contents)) {
 			// 파일 등록
 			fileId = fileService.registFileDownload(filePath, fileName, fileName);
 		}
@@ -1700,7 +1700,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			int records = projectMapper.selectReuseProjectTotalCount(project);
 			project.setTotListSize(records);
 			
-			if(records > 0){
+			if (records > 0){
 				list = projectMapper.selectReuseProject(project);
 			}
 			
@@ -1722,7 +1722,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		List<T2File> list = null;
 
 		try {
-			if(!isEmpty(project.getPrjId())){
+			if (!isEmpty(project.getPrjId())){
 				list = projectMapper.selectReusePackagingFileList(project.getPrjId());
 			}
 			
@@ -1777,7 +1777,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		
 		oss.fosslight.domain.File noticeFile = null;
 		
-		if(!isEmpty(project.getZipFileId())) {
+		if (!isEmpty(project.getZipFileId())) {
 			noticeFile = verificationMapper.selectVerificationFile(project.getZipFileId());
 			fileName =  noticeFile.getOrigNm();
 			filePath += File.separator+fileName;
@@ -1802,7 +1802,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 
 		oss.fosslight.domain.File reviewReportFile = null;
 
-		if(!isEmpty(project.getZipFileId())) {
+		if (!isEmpty(project.getZipFileId())) {
 			reviewReportFile = verificationMapper.selectVerificationFile(project.getZipFileId());
 			fileName =  reviewReportFile.getOrigNm();
 			filePath += File.separator+fileName;
@@ -1834,20 +1834,20 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		
 		project = projectMapper.getProjectBasicInfo(project);
 		
-		if(project != null){
-			if(isEmpty(prjName)) {
+		if (project != null){
+			if (isEmpty(prjName)) {
 				prjName = project.getPrjName();
 			}
 			
-			if(isEmpty(prjId)) {
+			if (isEmpty(prjId)) {
 				prjId = project.getPrjId();
 			}
 			
-			if(isEmpty(prjVersion)) {
+			if (isEmpty(prjVersion)) {
 				prjVersion = project.getPrjVersion();
 			}
 			
-			if(isEmpty(distributeSite)) {
+			if (isEmpty(distributeSite)) {
 				distributeSite = project.getDistributeTarget();
 			}
 		}
@@ -1863,17 +1863,17 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		
 		OssComponents ossComponent;
 		
-		for(OssComponents bean : ossComponentList) {
+		for (OssComponents bean : ossComponentList) {
 			OssComponents oc = verificationMapper.checkOssNickName2(bean);
-			if(oc != null) {
+			if (oc != null) {
 				String copyright = CoCodeManager.OSS_INFO_BY_ID.get(oc.getOssId()).getCopyright();
 				String homepage = CoCodeManager.OSS_INFO_BY_ID.get(oc.getOssId()).getHomepage();
 				
-				if(isEmpty(bean.getCopyrightText()) && !isEmpty(copyright)) {
+				if (isEmpty(bean.getCopyrightText()) && !isEmpty(copyright)) {
 					bean.setCopyrightText(copyright);
 				}
 				
-				if(isEmpty(bean.getHomepage()) && !isEmpty(homepage)) {
+				if (isEmpty(bean.getHomepage()) && !isEmpty(homepage)) {
 					bean.setHomepage(homepage);
 				}
 			}
@@ -1882,7 +1882,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 									? bean.getOssName() 
 									: bean.getOssName() + "|" + bean.getOssVersion()).toUpperCase();
 			
-			if("-".equals(bean.getOssName())) {
+			if ("-".equals(bean.getOssName())) {
 				componentKey += dashSeq++;
 			}
 			
@@ -1893,14 +1893,14 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			// confirm 처리에서 obligation이 고지의무가 있거나 소스코드 공개의무가 있는 경우만 '50'으로 copy되도록 수정하였으나, 여기서 한번도 필터링함
 			boolean isNotice = CoConstDef.CD_DTL_OBLIGATION_NOTICE.equals(bean.getObligationType());
 			
-			if(!isDisclosure && !isNotice) {
+			if (!isDisclosure && !isNotice) {
 				continue;
 			}
 			
 			// 2017.07.05
 			// Accompanied with source code 의 경우
 			// 소스공개여부와 상관없이 모두 소스공개가 필요한 oss table에 표시
-			if(CoConstDef.CD_DTL_NOTICE_TYPE_ACCOMPANIED.equals(ossNotice.getNoticeType())) {
+			if (CoConstDef.CD_DTL_NOTICE_TYPE_ACCOMPANIED.equals(ossNotice.getNoticeType())) {
 				isDisclosure = true;
 			}
 			
@@ -1909,15 +1909,15 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			boolean addNotice = !isDisclosure && noticeInfo.containsKey(componentKey);
 			
 			
-			if(addDisclosure) {
+			if (addDisclosure) {
 				ossComponent = srcInfo.get(componentKey);
-			} else if(addNotice) {
+			} else if (addNotice) {
 				ossComponent = noticeInfo.get(componentKey);
 			} else {
 				ossComponent = bean;
 			}
 			
-			if(hideOssVersionFlag) {
+			if (hideOssVersionFlag) {
 				
 				List<String> copyrightList = componentCopyright.containsKey(componentKey) 
 						? (List<String>) componentCopyright.get(componentKey) 
@@ -1927,13 +1927,13 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 						? (List<String>) componentAttribution.get(componentKey) 
 						: new ArrayList<>();
 						
-				if(!isEmpty(bean.getCopyrightText())) {
-					for(String copyright : bean.getCopyrightText().split("\n")) {
+				if (!isEmpty(bean.getCopyrightText())) {
+					for (String copyright : bean.getCopyrightText().split("\n")) {
 						copyrightList.add(copyright);
 					}
 				}
 				
-				if(!isEmpty(bean.getOssAttribution())) {
+				if (!isEmpty(bean.getOssAttribution())) {
 					attributionList.add(bean.getOssAttribution());
 				}
 
@@ -1944,16 +1944,16 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				license.setLicenseText(bean.getLicenseText());
 				license.setAttribution(bean.getAttribution());
 
-				if(!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
+				if (!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
 					ossComponent.addOssComponentsLicense(license);
 				}
 				
-				if(CoConstDef.FLAG_NO.equals(bean.getAdminCheckYn())) {
+				if (CoConstDef.FLAG_NO.equals(bean.getAdminCheckYn())) {
 					String ossCopyright = findAddedOssCopyright(bean.getOssId(), bean.getLicenseId(), bean.getOssCopyright());
 					
 					// multi license 추가 copyright
-					if(!isEmpty(ossCopyright)) {
-						for(String copyright : ossCopyright.split("\n")) {
+					if (!isEmpty(ossCopyright)) {
+						for (String copyright : ossCopyright.split("\n")) {
 							copyrightList.add(copyright);
 						}
 					}
@@ -1972,21 +1972,21 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				ossComponent.setOssAttribution(String.join("\r\n", attributionList));
 				componentAttribution.put(componentKey, attributionList);
 				
-				if(isDisclosure) {
-					if(addDisclosure) {
+				if (isDisclosure) {
+					if (addDisclosure) {
 						srcInfo.replace(componentKey, ossComponent);
 					} else {
 						srcInfo.put(componentKey, ossComponent);
 					}
 				} else {
-					if(addNotice) {
+					if (addNotice) {
 						noticeInfo.replace(componentKey, ossComponent);
 					} else {
 						noticeInfo.put(componentKey, ossComponent);
 					}
 				}
 				
-				if(!licenseInfo.containsKey(license.getLicenseName())) {
+				if (!licenseInfo.containsKey(license.getLicenseName())) {
 					licenseInfo.put(license.getLicenseName(), license);
 				}
 			} else {
@@ -2000,7 +2000,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				
 				// 하나의 oss에 대해서 동일한 LICENSE가 복수 표시되는 현상 
 				// 일단 여기서 막는다. (쿼리가 잘못된 건지, DATA가 꼬이는건지 모르겠음)
-				if(!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
+				if (!checkLicenseDuplicated(ossComponent.getOssComponentsLicense(), license)) {
 					ossComponent.addOssComponentsLicense(license);
 					
 					// OSS의 Copyright text를 수정하였음에도 Packaging > Notice Preview에 업데이트 안 됨.
@@ -2008,14 +2008,14 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 					// verification단계에서의 oss_component_license는 oss_license의 license등록 순번을 가지고 있지 않기 때문에 (exclude된 license는 이관하지 않음)
 					// 여기서 oss id와 license id를 이용하여 찾는다.
 					// 동이한 라이선스를 or 구분으로 여러번 정의한 경우 문제가 될 수 있으나, 동일한 oss의 동일한 license의 경우 같은 copyright를 추가한다는 전제하에 적용함 (이부분에서 추가적인 이슉가 발생할 경우 대응방법이 복잡해짐)
-					if(CoConstDef.FLAG_NO.equals(ossComponent.getAdminCheckYn())) {
+					if (CoConstDef.FLAG_NO.equals(ossComponent.getAdminCheckYn())) {
 						bean.setOssCopyright(findAddedOssCopyright(bean.getOssId(), bean.getLicenseId(), bean.getOssCopyright()));
 						
 						// multi license 추가 copyright
-						if(!isEmpty(bean.getOssCopyright())) {
+						if (!isEmpty(bean.getOssCopyright())) {
 							String addCopyright = avoidNull(ossComponent.getCopyrightText());
 							
-							if(!isEmpty(ossComponent.getCopyrightText())) {
+							if (!isEmpty(ossComponent.getCopyrightText())) {
 								addCopyright += "\r\n";
 							}
 							 
@@ -2025,33 +2025,33 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 					}
 				}
 				
-				if(isDisclosure) {
-					if(addDisclosure) {
+				if (isDisclosure) {
+					if (addDisclosure) {
 						srcInfo.replace(componentKey, ossComponent);
 					} else {
 						srcInfo.put(componentKey, ossComponent);
 					}
 				} else {
-					if(addNotice) {
+					if (addNotice) {
 						noticeInfo.replace(componentKey, ossComponent);
 					} else {
 						noticeInfo.put(componentKey, ossComponent);
 					}
 				}
 				
-				if(!licenseInfo.containsKey(license.getLicenseName())) {
+				if (!licenseInfo.containsKey(license.getLicenseName())) {
 					licenseInfo.put(license.getLicenseName(), license);
 				}
 			}
 		}
 		
 		// copyleft에 존재할 경우 notice에서는 출력하지 않고 copyleft로 merge함.
-		if(hideOssVersionFlag) {
+		if (hideOssVersionFlag) {
 			Map<String, OssComponents> hideOssVersionMergeNoticeInfo = new HashMap<>();
 			Set<String> noticeKeyList = noticeInfo.keySet();
 			
-			for(String key : noticeKeyList) {
-				if(!srcInfo.containsKey(key)) {
+			for (String key : noticeKeyList) {
+				if (!srcInfo.containsKey(key)) {
 					hideOssVersionMergeNoticeInfo.put(key, noticeInfo.get(key));
 				}
 			}
@@ -2063,10 +2063,10 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		// OSS NAME을 하이픈 ('-') 으로 등록한 경우 (고지문구에 라이선스만 추가)
 		List<OssComponents> addOssComponentList = verificationMapper.selectVerificationNoticeClassAppend(ossNotice);
 		
-		if(addOssComponentList != null) {
+		if (addOssComponentList != null) {
 			List<String> checkKeyInfo = new ArrayList<>();
 			
-			for(OssComponents bean : addOssComponentList) {
+			for (OssComponents bean : addOssComponentList) {
 				String componentKey = (hideOssVersionFlag
 											? bean.getOssName() 
 											: bean.getOssName() + "|" + bean.getOssVersion()).toUpperCase();
@@ -2075,11 +2075,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 										? bean.getOssName() + "|" + bean.getLicenseName()
 										: bean.getOssName() + "|" + bean.getOssVersion() + "|" + bean.getLicenseName()).toUpperCase();
 				
-				if(checkKeyInfo.contains(checkKey)) {
+				if (checkKeyInfo.contains(checkKey)) {
 					continue;
 				}
 				
-				if("-".equals(bean.getOssName())) {
+				if ("-".equals(bean.getOssName())) {
 					componentKey += dashSeq++;
 				}
 				
@@ -2090,14 +2090,14 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				license.setAttribution(bean.getAttribution());
 				bean.addOssComponentsLicense(license);
 				
-				if(CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE.equals(bean.getObligationType())
+				if (CoConstDef.CD_DTL_OBLIGATION_DISCLOSURE.equals(bean.getObligationType())
 						|| CoConstDef.CD_DTL_NOTICE_TYPE_ACCOMPANIED.equals(ossNotice.getNoticeType())) { // Accompanied with source code 의 경우 source 공개 의무
 					srcInfo.put(componentKey, bean);
 				} else {
 					noticeInfo.put(componentKey, bean);
 				}
 				
-				if(!licenseInfo.containsKey(license.getLicenseName())) {
+				if (!licenseInfo.containsKey(license.getLicenseName())) {
 					licenseInfo.put(componentKey, license);
 				}
 				
@@ -2111,8 +2111,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		// 개행처리 및 velocity용 list 생성
 		List<OssComponents> noticeList = new ArrayList<>();
 		
-		for(OssComponents bean : noticeInfo.values()) {
-			if(isTextNotice) {
+		for (OssComponents bean : noticeInfo.values()) {
+			if (isTextNotice) {
 				bean.setCopyrightText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getCopyrightText()))));
 				bean.setLicenseText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getLicenseText()))));
 				bean.setOssAttribution(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getOssAttribution()))));
@@ -2122,11 +2122,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				bean.setOssAttribution(CommonFunction.lineReplaceToBR(StringEscapeUtils.escapeHtml(avoidNull(bean.getOssAttribution()))));
 			}
 
-			if(!isEmpty(bean.getOssAttribution()) && !ossAttributionMap.containsKey(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()))) {
+			if (!isEmpty(bean.getOssAttribution()) && !ossAttributionMap.containsKey(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()))) {
 				ossAttributionMap.put(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()), avoidNull(bean.getOssName(), "") + "__" + bean.getOssAttribution());
 			}
 			
-			if(!isEmpty(bean.getOssName())) {
+			if (!isEmpty(bean.getOssName())) {
 				bean.setOssName(StringUtil.replaceHtmlEscape(bean.getOssName()));
 			}
 			
@@ -2142,8 +2142,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		
 		List<OssComponents> srcList = new ArrayList<>();
 		
-		for(OssComponents bean : srcInfo.values()) {
-			if(isTextNotice) {
+		for (OssComponents bean : srcInfo.values()) {
+			if (isTextNotice) {
 				bean.setCopyrightText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getCopyrightText()))));
 				bean.setLicenseText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getLicenseText()))));
 				bean.setOssAttribution(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getOssAttribution()))));
@@ -2154,11 +2154,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			}
 			
 
-			if(!isEmpty(bean.getOssAttribution()) && !ossAttributionMap.containsKey(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()))) {
+			if (!isEmpty(bean.getOssAttribution()) && !ossAttributionMap.containsKey(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()))) {
 				ossAttributionMap.put(avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion()), avoidNull(bean.getOssName(), "") + "__" + bean.getOssAttribution());
 			}
 			
-			if(!isEmpty(bean.getOssName())) {
+			if (!isEmpty(bean.getOssName())) {
 				bean.setOssName(StringUtil.replaceHtmlEscape(bean.getOssName()));
 			}
 			
@@ -2180,8 +2180,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		// 정렬
 		TreeMap<String, OssComponentsLicense> licenseTreeMap = new TreeMap<>( licenseInfo );
 		
-		for(OssComponentsLicense bean : licenseTreeMap.values()) {
-			if(isTextNotice) {
+		for (OssComponentsLicense bean : licenseTreeMap.values()) {
+			if (isTextNotice) {
 				bean.setCopyrightText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getCopyrightText()))));
 				bean.setLicenseText(CommonFunction.lineReplaceToBR(StringEscapeUtils.unescapeHtml(avoidNull(bean.getLicenseText()))));
 			} else {
@@ -2192,10 +2192,10 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			// 배포사이트 license text url
 			licenseList.add(bean);
 			
-			if(CoConstDef.FLAG_YES.equals(ossNotice.getSimpleNoticeFlag())) {
+			if (CoConstDef.FLAG_YES.equals(ossNotice.getSimpleNoticeFlag())) {
 				LicenseMaster licenseBean = CoCodeManager.LICENSE_INFO_BY_ID.get(bean.getLicenseId());
 				
-				if(licenseBean != null) {
+				if (licenseBean != null) {
 //					String simpleLicenseFileName = !isEmpty(licenseBean.getShortIdentifier()) ? licenseBean.getShortIdentifier() : licenseBean.getLicenseNameTemp();
 //					String distributeUrl = CoCodeManager.getCodeExpString(CoConstDef.CD_DISTRIBUTE_CODE, CoConstDef.CD_DTL_DISTRIBUTE_LGE);
 //					simpleLicenseFileName = simpleLicenseFileName.replaceAll(" ", "_").replaceAll("/", "_") + ".html";
@@ -2208,7 +2208,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				}
 			}
 
-			if(!isEmpty(bean.getAttribution())) {
+			if (!isEmpty(bean.getAttribution())) {
 				bean.setAttribution(CommonFunction.lineReplaceToBR(StringEscapeUtils.escapeHtml(avoidNull(bean.getAttribution()))));
 				attributionList.add(bean);
 			}
@@ -2228,7 +2228,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		String appendedContentsTEXT = ossNotice.getAppendedTEXT();
 		String appendedContents = ossNotice.getAppended();
 		
-		if(!isEmpty(distributionSiteUrl) && !(distributionSiteUrl.startsWith("http://") || distributionSiteUrl.startsWith("https://") || distributionSiteUrl.startsWith("ftp://"))) {
+		if (!isEmpty(distributionSiteUrl) && !(distributionSiteUrl.startsWith("http://") || distributionSiteUrl.startsWith("https://") || distributionSiteUrl.startsWith("ftp://"))) {
 			distributionSiteUrl = "http://" + distributionSiteUrl;
 		}
 		model.put("noticeType", noticeType);
@@ -2249,7 +2249,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		model.put("editAppendedYn", ossNotice.getEditAppendedYn());
 		
 		/*//ui 개선버전으로 신규 추가된 flag */
-		if(CoConstDef.FLAG_YES.equals(ossNotice.getSimpleNoticeFlag())) {
+		if (CoConstDef.FLAG_YES.equals(ossNotice.getSimpleNoticeFlag())) {
 			model.put("licenseListUrls", licenseListUrls);
 		} else {
 			model.put("licenseList", licenseList);
@@ -2258,13 +2258,13 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		model.put("attributionList", attributionList.isEmpty() ? null : attributionList);
 		model.put("ossAttributionList", ossAttributionList.isEmpty() ? null : ossAttributionList);
 		
-		if("text".equals(ossNotice.getFileType())){
+		if ("text".equals(ossNotice.getFileType())){
 			model.put("appended", avoidNull(appendedContentsTEXT, "").replaceAll("&nbsp;", " "));
 		} else {
 			model.put("appended", appendedContents);
 		}
 
-		if("text".equals(ossNotice.getFileType())){
+		if ("text".equals(ossNotice.getFileType())){
 			model.put("templateURL", CoCodeManager.getCodeExpString(noticeInfoCode, CoConstDef.CD_DTL_NOTICE_TEXT_TEMPLATE));
 		} else {
 			model.put("templateURL", CoCodeManager.getCodeExpString(noticeInfoCode, CoConstDef.CD_DTL_NOTICE_DEFAULT_TEMPLATE));
@@ -2278,9 +2278,9 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	
 	private boolean checkLicenseDuplicated(List<OssComponentsLicense> ossComponentsLicense,
 			OssComponentsLicense license) {
-		if(ossComponentsLicense != null) {
-			for(OssComponentsLicense bean : ossComponentsLicense) {
-				if(bean.getLicenseId().equals(license.getLicenseId())) {
+		if (ossComponentsLicense != null) {
+			for (OssComponentsLicense bean : ossComponentsLicense) {
+				if (bean.getLicenseId().equals(license.getLicenseId())) {
 					return true;
 				}
 			}
@@ -2297,11 +2297,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	 * @return
 	 */
 	private String findAddedOssCopyright(String ossId, String licenseId, String ossCopyright) {
-		if(!isEmpty(ossId) && !isEmpty(licenseId)) {
+		if (!isEmpty(ossId) && !isEmpty(licenseId)) {
 			OssMaster bean = CoCodeManager.OSS_INFO_BY_ID.get(ossId);
 			if (bean != null) {
-				for(OssLicense license : bean.getOssLicenses()) {
-					if(licenseId.equals(license.getLicenseId()) && !isEmpty(license.getOssCopyright())) {
+				for (OssLicense license : bean.getOssLicenses()) {
+					if (licenseId.equals(license.getLicenseId()) && !isEmpty(license.getOssCopyright())) {
 						return license.getOssCopyright();
 					}
 				}
@@ -2319,7 +2319,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			int pFileCnt = deCompResultMap.get(url);
 			deCompResultMap.put(url, fileCnt + pFileCnt);
 			
-			if(deCompResultMap.get(url.substring(0, url.lastIndexOf("/"))) != null){
+			if (deCompResultMap.get(url.substring(0, url.lastIndexOf("/"))) != null){
 				setAddFileCount(deCompResultMap, url, fileCnt);
 			}
 			
@@ -2356,12 +2356,12 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		final Comparator<OssComponents> comp = Comparator.comparing((OssComponents o) -> o.getOssName()+"|"+o.getOssVersion());
 		gridData = gridData.stream().sorted(comp).collect(Collectors.toList());
 		
-		for(OssComponents info : gridData) {
-			if(isEmpty(groupColumn)) {
+		for (OssComponents info : gridData) {
+			if (isEmpty(groupColumn)) {
 				groupColumn = info.getOssName() + "-" + info.getOssVersion();
 			}
 						
-			if(groupColumn.equals(info.getOssName() + "-" + info.getOssVersion()) // 같은 groupColumn이면 데이터를 쌓음
+			if (groupColumn.equals(info.getOssName() + "-" + info.getOssVersion()) // 같은 groupColumn이면 데이터를 쌓음
 					&& !("-".equals(info.getOssName()) 
 					&& !"NA".equals(info.getLicenseType()))) { // 단, OSS Name: - 이면서, License Type: Proprietary이 아닌 경우 Row를 합치지 않음.
 				tempData.add(info);
@@ -2380,11 +2380,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	}	
 	
 	public static void setMergeData(List<OssComponents> tempData, List<OssComponents> resultGridData){
-		if(tempData.size() > 0) {
+		if (tempData.size() > 0) {
 			Collections.sort(tempData, new Comparator<OssComponents>() {
 				@Override
 				public int compare(OssComponents o1, OssComponents o2) {
-					if(o1.getLicenseName().length() >= o2.getLicenseName().length()) {
+					if (o1.getLicenseName().length() >= o2.getLicenseName().length()) {
 						return 1;
 					}else {
 						return -1;
@@ -2394,8 +2394,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			
 			OssComponents rtnBean = null;
 			
-			for(OssComponents temp : tempData) {
-				if(rtnBean == null) {
+			for (OssComponents temp : tempData) {
+				if (rtnBean == null) {
 					rtnBean = temp;
 					
 					continue;
@@ -2403,8 +2403,8 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 				
 				String key = temp.getOssName() + "-" + temp.getLicenseType();
 				
-				if("--NA".equals(key)) {
-					if(!rtnBean.getLicenseName().contains(temp.getLicenseName())) {
+				if ("--NA".equals(key)) {
+					if (!rtnBean.getLicenseName().contains(temp.getLicenseName())) {
 						resultGridData.add(rtnBean);
 						rtnBean = temp;
 						
@@ -2412,18 +2412,18 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 					}
 				}
 				
-				for(String licenseName : temp.getLicenseName().split(",")) {
+				for (String licenseName : temp.getLicenseName().split(",")) {
 					boolean equalFlag = false;
 					
-					for(String rtnLicenseName : rtnBean.getLicenseName().split(",")) {
-						if(rtnLicenseName.equals(licenseName)) {
+					for (String rtnLicenseName : rtnBean.getLicenseName().split(",")) {
+						if (rtnLicenseName.equals(licenseName)) {
 							equalFlag = true;
 							
 							break;
 						}
 					}
 					
-					if(!equalFlag) {
+					if (!equalFlag) {
 						rtnBean.setLicenseName(rtnBean.getLicenseName() + "," + licenseName);
 					}
 				}
@@ -2501,39 +2501,39 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	public int allowDownloadMultiFlagToBitFlag(Project project) {
 		int bitFlag = 1;
 		
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeHTMLYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeHTMLYn())) {
 			bitFlag |= CoConstDef.FLAG_A;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeTextYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadNoticeTextYn())) {
 			bitFlag |= CoConstDef.FLAG_B;
 		}
 		
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleHTMLYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleHTMLYn())) {
 			bitFlag |= CoConstDef.FLAG_C;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleTextYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSimpleTextYn())) {
 			bitFlag |= CoConstDef.FLAG_D;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXSheetYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXSheetYn())) {
 			bitFlag |= CoConstDef.FLAG_E;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXRdfYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXRdfYn())) {
 			bitFlag |= CoConstDef.FLAG_F;
 		}
 			
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXTagYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXTagYn())) {
 			bitFlag |= CoConstDef.FLAG_G;
 		}
 
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXJsonYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXJsonYn())) {
 			bitFlag |= CoConstDef.FLAG_H;
 		}
 
-		if(CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXYamlYn())) {
+		if (CoConstDef.FLAG_YES.equals(project.getAllowDownloadSPDXYamlYn())) {
 			bitFlag |= CoConstDef.FLAG_I;
 		}
 		
@@ -2548,11 +2548,11 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			project = projectMapper.selectProjectMaster(project);
 			
 			// android project는 notice를 사용하지 않음.
-			if(!CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equalsIgnoreCase(project.getNoticeType())) {
+			if (!CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED.equalsIgnoreCase(project.getNoticeType())) {
 				verificationMapper.insertOssNotice(ossNotice);
 			}
 			
-			if(isEmpty(project.getVerificationStatus())){
+			if (isEmpty(project.getVerificationStatus())){
 				verificationMapper.updateVerificationStatusProgress(ossNotice);
 			}
 		}catch(Exception e){

--- a/src/main/java/oss/fosslight/service/impl/VulnerabilityHistoryServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VulnerabilityHistoryServiceImpl.java
@@ -28,13 +28,13 @@ public class VulnerabilityHistoryServiceImpl extends CoTopComponent implements V
 
 		String filterCondition = CommonFunction.getFilterToString(vulnerabilityHistory.getFilters());
 		
-		if(!isEmpty(filterCondition)) {
+		if (!isEmpty(filterCondition)) {
 			vulnerabilityHistory.setFilterCondition(filterCondition);
 		}
 		
 		int records = vulnerabilityHistoryMapper.selectVulnerabilityHistoryTotalCount(vulnerabilityHistory);
 		
-		if(records > 0) {
+		if (records > 0) {
 			vulnerabilityHistory.setTotListSize(records);
 			// Grid paging 처리를 위한 기본 param 설정 Map 생성(반드시 totlistsize를 set 하고 나서 생성해야함)
 			map = getGridPagerMap(vulnerabilityHistory);

--- a/src/main/java/oss/fosslight/service/impl/VulnerabilityServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VulnerabilityServiceImpl.java
@@ -54,28 +54,28 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 		Map<String, String> ambiguousMap = new HashMap<>();
 		ambiguousMap.put("CVE_ID", "T1");
 		String filterCondition = CommonFunction.getFilterToString(vulnerability.getFilters(), ambiguousMap);
-		if(!isEmpty(filterCondition)) {
+		if (!isEmpty(filterCondition)) {
 			vulnerability.setFilterCondition(filterCondition);
 		}
 		
-		if(isEmpty(vulnerability.getOssNameAllSearchFlag())) {
+		if (isEmpty(vulnerability.getOssNameAllSearchFlag())) {
 			vulnerability.setOssNameAllSearchFlag(CoConstDef.FLAG_NO);
 		}
 		
-		if(CoConstDef.FLAG_YES.equals(vulnerability.getOssNameAllSearchFlag()) && "PRODUCT".equals(vulnerability.getSidx().toUpperCase())) {
+		if (CoConstDef.FLAG_YES.equals(vulnerability.getOssNameAllSearchFlag()) && "PRODUCT".equals(vulnerability.getSidx().toUpperCase())) {
 			vulnerability.setSidx("version");
 			vulnerability.setSord("desc");
 		}
 		
 		String[] nicknameList = ossService.getOssNickNameListByOssName(vulnerability.getProduct());
-		if(nicknameList != null) {
+		if (nicknameList != null) {
 			vulnerability.setOssNicknames(nicknameList);
 		}
 		
-		if(vulnerability.getProduct() != null) {
+		if (vulnerability.getProduct() != null) {
 			String searchProduct = vulnerability.getProduct();
-			if(searchProduct.contains(" ") || searchProduct.contains("_")) {
-				if(searchProduct.contains("_")) {
+			if (searchProduct.contains(" ") || searchProduct.contains("_")) {
+				if (searchProduct.contains("_")) {
 					vulnerability.setProduct(vulnerability.getProduct().replaceAll("_", " "));
 					vulnerability.setSpecialCharactersProduct(searchProduct.replace("_", "#_"));
 				} else {
@@ -88,21 +88,21 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 		vulnerability.setTotListSize(records);
 
 		List<Vulnerability> list = null;
-		if(exportFlag) {
+		if (exportFlag) {
 			list = vulnerabilityMapper.selectVulnerabilityExportList(vulnerability);
 		}else {
 			list = vulnerabilityMapper.selectVulnerabilityList(vulnerability);
 			List<String> replaceVendor = new ArrayList<>();
-			for(Vulnerability vuln : list) {
+			for (Vulnerability vuln : list) {
 				String vendor = vuln.getVendor();
-				for(String vendorNm : vendor.split(",")) {
-					if(!isEmpty(vendorNm)) {
+				for (String vendorNm : vendor.split(",")) {
+					if (!isEmpty(vendorNm)) {
 						replaceVendor.add(vendorNm);
 					}
 				}
 				vendor = "";
-				if(replaceVendor.size() > 0) {
-					for(String reNm : replaceVendor) {
+				if (replaceVendor.size() > 0) {
+					for (String reNm : replaceVendor) {
 						vendor += reNm + ",";
 					}
 					vuln.setVendor(vendor.substring(0, vendor.length()-1));
@@ -147,7 +147,7 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 	public Map<String, Object> getVulnListByOssName(OssMaster bean) {
 		Map<String, Object> result = new HashMap<String, Object>();
 		
-		if("N/A".equals(bean.getOssVersion())) {
+		if ("N/A".equals(bean.getOssVersion())) {
 			bean.setOssVersion("");
 		}
 		
@@ -182,13 +182,13 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 	public List<Vulnerability> checkVulnData(List<Vulnerability> list, String[] nicknameList){
 		List<Vulnerability> result = new ArrayList<Vulnerability>();
 				
-		for(Vulnerability bean : list) {
+		for (Vulnerability bean : list) {
 			bean.setOssNameAllSearchFlag(CoConstDef.FLAG_YES);
-			if(nicknameList != null) {
+			if (nicknameList != null) {
 				bean.setOssNicknames(nicknameList);
 			}
 			int vulnCnt = vulnerabilityMapper.checkVulnDataCnt(bean);
-			if(vulnCnt > 0) {
+			if (vulnCnt > 0) {
 				result.add(bean);
 			}
 		}
@@ -218,9 +218,9 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 		List<String> nvdInfoValueList = null;
 		Map<String, List<String>> diffVendorList = new HashMap<>();
 		scheduler_log.info("doSyncOSSNvdInfo standard cvss score : " + standardScore);
-		for(String ossKey : ossInfoMap.keySet()) {
+		for (String ossKey : ossInfoMap.keySet()) {
 			OssMaster ossBean = ossInfoMap.get(ossKey);
-			if(checkedOssList.contains(ossBean.getOssId())) {
+			if (checkedOssList.contains(ossBean.getOssId())) {
 				continue;
 			}
 			nvdInfoValueList = null;
@@ -231,36 +231,36 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 			Map<String, Object> nvdInfo = vulnerabilityMapper.selectNvdInfo(ossBean);
 			
 			boolean vendorFlag = false;
-			if(nvdInfo != null && !isEmpty((String) nvdInfo.get("VENDOR"))) {
+			if (nvdInfo != null && !isEmpty((String) nvdInfo.get("VENDOR"))) {
 				vendorFlag =  true;
 			}
 			
 			List<Map<String, Object>> nvdInfoList = vulnerabilityMapper.selectNvdInfo1(ossBean);
 			List<Map<String, Object>> nvdInfoUnderbarList = null;
 			// check underbar
-			if(ossBean.getOssName().trim().contains(" ")) {
+			if (ossBean.getOssName().trim().contains(" ")) {
 				ossBean.setOssName(ossBean.getOssName().trim().replaceAll(" ", "_"));
 				nvdInfoUnderbarList = vulnerabilityMapper.selectNvdInfo2(ossBean);
 			}
 			
 			ossBean.setOssName(ossName);
 			boolean reCheckNVDInfo = false;
-			if(nvdInfo != null && !nvdInfo.isEmpty() && vendorFlag) {
+			if (nvdInfo != null && !nvdInfo.isEmpty() && vendorFlag) {
 				BigDecimal bdScore = new BigDecimal(String.valueOf(nvdInfo.get("CVSS_SCORE")));
 				BigDecimal bdOrgMasterScore = new BigDecimal(CommonFunction.avoidNull(ossBean.getCvssScore(), "0"));
 				String cveId = String.valueOf(nvdInfo.get("CVE_ID"));
 				
 				updateVulnAndMailing(ossBean, nvdInfo, bdScore, bdOrgMasterScore, standardScore, cveId, _prjMailList, _reCalcPrjMailList, notUsedOssList, reCalcOssInfoMap);
 			}
-			else if(nvdInfoUnderbarList != null && !nvdInfoUnderbarList.isEmpty()) {
-				if(nvdInfoUnderbarList.size() > 1) {
+			else if (nvdInfoUnderbarList != null && !nvdInfoUnderbarList.isEmpty()) {
+				if (nvdInfoUnderbarList.size() > 1) {
 					String nvdInfoKey = "";
 					
-					for(Map<String, Object> nvdInfo1 : nvdInfoUnderbarList) {
-						if(!isEmpty((String) nvdInfo1.get("VENDOR"))) {
+					for (Map<String, Object> nvdInfo1 : nvdInfoUnderbarList) {
+						if (!isEmpty((String) nvdInfo1.get("VENDOR"))) {
 							nvdInfoKey = ((String) nvdInfo1.get("VENDOR") + "|" + (String) nvdInfo1.get("PRODUCT")).toUpperCase();
-							if(!nvdInfoKeyList.contains(nvdInfoKey)) {
-								if(diffVendorList.containsKey((String) nvdInfo1.get("PRODUCT"))) {
+							if (!nvdInfoKeyList.contains(nvdInfoKey)) {
+								if (diffVendorList.containsKey((String) nvdInfo1.get("PRODUCT"))) {
 									nvdInfoValueList = (List<String>) diffVendorList.get((String) nvdInfo1.get("PRODUCT"));
 									nvdInfoKeyList.add(nvdInfoKey);
 									diffVendorList.replace((String) nvdInfo1.get("PRODUCT"), nvdInfoValueList);
@@ -281,15 +281,15 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 				
 				updateVulnAndMailing(ossBean, nvdInfoUnderbarList.get(0), bdScore, bdOrgMasterScore, standardScore, cveId, _prjMailList, _reCalcPrjMailList, notUsedOssList, reCalcOssInfoMap);
 			}
-			else if(nvdInfoList != null && !nvdInfoList.isEmpty()) {
-				if(nvdInfoList.size() > 1) {
+			else if (nvdInfoList != null && !nvdInfoList.isEmpty()) {
+				if (nvdInfoList.size() > 1) {
 					String nvdInfoKey = "";
 					
-					for(Map<String, Object> nvdInfo2 : nvdInfoList) {
-						if(!isEmpty((String) nvdInfo2.get("VENDOR"))) {
+					for (Map<String, Object> nvdInfo2 : nvdInfoList) {
+						if (!isEmpty((String) nvdInfo2.get("VENDOR"))) {
 							nvdInfoKey = ((String) nvdInfo2.get("VENDOR") + "|" + (String) nvdInfo2.get("PRODUCT")).toUpperCase();
-							if(!nvdInfoKeyList.contains(nvdInfoKey)) {
-								if(diffVendorList.containsKey((String) nvdInfo2.get("PRODUCT"))) {
+							if (!nvdInfoKeyList.contains(nvdInfoKey)) {
+								if (diffVendorList.containsKey((String) nvdInfo2.get("PRODUCT"))) {
 									nvdInfoValueList = (List<String>) diffVendorList.get((String) nvdInfo2.get("PRODUCT"));
 									nvdInfoKeyList.add(nvdInfoKey);
 									diffVendorList.replace((String) nvdInfo2.get("PRODUCT"), nvdInfoValueList);
@@ -312,16 +312,16 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 			}
 
 			// 일치하는 결과가 없고, OSS VERSION이 설정되어 있지 않은 경우 해당 OSS의 MAX SCORE를 등록한다.
-			else if(isEmpty(ossBean.getOssVersion())) {
+			else if (isEmpty(ossBean.getOssVersion())) {
 				Map<String, Object> nvdInfo2 = vulnerabilityMapper.selectNvdInfoWithOutVer(ossBean);
 				ossName = ossBean.getOssName();
-				if(nvdInfo2 != null && !nvdInfo2.isEmpty()) {
+				if (nvdInfo2 != null && !nvdInfo2.isEmpty()) {
 
 					BigDecimal bdScore = new BigDecimal(String.valueOf(nvdInfo2.get("CVSS_SCORE")));
 					BigDecimal bdOrgMasterScore = new BigDecimal(CommonFunction.avoidNull(ossBean.getCvssScore(), "0"));
 					String cveId = String.valueOf(nvdInfo2.get("CVE_ID"));
 					// 현재 등록되어 있는 score와 cve_id가 일치하지 않으면 업데이트
-					if( !bdScore.equals(bdOrgMasterScore) || !cveId.equals(ossBean.getCveId())) {
+					if ( !bdScore.equals(bdOrgMasterScore) || !cveId.equals(ossBean.getCveId())) {
 						scheduler_log.info("Vulnerability updateOssVulnInfo OSS ID : " + ossBean.getOssId());
 						ossBean.setCvssScoreTo(String.valueOf(nvdInfo2.get("CVSS_SCORE")));
 						ossBean.setCveIdTo(String.valueOf(nvdInfo2.get("CVE_ID")));
@@ -336,11 +336,11 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 						// score가 7.0 이상인 경우만 메일을 발송
 						// 처음으로 9.0 이상 Score가 등록된 경우 (기존 Score가 9.0 미만이고 NVD update score가 9.0 이상인 경우)
 						// vulnerability mail > base score changed from 9.0 to 8.0
-						if(bdScore.compareTo(new BigDecimal(standardScore)) > -1 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) < 0) {
+						if (bdScore.compareTo(new BigDecimal(standardScore)) > -1 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) < 0) {
 							String[] nickNameList = ossMapper.checkNickNameRegOss(ossBean.getOssName()).toArray(new String[0]);
 							ossBean.setOssNames(nickNameList);
 							List<String> _prjList = vulnerabilityMapper.selectUsedVulnerabilityOssProject(ossBean);
-							if(_prjList != null && !_prjList.isEmpty()) {
+							if (_prjList != null && !_prjList.isEmpty()) {
 								_prjMailList.addAll(_prjList);
 							}
 							notUsedOssList.add(ossBean.getOssName().toUpperCase()+"_"+ossBean.getOssVersion());
@@ -348,28 +348,28 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 						
 						// NVD Score가 9.0 미만이면서 기존 Score가 9.0 이상인 경우, Score가 변경되었음을 메일로 통지
 						// vulnerability mail > base score changed from 9.0 to 8.0
-						if(bdScore.compareTo(new BigDecimal(standardScore)) < 0 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) > -1) {
+						if (bdScore.compareTo(new BigDecimal(standardScore)) < 0 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) > -1) {
 							String[] nickNameList = ossMapper.checkNickNameRegOss(ossBean.getOssName()).toArray(new String[0]);
 							ossBean.setOssNames(nickNameList);
 							List<String> _prjList = vulnerabilityMapper.selectUsedVulnerabilityOssProject(ossBean);
-							if(_prjList != null && !_prjList.isEmpty()) {
+							if (_prjList != null && !_prjList.isEmpty()) {
 								_reCalcPrjMailList.addAll(_prjList);
 							}
 							reCalcOssInfoMap.put(ossBean.getOssName().toUpperCase()+"_"+ossBean.getOssVersion(), ossBean);
 						}
 					}
 				} else {
-					if(ossName.contains(" ")) {
+					if (ossName.contains(" ")) {
 						ossBean.setOssName(ossName.replaceAll(" ", "_"));
 						Map<String, Object> nvdInfo3 = vulnerabilityMapper.selectNvdInfoWithOutVer(ossBean);
 						
-						if(nvdInfo3 != null && !nvdInfo3.isEmpty()) {
+						if (nvdInfo3 != null && !nvdInfo3.isEmpty()) {
 
 							BigDecimal bdScore = new BigDecimal(String.valueOf(nvdInfo3.get("CVSS_SCORE")));
 							BigDecimal bdOrgMasterScore = new BigDecimal(CommonFunction.avoidNull(ossBean.getCvssScore(), "0"));
 							String cveId = String.valueOf(nvdInfo3.get("CVE_ID"));
 							// 현재 등록되어 있는 score와 cve_id가 일치하지 않으면 업데이트
-							if( !bdScore.equals(bdOrgMasterScore) || !cveId.equals(ossBean.getCveId())) {
+							if ( !bdScore.equals(bdOrgMasterScore) || !cveId.equals(ossBean.getCveId())) {
 								scheduler_log.info("Vulnerability updateOssVulnInfo OSS ID : " + ossBean.getOssId());
 								ossBean.setCvssScoreTo(String.valueOf(nvdInfo2.get("CVSS_SCORE")));
 								ossBean.setCveIdTo(String.valueOf(nvdInfo2.get("CVE_ID")));
@@ -384,11 +384,11 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 								// score가 7.0 이상인 경우만 메일을 발송
 								// 처음으로 9.0 이상 Score가 등록된 경우 (기존 Score가 9.0 미만이고 NVD update score가 9.0 이상인 경우)
 								// vulnerability mail > base score changed from 9.0 to 8.0
-								if(bdScore.compareTo(new BigDecimal(standardScore)) > -1 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) < 0) {
+								if (bdScore.compareTo(new BigDecimal(standardScore)) > -1 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) < 0) {
 									String[] nickNameList = ossMapper.checkNickNameRegOss(ossBean.getOssName()).toArray(new String[0]);
 									ossBean.setOssNames(nickNameList);
 									List<String> _prjList = vulnerabilityMapper.selectUsedVulnerabilityOssProject(ossBean);
-									if(_prjList != null && !_prjList.isEmpty()) {
+									if (_prjList != null && !_prjList.isEmpty()) {
 										_prjMailList.addAll(_prjList);
 									}
 									notUsedOssList.add(ossBean.getOssName().toUpperCase()+"_"+ossBean.getOssVersion());
@@ -396,11 +396,11 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 								
 								// NVD Score가 9.0 미만이면서 기존 Score가 9.0 이상인 경우, Score가 변경되었음을 메일로 통지
 								// vulnerability mail > base score changed from 9.0 to 8.0
-								if(bdScore.compareTo(new BigDecimal(standardScore)) < 0 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) > -1) {
+								if (bdScore.compareTo(new BigDecimal(standardScore)) < 0 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) > -1) {
 									String[] nickNameList = ossMapper.checkNickNameRegOss(ossBean.getOssName()).toArray(new String[0]);
 									ossBean.setOssNames(nickNameList);
 									List<String> _prjList = vulnerabilityMapper.selectUsedVulnerabilityOssProject(ossBean);
-									if(_prjList != null && !_prjList.isEmpty()) {
+									if (_prjList != null && !_prjList.isEmpty()) {
 										_reCalcPrjMailList.addAll(_prjList);
 									}
 									reCalcOssInfoMap.put(ossBean.getOssName().toUpperCase()+"_"+ossBean.getOssVersion(), ossBean);
@@ -424,10 +424,10 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 
 			// NVD 정보는 없지만 oss list에 nvd 정보가 이미 설정되어 있는 경우
 			// NVD 사이트에서 Excluding 되었을 가능성이 높다 (삭제됨)
-			if(reCheckNVDInfo) {
+			if (reCheckNVDInfo) {
 				// 혹시 BATCH에서 오류가 발생하여 NVD_DATA_SCORE_V3 테이블에 DATA 가 등록되지 않은 경우 
 				// 모든 NVD DATA가 삭제되는 것을 방지하기 위해서 건수가 0건이상인지 확인한다.
-				if(hasNvdData && !isEmpty(ossBean.getCveId())) {
+				if (hasNvdData && !isEmpty(ossBean.getCveId())) {
 					scheduler_log.info("Vulnerability deleteOssVulnInfo OSS ID : " + ossBean.getOssId());
 					// oss list에서 NVD 정보를 삭제한다.
 					ossBean.setCvssScoreTo("0");
@@ -438,11 +438,11 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 					BigDecimal bdOrgMasterScore = new BigDecimal(String.valueOf(ossBean.getCvssScore()));
 					
 					// vulnerability mail > base score changed from 9.0 to 8.0
-					if(bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) > -1) {
+					if (bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) > -1) {
 						String[] nickNameList = ossMapper.checkNickNameRegOss(ossBean.getOssName()).toArray(new String[0]);
 						ossBean.setOssNames(nickNameList);
 						List<String> _prjList = vulnerabilityMapper.selectUsedVulnerabilityOssProject(ossBean);
-						if(_prjList != null && !_prjList.isEmpty()) {
+						if (_prjList != null && !_prjList.isEmpty()) {
 							_removeReCalcPrjMailList.addAll(_prjList);
 						}
 						
@@ -452,17 +452,17 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 			}
 		}
 		
-		if(diffVendorList.size() > 1) {
+		if (diffVendorList.size() > 1) {
 			Map<String, Object> map = new HashMap<>();
 			String vendor = "";
 			String cveId = "";
 			
-			for(String diffVendorKey : diffVendorList.keySet()) {
+			for (String diffVendorKey : diffVendorList.keySet()) {
 				List<String> diffVendor = diffVendorList.get(diffVendorKey);
-				if(diffVendor.size() > 1) {
-					for(String diff : diffVendor) {
+				if (diffVendor.size() > 1) {
+					for (String diff : diffVendor) {
 						vendor += diff.split("[|]")[0] + ",";
-						if(!cveId.contains(diff.split("[|]")[1])) {
+						if (!cveId.contains(diff.split("[|]")[1])) {
 							cveId += diff.split("[|]")[1] + ",";
 						}
 					}
@@ -479,10 +479,10 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 		
 		CoCodeManager.getInstance().refreshOssInfo();
 		
-		if(_prjMailList != null && !_prjMailList.isEmpty()) {
+		if (_prjMailList != null && !_prjMailList.isEmpty()) {
 			List<String> prjMailList = new ArrayList<String>(new HashSet<String>(_prjMailList));
 			scheduler_log.info("Vulnerability prj COUNT : " + prjMailList.size());
-			for(String prjId : prjMailList) {
+			for (String prjId : prjMailList) {
 				CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT);
 				mailBean.setParamPrjId(prjId);
 				CoMailManager.getInstance().sendMail(mailBean);
@@ -490,10 +490,10 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 			
 		}
 		
-		if(_reCalcPrjMailList != null && !_reCalcPrjMailList.isEmpty()) {
+		if (_reCalcPrjMailList != null && !_reCalcPrjMailList.isEmpty()) {
 			List<String> prjMailList = new ArrayList<String>(new HashSet<String>(_reCalcPrjMailList));
 			scheduler_log.info("Vulnerability risk recalculated prj COUNT : " + _reCalcPrjMailList.size());
-			for(String prjId : prjMailList) {
+			for (String prjId : prjMailList) {
 				CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_RECALCULATED);
 				mailBean.setParamPrjId(prjId);
 				mailBean.setParamStandardScore(standardScore);
@@ -503,10 +503,10 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 			
 		}
 		
-		if(_removeReCalcPrjMailList != null && !_removeReCalcPrjMailList.isEmpty()) {
+		if (_removeReCalcPrjMailList != null && !_removeReCalcPrjMailList.isEmpty()) {
 			List<String> prjMailList = new ArrayList<String>(new HashSet<String>(_removeReCalcPrjMailList));
 			scheduler_log.info("Vulnerability risk remove > recalculated prj COUNT : " + _removeReCalcPrjMailList.size());
-			for(String prjId : prjMailList) {
+			for (String prjId : prjMailList) {
 				CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_REMOVE_RECALCULATED);
 				mailBean.setParamPrjId(prjId);
 				mailBean.setParamStandardScore(standardScore);
@@ -516,7 +516,7 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 			
 		}
 		
-		if(!notUsedOssList.isEmpty()) {
+		if (!notUsedOssList.isEmpty()) {
 			try {
 				scheduler_log.info("Vulnerability notUsedOssList COUNT : " + notUsedOssList.size());
 				CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_VULNERABILITY_OSS);
@@ -527,7 +527,7 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 			}
 		}
 		
-		if(reCalcOssInfoMap.keySet().size() > 0) {
+		if (reCalcOssInfoMap.keySet().size() > 0) {
 			try {
 				scheduler_log.info("Vulnerability reCalculated All COUNT : " + reCalcOssInfoMap.keySet().size());
 				CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_VULNERABILITY_PROJECT_RECALCULATED_ALL);
@@ -539,7 +539,7 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 			}
 		}
 		
-		if(_nvdInfoDiffVendorList != null && _nvdInfoDiffVendorList.size() > 0) {
+		if (_nvdInfoDiffVendorList != null && _nvdInfoDiffVendorList.size() > 0) {
 			try {
 				scheduler_log.info("Vulnerability nvdInfoDiffVendorList COUNT : " + _nvdInfoDiffVendorList.size());
 				CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_VULNERABILITY_NVDINFO_DIFF);
@@ -565,7 +565,7 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 
 		List<Map<String, Object>> list = vulnerabilityMapper.selectMaxScoreNvdInfo(paramMap);
 		
-		if(product.contains(" ") && list == null) {
+		if (product.contains(" ") && list == null) {
 			paramMap.replace("ossName", product.replaceAll(" ", "_"));
 			list = vulnerabilityMapper.selectMaxScoreNvdInfo(paramMap);
 		}
@@ -576,7 +576,7 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 	private void updateVulnAndMailing(OssMaster ossBean, Map<String, Object> nvdInfo, BigDecimal bdScore, BigDecimal bdOrgMasterScore, String standardScore, String cveId
 			, List<String> _prjMailList, List<String> _reCalcPrjMailList, List<String> notUsedOssList, Map<String, OssMaster> reCalcOssInfoMap) {
 		// 현재 등록되어 있는 score와 cve_id가 일치하지 않으면 업데이트
-		if( !bdScore.equals(bdOrgMasterScore) || !cveId.equals(ossBean.getCveId())) {
+		if ( !bdScore.equals(bdOrgMasterScore) || !cveId.equals(ossBean.getCveId())) {
 			ossBean.setCvssScoreTo(String.valueOf(nvdInfo.get("CVSS_SCORE")));
 			ossBean.setCveIdTo(String.valueOf(nvdInfo.get("CVE_ID")));
 			vulnerabilityMapper.insertNvdOssHis(ossBean);
@@ -591,11 +591,11 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 		// score가 7.0 이상인 경우만 메일을 발송
 		// 처음으로 9.0 이상 Score가 등록된 경우 (기존 Score가 9.0 미만이고 NVD update score가 9.0 이상인 경우)
 		// vulnerability mail > base score changed from 9.0 to 8.0
-		if(bdScore.compareTo(new BigDecimal(standardScore)) > -1 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) < 0) {
+		if (bdScore.compareTo(new BigDecimal(standardScore)) > -1 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) < 0) {
 			String[] nickNameList = ossMapper.checkNickNameRegOss(ossBean.getOssName()).toArray(new String[0]);
 			ossBean.setOssNames(nickNameList);
 			List<String> _prjList = vulnerabilityMapper.selectUsedVulnerabilityOssProject(ossBean);
-			if(_prjList != null && !_prjList.isEmpty()) {
+			if (_prjList != null && !_prjList.isEmpty()) {
 				_prjMailList.addAll(_prjList);
 			}
 			notUsedOssList.add(ossBean.getOssName().toUpperCase()+"_"+ossBean.getOssVersion());
@@ -603,11 +603,11 @@ public class VulnerabilityServiceImpl extends CoTopComponent implements Vulnerab
 		
 		// NVD Score가 9.0 미만이면서 기존 Score가 9.0 이상인 경우, Score가 변경되었음을 메일로 통지
 		// vulnerability mail > base score changed from 9.0 to 8.0
-		if(bdScore.compareTo(new BigDecimal(standardScore)) < 0 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) > -1) {
+		if (bdScore.compareTo(new BigDecimal(standardScore)) < 0 && bdOrgMasterScore.compareTo(new BigDecimal(standardScore)) > -1) {
 			String[] nickNameList = ossMapper.checkNickNameRegOss(ossBean.getOssName()).toArray(new String[0]);
 			ossBean.setOssNames(nickNameList);
 			List<String> _prjList = vulnerabilityMapper.selectUsedVulnerabilityOssProject(ossBean);
-			if(_prjList != null && !_prjList.isEmpty()) {
+			if (_prjList != null && !_prjList.isEmpty()) {
 				_reCalcPrjMailList.addAll(_prjList);
 			}
 			reCalcOssInfoMap.put(ossBean.getOssName().toUpperCase()+"_"+ossBean.getOssVersion(), ossBean);

--- a/src/main/java/oss/fosslight/util/CompressUtil.java
+++ b/src/main/java/oss/fosslight/util/CompressUtil.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CompressUtil {
     public static void compressGZIP(File input, File output, boolean deleteInputFile) throws IOException {
         
-		try(
+		try (
 			GzipCompressorOutputStream out = new GzipCompressorOutputStream(new FileOutputStream(output));
 		) {	
             IOUtils.copy(new FileInputStream(input), out);
@@ -32,7 +32,7 @@ public class CompressUtil {
 			throw e;
 		}
         
-        if(deleteInputFile) {
+        if (deleteInputFile) {
         	try {
         		input.deleteOnExit();
         	} catch(Exception e) {
@@ -52,7 +52,7 @@ public class CompressUtil {
         	out = new FileOutputStream(output);
             IOUtils.copy(in, out);
             
-            if(deleteInputFile) {
+            if (deleteInputFile) {
             	try {
             		input.deleteOnExit();
             	} catch(Exception e) {
@@ -62,19 +62,19 @@ public class CompressUtil {
         } catch(Exception e) {
         	log.error(e.getMessage());
         } finally {
-			if(in != null) {
+			if (in != null) {
 				try {
 					in.close();
 				} catch (Exception e) {}
 			}
 			
-			if(zin != null) {
+			if (zin != null) {
 				try {
 					zin.close();
 				} catch (Exception e) {}
 			}
 			
-			if(out != null) {
+			if (out != null) {
 				try {
 					out.close();
 				} catch (Exception e2) {}
@@ -85,11 +85,11 @@ public class CompressUtil {
     public static void decompressTarGZ(File tarFile, String dest) throws IOException {
     	File dir = new File(dest);
     	
-    	if(!dir.exists()) {
+    	if (!dir.exists()) {
     		dir.mkdirs();
     	}
     	
-		try(
+		try (
 			TarArchiveInputStream tarIn = new TarArchiveInputStream(
 			new GzipCompressorInputStream(
 				new BufferedInputStream(
@@ -98,7 +98,7 @@ public class CompressUtil {
 				)
 			);
 		) {
-			TarArchiveEntry tarEntry = tarIn.getNextTarEntry();
+			TarArchiveEntry tarEntry = tarIn.getNextTarEntry ();
 			
 			while (tarEntry != null) {
 				File destPath = new File(dest, tarEntry.getName());
@@ -108,13 +108,13 @@ public class CompressUtil {
 				} else { // tar.gz의 하위 file이 dir가 아닐경우 file로 생성
 					destPath.createNewFile();
 					byte [] btoRead = new byte[1024];
-					try(
+					try (
 						BufferedOutputStream bout = 
 						new BufferedOutputStream(new FileOutputStream(destPath));
 					){
 						int len = 0;
 					
-						while((len = tarIn.read(btoRead)) != -1){
+						while ((len = tarIn.read(btoRead)) != -1){
 							bout.write(btoRead,0,len);
 						}
 						
@@ -124,7 +124,7 @@ public class CompressUtil {
 					}
 				}
 				
-				tarEntry = tarIn.getNextTarEntry();
+				tarEntry = tarIn.getNextTarEntry ();
 			}
 		} catch (Exception e) {
 			throw e;

--- a/src/main/java/oss/fosslight/util/CryptUtil.java
+++ b/src/main/java/oss/fosslight/util/CryptUtil.java
@@ -44,7 +44,7 @@ public class CryptUtil {
 	 * @throws InvalidKeySpecException 
 	 */
     public static String encryptAES256(String message, String key) throws Exception {
-    	if(message == null || message.trim().length() == 0) {
+    	if (message == null || message.trim().length() == 0) {
     		return message;
     	}
     	byte[] textBytes = message.getBytes("UTF-8");
@@ -74,7 +74,7 @@ public class CryptUtil {
      * @throws BadPaddingException
      */
     public static String decryptAES256(String encMessage, String key) throws Exception {
-    	if(encMessage == null || encMessage.trim().length() == 0) {
+    	if (encMessage == null || encMessage.trim().length() == 0) {
     		return encMessage;
     	}
     	byte[] textBytes = Base64.decodeBase64(encMessage);

--- a/src/main/java/oss/fosslight/util/CsvUtil.java
+++ b/src/main/java/oss/fosslight/util/CsvUtil.java
@@ -48,7 +48,7 @@ public class CsvUtil extends CoTopComponent {
 			int cellIdx = 0;
 			Row row = sheet.createRow(rowIdx);
 
-			for(String token : nextLine) {
+			for (String token : nextLine) {
 				Cell cell = row.createCell(cellIdx); cellIdx++;
 				cell.setCellValue(token);
 			}

--- a/src/main/java/oss/fosslight/util/DateUtil.java
+++ b/src/main/java/oss/fosslight/util/DateUtil.java
@@ -257,7 +257,7 @@ public final class DateUtil {
 		
 		date = date.replaceAll("[^\\d]*", "");
 		
-		if(date.length() > 8) {
+		if (date.length() > 8) {
 			date = date.substring(0, 8);
 		}
 		
@@ -608,7 +608,7 @@ public final class DateUtil {
 		Calendar cal1 = convertStringToCalender(date1);
 		Calendar cal2 = convertStringToCalender(date2);
 
-		if(cal1 == null || cal2 == null) {
+		if (cal1 == null || cal2 == null) {
 			return -1;
 		}
 
@@ -789,7 +789,7 @@ public final class DateUtil {
      * @return
      */
     public static String dateTypeConvert(String date){
-    	if(!date.isEmpty()){
+    	if (!date.isEmpty()){
     		date = date.substring(0, 10);
         	String[] temp = date.split("-");
         	date = date.format("%s년 %s월 %s일", 	temp[0], temp[1], temp[2]);
@@ -848,7 +848,7 @@ public final class DateUtil {
      */
     public static String dateFormatConvert(String date, String orgDateFormat, String convDateFormat) {
     	try{
-    		if(StringUtil.isEmpty(date)) {
+    		if (StringUtil.isEmpty(date)) {
     			return date;
     		}
     		
@@ -930,7 +930,7 @@ public final class DateUtil {
     	// 현재 날짜
     	Date toDay = convertStringToSQLDate(getCurrentDateAsString());
 		
-    	if(!((toDay.compareTo(date1) >= 0) && (toDay.compareTo(date2) <= 0))){
+    	if (!((toDay.compareTo(date1) >= 0) && (toDay.compareTo(date2) <= 0))){
 			ret = (toDay.compareTo(date1) < 0) ? -1 : 1;
 		}
 		

--- a/src/main/java/oss/fosslight/util/ExcelDownLoadUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelDownLoadUtil.java
@@ -133,7 +133,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			projectInfo.setPrjId(prjId);
 			projectInfo = projectService.getProjectDetail(projectInfo);
 			
-			if(isEmpty(type) && CoConstDef.FLAG_YES.equals(projectInfo.getAndroidFlag())) {
+			if (isEmpty(type) && CoConstDef.FLAG_YES.equals(projectInfo.getAndroidFlag())) {
 				type = CoConstDef.CD_DTL_COMPONENT_ID_ANDROID;
 			}
 			
@@ -142,7 +142,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			wb = WorkbookFactory.create(inFile);
 			
 			{
-				if(!isEmpty(projectInfo.getNoticeTypeEtc())) {
+				if (!isEmpty(projectInfo.getNoticeTypeEtc())) {
 					wb.setSheetName(5, "BIN (" + CoCodeManager.getCodeString(CoConstDef.CD_PLATFORM_GENERATED, projectInfo.getNoticeTypeEtc()) + ")");
 				}
 				
@@ -158,35 +158,35 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			ossListParam.setReferenceId(prjId);
 			
 			//3rdparty
-			if(isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type)) {
+			if (isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type)) {
 				ossListParam.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER);
 				
 				reportIdentificationSheet(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER, wb.getSheetAt(2), projectService.getIdentificationGridList(ossListParam), projectInfo);
 			}
 			
 			//src
-			if(isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(type)) {
+			if (isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(type)) {
 				ossListParam.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_SRC);
 				
 				reportIdentificationSheet(CoConstDef.CD_DTL_COMPONENT_ID_SRC, wb.getSheetAt(3), projectService.getIdentificationGridList(ossListParam), projectInfo);
 			}
 			
 			//BIN
-			if(isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type)) {
+			if (isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type)) {
 				ossListParam.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_BIN);
 				
 				reportIdentificationSheet(CoConstDef.CD_DTL_COMPONENT_ID_BIN, wb.getSheetAt(4), projectService.getIdentificationGridList(ossListParam), projectInfo);
 			}
 			
 			//BIN(ANDROID)
-			if(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
+			if (CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
 				ossListParam.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID);
 				
 				reportIdentificationSheet(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID, wb.getSheetAt(5), projectService.getIdentificationGridList(ossListParam), projectInfo);
 			}
 			
 			//bom
-			if(isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
+			if (isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
 				ossListParam.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_BOM);
 				ossListParam.setMerge(CoConstDef.FLAG_NO);
 				
@@ -195,12 +195,12 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			// model
 			// OSS Report를 출력을 시작한 대상이 BOM Tab, platform generated인 경우에 대해서는 Model Info를 출력하도록 수정.
-			if(isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
+			if (isEmpty(type) || CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
 				Map<String, List<Project>> modelMap = projectService.getModelList(prjId);
 				
-				if(modelMap != null) {
+				if (modelMap != null) {
 					List<Project> modelList = modelMap.get("rows");
-					if(modelList != null && !modelList.isEmpty()) {
+					if (modelList != null && !modelList.isEmpty()) {
 						reportProjectModelSheet(sheet1, wb.getSheetAt(1), modelList, projectInfo);
 					}
 				}
@@ -210,7 +210,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch(Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e) {}
@@ -223,7 +223,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		List<String[]> rows = new ArrayList<>();
 		int modelCnt = 1;
 		
-		for(Project bean : modelList) {
+		for (Project bean : modelList) {
 			List<String> params = new ArrayList<>();
 			params.add(String.valueOf(modelCnt++));
 			params.add(bean.getModelName()); // model name
@@ -251,17 +251,17 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 	@SuppressWarnings("unchecked")
 	private static void reportIdentificationSheet(String type, Sheet sheet, Map<String, Object> listMap, Project projectInfo, boolean isSelfCheck) {
 		List<ProjectIdentification> list = null;
-		if(listMap != null && (listMap.containsKey("mainData") || listMap.containsKey("rows") )) {
+		if (listMap != null && (listMap.containsKey("mainData") || listMap.containsKey("rows") )) {
 			list = (List<ProjectIdentification>) listMap.get(listMap.containsKey("mainData") ? "mainData" : "rows");
 			List<String[]> rows = new ArrayList<>();
 			//Excell export sort
 			T2CoProjectValidator pv = new T2CoProjectValidator();
 
-			if(!CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
+			if (!CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
 				pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_SOURCE);
 				pv.setAppendix("mainList", list);
 				
-				if(CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(type) || CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type)) {
+				if (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(type) || CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type)) {
 					pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_SOURCE);
 					
 					if (CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type)) {
@@ -271,7 +271,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					pv.setAppendix("projectId", avoidNull(projectInfo.getPrjId()));
 					// sub grid
 					pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) listMap.get("subData"));
-				} else if(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
+				} else if (CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
 					pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_ANDROID);
 					pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) listMap.get("subData"));
 
@@ -298,10 +298,10 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					if (existsBinaryName != null) {
 						pv.setAppendix("existsResultBinaryName", existsBinaryName);
 					}
-				} else if((CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(type) || CoConstDef.CD_DTL_COMPONENT_BAT.equals(type))) {
+				} else if ((CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(type) || CoConstDef.CD_DTL_COMPONENT_BAT.equals(type))) {
 					pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_BAT);
 					pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) listMap.get("subData"));
-				} else if(CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(type)) {
+				} else if (CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(type)) {
 					pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_PARTNER);
 					pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) listMap.get("subData"));
 				}
@@ -314,12 +314,12 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			list = (List<ProjectIdentification>) CommonFunction.identificationSortByValidInfo(list, vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false);
 			
 			// exclude 된 라이선스는 제외한다. (bom은 제외되어 있음)
-			for(ProjectIdentification bean : list) {
-				if(bean.getComponentLicenseList() != null && !bean.getComponentLicenseList().isEmpty()) {
+			for (ProjectIdentification bean : list) {
+				if (bean.getComponentLicenseList() != null && !bean.getComponentLicenseList().isEmpty()) {
 					List<ProjectIdentification> newLicenseList = new ArrayList<>();
 					
-					for(ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
-						if(!CoConstDef.FLAG_YES.equals(licenseBean.getExcludeYn())) {
+					for (ProjectIdentification licenseBean : bean.getComponentLicenseList()) {
+						if (!CoConstDef.FLAG_YES.equals(licenseBean.getExcludeYn())) {
 							newLicenseList.add(licenseBean);
 						}
 					}
@@ -329,26 +329,26 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			}
 			
 			// self check인 경우 oss_id가 있는 경우, 부가 정보를 추가해서 export한다.
-			if(isSelfCheck) {
+			if (isSelfCheck) {
 				Map<String, OssMaster> regOssInfoMapWithOssId = null;
 				OssMaster _ossParam = new OssMaster();
 				
-				for(ProjectIdentification bean : list) {
-					if(!isEmpty(bean.getOssId())) {
+				for (ProjectIdentification bean : list) {
+					if (!isEmpty(bean.getOssId())) {
 						_ossParam.addOssIdList(bean.getOssId());
 					}
 				}
 				
-				if(_ossParam.getOssIdList() != null && !_ossParam.getOssIdList().isEmpty()) {
+				if (_ossParam.getOssIdList() != null && !_ossParam.getOssIdList().isEmpty()) {
 					regOssInfoMapWithOssId = ossService.getBasicOssInfoListById(_ossParam);
 				}
 				
-				if(regOssInfoMapWithOssId != null) {
-					for(ProjectIdentification bean : list) {
-						if(!isEmpty(bean.getOssId()) && regOssInfoMapWithOssId.containsKey(bean.getOssId())) {
+				if (regOssInfoMapWithOssId != null) {
+					for (ProjectIdentification bean : list) {
+						if (!isEmpty(bean.getOssId()) && regOssInfoMapWithOssId.containsKey(bean.getOssId())) {
 							OssMaster mstData = regOssInfoMapWithOssId.get(bean.getOssId());
 							
-							if(mstData != null) {
+							if (mstData != null) {
 								bean.setDownloadLocation(mstData.getDownloadLocation());
 								bean.setHomepage(mstData.getHomepage());
 								bean.setCopyrightText(mstData.getCopyright());
@@ -358,22 +358,22 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				}
 			}
 			
-			if(CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
+			if (CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
 				list.sort(Comparator.comparing(ProjectIdentification::getGroupingColumn));
 			} 
 			
 			String currentGroupKey = null;
 			
-			for(ProjectIdentification bean : list) {
-				if(CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
-					if(currentGroupKey != null && currentGroupKey.equals(bean.getGroupingColumn())) {
-						for(String[] editRow : rows) {
-							if(!isEmpty(bean.getOssName()) && !bean.getOssName().equals("-")
+			for (ProjectIdentification bean : list) {
+				if (CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
+					if (currentGroupKey != null && currentGroupKey.equals(bean.getGroupingColumn())) {
+						for (String[] editRow : rows) {
+							if (!isEmpty(bean.getOssName()) && !bean.getOssName().equals("-")
 									&& editRow[1].equals(bean.getOssName()) && editRow[2].equals(bean.getOssVersion())) {
 								String referenceDiv = editRow[8];
 								String referenceDivChk = bean.getRefDiv();
 								
-								if(!isEmpty(referenceDivChk)) {
+								if (!isEmpty(referenceDivChk)) {
 									switch (avoidNull(referenceDivChk)) {
 									case CoConstDef.CD_DTL_COMPONENT_ID_PARTNER:
 										referenceDivChk = "3rd";
@@ -389,7 +389,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 										break;
 									}
 									
-									if(!referenceDiv.contains(referenceDivChk)) {
+									if (!referenceDiv.contains(referenceDivChk)) {
 										referenceDiv = referenceDiv + "," + referenceDivChk;
 										editRow[8] = referenceDiv;
 										break;
@@ -405,7 +405,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				}
 				
 				// bom의 경우
-				if(bean.getOssComponentsLicenseList() != null && !bean.getOssComponentsLicenseList().isEmpty()) {
+				if (bean.getOssComponentsLicenseList() != null && !bean.getOssComponentsLicenseList().isEmpty()) {
 					boolean isMainRow = true;
 					
 					List<String> params = new ArrayList<>();
@@ -420,17 +420,17 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					
 					String licenseTextUrl = "";
 					
-					for(String licenseName : bean.getLicenseName().split(",")) {
+					for (String licenseName : bean.getLicenseName().split(",")) {
 						String licenseUrl = CommonFunction.getLicenseUrlByName(licenseName.trim());
 						
-						if(isEmpty(licenseUrl)) {
+						if (isEmpty(licenseUrl)) {
 							boolean distributionFlag = CommonFunction.propertyFlagCheck("distribution.use.flag", CoConstDef.FLAG_YES);
 							
 							licenseUrl = CommonFunction.makeLicenseInternalUrl(CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(licenseName).toUpperCase()), distributionFlag);
 						}
 						
-						if(!isEmpty(licenseUrl)) {
-							if(!isEmpty(licenseTextUrl)) {
+						if (!isEmpty(licenseUrl)) {
+							if (!isEmpty(licenseTextUrl)) {
 								licenseTextUrl += ", ";
 							}
 							
@@ -487,7 +487,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					rows.add(params.toArray(new String[params.size()]));
 				} else {
 					// exclude 제외
-					if((CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type) && CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) || (isSelfCheck && CoConstDef.FLAG_YES.equals(bean.getExcludeYn()))) {
+					if ((CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type) && CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) || (isSelfCheck && CoConstDef.FLAG_YES.equals(bean.getExcludeYn()))) {
 						continue;
 					}
 					
@@ -498,21 +498,21 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					params.add(isSelfCheck ? bean.getComponentIdx() : bean.getComponentIdx());
 
 					// TODO 3rd party 이름 가져올 수 있나?
-					if(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type)) {
+					if (CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type)) {
 
 						params.add(projectService.getPartnerFormatName(bean.getRefPartnerId(), false)); //3rd Party
 					}
 
-					if(CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type)
+					if (CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type)
 							|| CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type) ) {
 						params.add(bean.getBinaryName()); // Binary Name
 					}
 
-					if(!CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type)) {
+					if (!CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type)) {
 						params.add(bean.getFilePath()); // path
 					}
 					
-					if(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
+					if (CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
 						params.add(bean.getBinaryNotice()); // notice
 					}
 					
@@ -520,15 +520,15 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					params.add(bean.getOssVersion()); // OSS Version
 					String licenseNameList = "";
 					
-					if(bean.getComponentLicenseList() != null) {
-						for( ProjectIdentification project : bean.getComponentLicenseList()) {
-							if(!isEmpty(licenseNameList)) {
+					if (bean.getComponentLicenseList() != null) {
+						for ( ProjectIdentification project : bean.getComponentLicenseList()) {
+							if (!isEmpty(licenseNameList)) {
 								licenseNameList += ",";
 							}
 							
 							LicenseMaster lm = CoCodeManager.LICENSE_INFO_UPPER.get(project.getLicenseName().toUpperCase());
 							
-							if(lm != null) {
+							if (lm != null) {
 								licenseNameList += (!isEmpty(lm.getShortIdentifier()) ? lm.getShortIdentifier() : lm.getLicenseName());
 							}else {
 								licenseNameList += project.getLicenseName();
@@ -541,23 +541,23 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					params.add(bean.getHomepage()); // home page url
 					params.add(bean.getCopyrightText());
 					
-					if(!(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type)
+					if (!(CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type)
 							|| CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(type)
 							|| CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type))
 						|| isSelfCheck) {
 						String licenseTextUrl = "";
 						
-						for(String licenseName : licenseNameList.split(",")) {
+						for (String licenseName : licenseNameList.split(",")) {
 							String licenseUrl = CommonFunction.getLicenseUrlByName(licenseName.trim());						
 							
-							if(isEmpty(licenseUrl)) {
+							if (isEmpty(licenseUrl)) {
 								boolean distributionFlag = CommonFunction.propertyFlagCheck("distribution.use.flag", CoConstDef.FLAG_YES);
 								
 								licenseUrl = CommonFunction.makeLicenseInternalUrl(CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(licenseName).toUpperCase()), distributionFlag);
 							}
 							
-							if(!isEmpty(licenseUrl)) {
-								if(!isEmpty(licenseTextUrl)) {
+							if (!isEmpty(licenseUrl)) {
+								if (!isEmpty(licenseTextUrl)) {
 									licenseTextUrl += ", ";
 								}
 								
@@ -568,12 +568,12 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 						params.add(licenseTextUrl);
 					}
 					
-					if(CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(type)) {
+					if (CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(type)) {
 						params.add(""); // check list > Modified or not
 					}
 					
-					if(!CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type) && !isSelfCheck) { // selfcheck에서는 출력하지 않음.
-						if( CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+					if (!CoConstDef.CD_DTL_COMPONENT_ID_PARTNER.equals(type) && !isSelfCheck) { // selfcheck에서는 출력하지 않음.
+						if ( CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 							params.add("Exclude");
 						} else {
 							params.add("");
@@ -583,7 +583,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					// Comment
 					String _comm = "";
 					
-					if(!isSelfCheck 
+					if (!isSelfCheck 
 						&& (CoConstDef.CD_DTL_COMPONENT_ID_SRC.equals(type) 
 							|| CoConstDef.CD_DTL_COMPONENT_ID_BIN.equals(type) 
 							|| CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type))) {
@@ -594,25 +594,25 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					
 					
 					// Vulnerability
-					if(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
+					if (CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(type)) {
 						params.add(new BigDecimal(avoidNull(bean.getCvssScore(), "0.0")).equals(new BigDecimal("0.0")) ? "" : bean.getCvssScore()); // Vuln
 						params.add(isEmpty(bean.getRestriction()) ? "" : bean.getRestriction());
 					}
 					
-					if(isSelfCheck){
+					if (isSelfCheck){
 						params.add((new BigDecimal(avoidNull(bean.getCvssScore(), "0.0")).equals(new BigDecimal("0.0")) ? "" : bean.getCvssScore())); // Vuln
 						
 						boolean errRowFlag = false;
 						
-						for(String errCd : vr.getErrorCodeMap().keySet()) {
-							if(errCd.contains(bean.getComponentId())) {
+						for (String errCd : vr.getErrorCodeMap().keySet()) {
+							if (errCd.contains(bean.getComponentId())) {
 								errRowFlag = true;
 								
 								break;
 							} 
 						}
 						
-						if(errRowFlag) {
+						if (errRowFlag) {
 							// notice
 							params.add("");
 							// source code
@@ -628,7 +628,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 						params.add((isEmpty(bean.getRestriction()) ? "" : bean.getRestriction()));
 					}
 					
-					if(CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(type)){
+					if (CoConstDef.CD_DTL_COMPONENT_PARTNER.equals(type)){
 						params.add(isEmpty(bean.getComments()) ? "" : bean.getComments());
 					}
 					
@@ -639,13 +639,13 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			}
 
 			//시트 만들기
-			if(!rows.isEmpty()) {
+			if (!rows.isEmpty()) {
 				int startIdx = isSelfCheck ? 1 : 2;
 				
 				try {
 					Font font = WorkbookFactory.create(true).createFont();
 					
-					if(isSelfCheck) {
+					if (isSelfCheck) {
 						makeSheetAddWarningMsg(sheet, rows, startIdx, false, font);
 					} else {
 						makeSheetAddWarningMsg(sheet, rows, startIdx, true, font);
@@ -660,17 +660,17 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 	private static void addColumnWarningMessage(String type, ProjectIdentification bean, T2CoValidationResult vr, List<String> params) {
 		String message = "";
 		
-		if(!vr.getValidMessageMap().isEmpty()) {
+		if (!vr.getValidMessageMap().isEmpty()) {
 			String gridId = "";
-			if(CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
+			if (CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
 				gridId = bean.getComponentId();
 			} else {
 				gridId = bean.getGridId();
 			}
 			
-			for(String key : vr.getValidMessageMap().keySet()) {
-				if(key.contains(".") && gridId.equals(key.split("[.]")[1])) {
-					if(!isEmpty(message)) {
+			for (String key : vr.getValidMessageMap().keySet()) {
+				if (key.contains(".") && gridId.equals(key.split("[.]")[1])) {
+					if (!isEmpty(message)) {
 						message += "/";
 					}
 					
@@ -679,16 +679,16 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			}
 		}
 		
-		if(!vr.getDiffMessageMap().isEmpty()) {
+		if (!vr.getDiffMessageMap().isEmpty()) {
 			String gridId = "";
-			if(CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
+			if (CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
 				gridId = bean.getComponentId();
 			} else {
 				gridId = bean.getGridId();
 			}
-			for(String key : vr.getDiffMessageMap().keySet()) {
-				if(key.contains(".") && gridId.equals(key.split("[.]")[1])) {
-					if(!isEmpty(message)) {
+			for (String key : vr.getDiffMessageMap().keySet()) {
+				if (key.contains(".") && gridId.equals(key.split("[.]")[1])) {
+					if (!isEmpty(message)) {
 						message += "/";
 					}
 					
@@ -758,7 +758,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		int endCol = 0;
 		int templateRowNum = 1;
 		
-		if(rows.isEmpty()){
+		if (rows.isEmpty()){
 			
 		}else{
 			endCol = rows.get(0).length-1;
@@ -772,11 +772,11 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		
 		startRow = templateRow.getRowNum();		
 		
-		for(int i = startRow; i < startRow+shiftRowNum; i++){
+		for (int i = startRow; i < startRow+shiftRowNum; i++){
 			String[] rowParam = rows.get(i-startRow);
 			
 			Row row = sheet.createRow(i);
-			for(int colNum=startCol; colNum<=endCol; colNum++){
+			for (int colNum=startCol; colNum<=endCol; colNum++){
 				
 				Cell cell=row.createCell(colNum);
 				cell.setCellStyle(style);
@@ -794,7 +794,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		int startRow= 1;
 		int startCol = 0;
 		int endCol = 0;
-		if(rows.isEmpty()){
+		if (rows.isEmpty()){
 		}else{
 			endCol = rows.get(0).length-1;
 		}
@@ -812,19 +812,19 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			String[] rowParam = rows.get(i - startRow);
 
 			Row row = sheet.getRow(i);
-			if(row == null) {
+			if (row == null) {
 				row = sheet.createRow(i);
 			}
 
 			for (int colNum = startCol; colNum <= endCol; colNum++) {
 				Cell cell = row.getCell(colNum);
 				
-				if(cell == null) {
+				if (cell == null) {
 					cell = row.createCell(colNum);
 				}
 				
 				// comment의 경우 줄바꿈 처리
-				if(useLastCellComment && colNum == endCol) {
+				if (useLastCellComment && colNum == endCol) {
 					CellStyle cs = style;
 					cs.setWrapText(true);
 					cell.setCellStyle(cs);
@@ -833,7 +833,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				}
 				
 				// 수식 삭제
-				if(CellType.FORMULA == cell.getCellType()) {
+				if (CellType.FORMULA == cell.getCellType()) {
 					cell.setCellType(CellType.BLANK);
 				}
 				
@@ -848,7 +848,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		int startRow= 1;
 		int startCol = 0;
 		int endCol = 0;
-		if(rows.isEmpty()){
+		if (rows.isEmpty()){
 		}else{
 			endCol = rows.get(0).length-1;
 		}
@@ -866,19 +866,19 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			String[] rowParam = rows.get(i - startRow);
 
 			Row row = sheet.getRow(i);
-			if(row == null) {
+			if (row == null) {
 				row = sheet.createRow(i);
 			}
 
 			for (int colNum = startCol; colNum <= endCol; colNum++) {
 				Cell cell = row.getCell(colNum);
 				
-				if(cell == null) {
+				if (cell == null) {
 					cell = row.createCell(colNum);
 				}
 				
 				// comment의 경우 줄바꿈 처리
-				if((useLastCellComment && colNum == endCol - 1) || colNum == endCol) {
+				if ((useLastCellComment && colNum == endCol - 1) || colNum == endCol) {
 					CellStyle cs = style;
 					cs.setWrapText(true);
 					cell.setCellStyle(cs);
@@ -887,12 +887,12 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				}
 				
 				// 수식 삭제
-				if(CellType.FORMULA == cell.getCellType()) {
+				if (CellType.FORMULA == cell.getCellType()) {
 					cell.setCellType(CellType.BLANK);
 				}
 				
 				// warning message의 경우 색상 처리
-				if(colNum == endCol) {
+				if (colNum == endCol) {
 					String cellValue = avoidNull(rowParam[colNum]);
 					String richTextStr = cellValue.replaceAll("[(]FONT_RED[)]", "").replaceAll("[(]FONT_BLUE[)]", "").replaceAll("[/]", System.lineSeparator());
 					
@@ -901,13 +901,13 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 						String[] messageArr = cellValue.split("/");
 						int startIndex = 0;
 						
-						for(int j=0; j<messageArr.length; j++) {
+						for (int j=0; j<messageArr.length; j++) {
 							String message = "";
-							if(messageArr[j].contains("(FONT_RED)")) {
+							if (messageArr[j].contains("(FONT_RED)")) {
 								message = messageArr[j].split("[(]FONT_RED[)]")[0];
 								font.setColor(HSSFColor.HSSFColorPredefined.RED.getIndex());
 								messageStr.applyFont(startIndex, startIndex + message.length(), font);
-							} else if(messageArr[j].contains("(FONT_BLUE)")){
+							} else if (messageArr[j].contains("(FONT_BLUE)")){
 								message = messageArr[j].split("[(]FONT_BLUE[)]")[0];
 								font.setColor(HSSFColor.HSSFColorPredefined.BLUE.getIndex());
 								messageStr.applyFont(startIndex, startIndex + message.length(), font);
@@ -933,7 +933,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		int endCol = 0;
 		int templateRowNum = 2;
 		
-		if(rows.isEmpty()) {
+		if (rows.isEmpty()) {
 			
 		} else {
 			endCol = rows.get(0).length-1;
@@ -947,12 +947,12 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		
 		startRow = templateRow.getRowNum();
 		
-		for(int i = startRow; i < startRow+shiftRowNum; i++){
+		for (int i = startRow; i < startRow+shiftRowNum; i++){
 			String[] rowParam = rows.get(i-startRow);
 			
 			Row row = sheet.createRow(i);
 			
-			for(int colNum=startCol; colNum<=endCol; colNum++){
+			for (int colNum=startCol; colNum<=endCol; colNum++){
 				Cell cell=row.createCell(colNum);
 				cell.setCellStyle(style);
 				cell.setCellValue(rowParam[colNum]);
@@ -966,7 +966,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		int startCol = 0;
 		int endCol = 0;
 		
-		if(rows.isEmpty()) {
+		if (rows.isEmpty()) {
 		} else {
 			endCol = rows.get(0).length-1;
 		}
@@ -978,19 +978,19 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 
 			Row row = sheet.getRow(i);
 			
-			if(row == null) {
+			if (row == null) {
 				row = sheet.createRow(i);
 			}
 
 			for (int colNum = startCol; colNum <= endCol; colNum++) {
 				Cell cell = row.getCell(colNum);
 				
-				if(cell == null) {
+				if (cell == null) {
 					cell = row.createCell(colNum);
 				}
 				
 				// 수식 삭제
-				if(CellType.FORMULA == cell.getCellType()) {
+				if (CellType.FORMULA == cell.getCellType()) {
 					cell.setCellType(CellType.BLANK);
 				}
 				cell.setCellValue(avoidNull(rowParam[colNum]));
@@ -1050,7 +1050,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		// Notice Type		
 		String noticeTypeStr = CoCodeManager.getCodeString(CoConstDef.CD_NOTICE_TYPE, project.getNoticeType());
 		
-		if(!isEmpty(project.getNoticeTypeEtc())) {
+		if (!isEmpty(project.getNoticeTypeEtc())) {
 			noticeTypeStr += " (" +CoCodeManager.getCodeString(CoConstDef.CD_PLATFORM_GENERATED, project.getNoticeTypeEtc()) + ")";
 		}
 		
@@ -1083,7 +1083,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			List<String[]> rows = new ArrayList<>();
 			
-			for(int i = 0; i < licenseList.size(); i++){
+			for (int i = 0; i < licenseList.size(); i++){
 				LicenseMaster param = licenseList.get(i);
 				String[] rowParam = {
 					param.getLicenseId()
@@ -1106,7 +1106,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (FileNotFoundException e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -1119,10 +1119,10 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 	
 	private static String convertLineSeparator(List<String> list) {
 		String rtn = "";
-		if(list != null) {
-			for(String s : list) {
-				if(!isEmpty(s)) {
-					if(!isEmpty(rtn)) {
+		if (list != null) {
+			for (String s : list) {
+				if (!isEmpty(s)) {
+					if (!isEmpty(rtn)) {
 						rtn += "\r\n";
 					}
 					
@@ -1153,7 +1153,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			wb.setSheetName(0, "ossList");
 			
 			List<String[]> rows = new ArrayList<>();
-			for(int i = 0; i < oss.size(); i++){
+			for (int i = 0; i < oss.size(); i++){
 				OssMaster param = oss.get(i);
 				String[] rowParam = {
 					param.getOssId()
@@ -1179,7 +1179,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (FileNotFoundException e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -1193,10 +1193,10 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 	private static String convertPipeToLineSeparator(String nick) {
 		String rtn = "";
 		
-		if(!isEmpty(nick)) {
-			for(String s : nick.split("\\|")) {
-				if(!isEmpty(s)) {
-					if(!isEmpty(rtn)) {
+		if (!isEmpty(nick)) {
+			for (String s : nick.split("\\|")) {
+				if (!isEmpty(s)) {
+					if (!isEmpty(rtn)) {
 						rtn += "\r\n";
 					}
 					
@@ -1234,7 +1234,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			Project expParam = new Project();
 			
-			for(Project p : projectList) {
+			for (Project p : projectList) {
 				expParam.addPrjIdList(p.getPrjId());
 			}
 			
@@ -1242,13 +1242,13 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			List<String[]> rows = new ArrayList<>();
 			
-			for(int i = 0; i < projectList.size(); i++){
+			for (int i = 0; i < projectList.size(); i++){
 				Project param = projectList.get(i);
 				Map<String, String> expandInfo = projectExpandInfo.get(param.getPrjId());
 				OssMaster nvdMaxScoreInfo = projectMapper.findIdentificationMaxNvdInfo(param.getPrjId(), null);
 				String nvdMaxScore = "";
 				
-				if(nvdMaxScoreInfo != null) {
+				if (nvdMaxScoreInfo != null) {
 					nvdMaxScore = avoidNull(nvdMaxScoreInfo.getCvssScore(), "");
 				}
 				
@@ -1289,7 +1289,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (FileNotFoundException e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -1302,7 +1302,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 	private static String getExpandProjectInfo(Map<String, String> map, String target) {
 		String rtnStr = "";
 		
-		if(map != null && map.containsKey(target)) {
+		if (map != null && map.containsKey(target)) {
 			rtnStr = avoidNull(String.valueOf(map.get(target)));
 			
 			switch (target) {
@@ -1315,45 +1315,45 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					
 					break;
 				case "DISTRIBUTE_DEPLOY_TIME":
-					if(!isEmpty(rtnStr)) {
+					if (!isEmpty(rtnStr)) {
 						rtnStr = CommonFunction.formatDate(rtnStr);
 					}
 					
 					break;
 				case "DISTRIBUTE_MASTER_CATEGORY":
-					if(!isEmpty(rtnStr)) {
+					if (!isEmpty(rtnStr)) {
 						rtnStr = StringUtil.leftPad(rtnStr, 6, "0");
 						rtnStr = CommonFunction.makeCategoryFormat(String.valueOf(map.get("DISTRIBUTE_TARGET")), rtnStr.substring(0, 3), rtnStr.substring(3));
 					}
 					
 					break;
 				case "MODEL_INFO":
-					if(!isEmpty(rtnStr)) {
+					if (!isEmpty(rtnStr)) {
 						// T3.CATEGORY, '@',T3.SUBCATEGORY, '@',T3.MODEL_NAME, '@', T3.RELEASE_DATE
 						String[] modelInfos = rtnStr.split("\\|");
 						rtnStr = "";
 						int modelSeq = 0;
-						for(String model : modelInfos) {
-							if(!isEmpty(rtnStr)) {
+						for (String model : modelInfos) {
+							if (!isEmpty(rtnStr)) {
 								rtnStr += "\n";
 							}
 							
-							if(rtnStr.length() > 32000) {
+							if (rtnStr.length() > 32000) {
 								break;
 							}
 							
 							String tmp = "";
 							String[] _tmpArr = model.split("@"); 
-							if(_tmpArr != null && _tmpArr.length == 4) {
+							if (_tmpArr != null && _tmpArr.length == 4) {
 								// category
-								if(!isEmpty(_tmpArr[0]) && !isEmpty(_tmpArr[1])) {
+								if (!isEmpty(_tmpArr[0]) && !isEmpty(_tmpArr[1])) {
 									rtnStr += CommonFunction.makeCategoryFormat(String.valueOf(map.get("DISTRIBUTE_TARGET")), _tmpArr[0], _tmpArr[1]);
 								}
 								
 								tmp += ",　";
 								tmp += _tmpArr[2];
 								tmp += ",　";
-								if(!isEmpty(_tmpArr[3])) {
+								if (!isEmpty(_tmpArr[3])) {
 									tmp += CommonFunction.formatDateSimple(_tmpArr[3]);
 								}
 								rtnStr += tmp;
@@ -1361,7 +1361,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 							}
 						}
 						
-						if(modelInfos.length-modelSeq > 0) {
+						if (modelInfos.length-modelSeq > 0) {
 							rtnStr += "and " + (modelInfos.length-modelSeq);
 						}
 					}
@@ -1386,10 +1386,10 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			sheet = wb.getSheetAt(0);
 			wb.setSheetName(0, "3rdList");
 		
-			if(ossList != null && !ossList.isEmpty()) {
+			if (ossList != null && !ossList.isEmpty()) {
 				List<String[]> rows = new ArrayList<>();
 				
-				for(PartnerMaster bean : ossList) {
+				for (PartnerMaster bean : ossList) {
 					List<String> params = new ArrayList<>();
 					
 					// main 정보
@@ -1415,7 +1415,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -1436,7 +1436,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			wb = new XSSFWorkbook(inFile);
 				
-			if(fileData != null){
+			if (fileData != null){
 				sheet = wb.getSheetAt(0);
 				
 				int idx = 1;
@@ -1448,7 +1448,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				
 				int length = productGroupsLength > modelListLength ? productGroupsLength : modelListLength;
 				
-				for(int i = 0 ; i < length ; i++){
+				for (int i = 0 ; i < length ; i++){
 					List<String> params = new ArrayList<>();
 					
 					// main 정보
@@ -1463,13 +1463,13 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				makeSheet2(sheet, rows);
 			}
 			
-			if(project != null && !project.isEmpty()) {
+			if (project != null && !project.isEmpty()) {
 				sheet = wb.getSheetAt(1);
 				
 				int idx = 1;
 				List<String[]> rows = new ArrayList<>();
 				
-				for(Project bean : project) {
+				for (Project bean : project) {
 					List<String> params = new ArrayList<>();
 					
 					// main 정보
@@ -1493,7 +1493,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -1514,11 +1514,11 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			inFile= new FileInputStream(new File(downloadpath+"/complianceStatus.xlsx"));
 			wb = new XSSFWorkbook(inFile);
 			sheet = wb.getSheetAt(2);
-			if(ossList != null && !ossList.isEmpty()) {
+			if (ossList != null && !ossList.isEmpty()) {
 				int idx = 1;
 				List<String[]> rows = new ArrayList<>();
 				
-				for(PartnerMaster bean : ossList) {
+				for (PartnerMaster bean : ossList) {
 					List<String> params = new ArrayList<>();
 					
 					// main 정보
@@ -1541,7 +1541,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -1572,7 +1572,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			List<String[]> rows = new ArrayList<>();
 			
-			for(int i = 0; i < userList.size(); i++){
+			for (int i = 0; i < userList.size(); i++){
 				T2Users param = userList.get(i);
 				String[] rowParam = {
 					String.valueOf(i+1)
@@ -1593,7 +1593,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (FileNotFoundException e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -1620,10 +1620,10 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			rows = new ArrayList<>();
 			int idx = 1;
 			
-			for(String mCode : CoCodeManager.getCodes(mainModelCode)) {
+			for (String mCode : CoCodeManager.getCodes(mainModelCode)) {
 				String sCode = CoCodeManager.getSubCodeNo(mainModelCode, mCode);
 				
-				for(String subCode : CoCodeManager.getCodes(sCode)) {
+				for (String subCode : CoCodeManager.getCodes(sCode)) {
 					String categoryName = CoCodeManager.getCodeString(mainModelCode, mCode);
 					String subCategoryName = CoCodeManager.getCodeString(sCode, subCode);
 					
@@ -1647,8 +1647,8 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			rows = new ArrayList<>();
 			
-			if(modelList != null) {
-				for(int i = 0; i < modelList.size(); i++){
+			if (modelList != null) {
+				for (int i = 0; i < modelList.size(); i++){
 					Project param = modelList.get(i);
 					String main = StringUtil.substring(param.getCategory(), 0, 3);
 					String sub = StringUtil.substring(param.getCategory(), 3);
@@ -1668,7 +1668,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				}		
 			}
 			
-			if(rows.size() > 0) {
+			if (rows.size() > 0) {
 				DataValidationHelper dvHelper = sheet.getDataValidationHelper();
 				DataValidationConstraint dvConstraint = dvHelper.createFormulaListConstraint("'Category List'!$D$2:$D$1048576");
 				CellRangeAddressList addressList = new CellRangeAddressList(1, rows.size(), 1, 1);
@@ -1697,7 +1697,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (FileNotFoundException e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -1721,7 +1721,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		FileOutputStream outFile = null;
 		
 		try {
-			if(!Files.exists(Paths.get(excelFilePath))) {
+			if (!Files.exists(Paths.get(excelFilePath))) {
 				Files.createDirectories(Paths.get(excelFilePath));
 			}
 			outFile = new FileOutputStream(excelFilePath + logiFileName);
@@ -1732,7 +1732,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(outFile != null) {
+			if (outFile != null) {
 				try {
 					outFile.close();
 				} catch (Exception e2) {}
@@ -1759,13 +1759,13 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		try {			
 			fileWriter = new FileWriter(excelFilePath + logiFileName);
 
-			if(!Files.exists(Paths.get(excelFilePath))) {
+			if (!Files.exists(Paths.get(excelFilePath))) {
 				Files.createDirectories(Paths.get(excelFilePath));
 			}
 			
 			csvFilePrinter = new CSVPrinter(fileWriter, csvFileFormat);
 			
-			for(String[] row : datas) {
+			for (String[] row : datas) {
 				csvFilePrinter.printRecord(Arrays.asList(row));
 			}
 			
@@ -1775,25 +1775,25 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(outFile != null) {
+			if (outFile != null) {
 				try {
 					outFile.close();
 				} catch (Exception e2) {}
 			}
 			
-			if(cw != null) {
+			if (cw != null) {
 				try {
 					cw.close();
 				} catch (Exception e2) {}
 			}
 			
-			if(fileWriter != null) {
+			if (fileWriter != null) {
 				try {
 					fileWriter.close();
 				} catch (Exception e2) {}
 			}
 			
-			if(csvFilePrinter != null) {
+			if (csvFilePrinter != null) {
 				try {
 					csvFilePrinter.close();
 				} catch (Exception e2) {}
@@ -1812,7 +1812,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		FileOutputStream outFile = null;
 		
 		try {
-			if(!Files.exists(Paths.get(analysisSavePath))) {
+			if (!Files.exists(Paths.get(analysisSavePath))) {
 				Files.createDirectories(Paths.get(analysisSavePath));
 			}
 			
@@ -1825,7 +1825,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(outFile != null) {
+			if (outFile != null) {
 				try {
 					outFile.close();
 				} catch (Exception e2) {}
@@ -1855,11 +1855,11 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				Map<String, Object> projectMap = new HashMap<String, Object>();
 				projectMap = mapper.readValue((String) dataStr, new TypeReference<Map<String, Object>>(){});
 				
-				if(projectMap != null){ 
-					if(projectMap.get("statuses") != null) {
+				if (projectMap != null){ 
+					if (projectMap.get("statuses") != null) {
 						String statuses = String.valueOf(projectMap.get("statuses"));
 						
-						if(!isEmpty(statuses)){
+						if (!isEmpty(statuses)){
 							String[] arrStatuses = statuses.split(",");
 							projectMap.put("arrStatuses", arrStatuses);
 						}
@@ -1876,7 +1876,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				project.setExcelDownloadFlag(CoConstDef.FLAG_YES);
 				Map<String, Object> prjMap =	 projectService.getProjectList(project);
 				
-				if(isMaximumRowCheck((int) prjMap.get("records"))){
+				if (isMaximumRowCheck((int) prjMap.get("records"))){
 					downloadId	= getProjectExcel((List<Project>) prjMap.get("rows"));
 				}
 				
@@ -1905,7 +1905,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				license.setPageListSize(MAX_RECORD_CNT);
 				List<LicenseMaster> licenseList = licenseService.getLicenseMasterListExcel(license);
 				
-				if(isMaximumRowCheck(licenseService.selectLicenseMasterTotalCount(license))){
+				if (isMaximumRowCheck(licenseService.selectLicenseMasterTotalCount(license))){
 					downloadId 	= getLicenseExcel(licenseList);
 				}
 				
@@ -1963,7 +1963,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				
 				String filterCondition = CommonFunction.getFilterToString(bianryDbLogBean.getFilters(), null, exceptionMap);
 				
-				if(!isEmpty(filterCondition)) {
+				if (!isEmpty(filterCondition)) {
 					bianryDbLogBean.setFilterCondition(filterCondition);
 				}
 	
@@ -1973,7 +1973,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				
 				Map<String, Object> bianryDbLogMap = binaryDataHistoryService.getBinaryDataHistoryList(bianryDbLogBean);
 				
-				if(isMaximumRowCheck((int) bianryDbLogMap.get("records"))){
+				if (isMaximumRowCheck((int) bianryDbLogMap.get("records"))){
 					downloadId = getBinaryDBLogExcel((List<BinaryAnalysisResult>) bianryDbLogMap.get("rows"));
 				}
 				
@@ -1982,10 +1982,10 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				Type 				partnerType = new TypeToken<PartnerMaster>(){}.getType();
 				PartnerMaster 		partner 	= (PartnerMaster) fromJson(dataStr, partnerType);
 	
-				if(partner.getStatus() != null) {
+				if (partner.getStatus() != null) {
 					String statuses = partner.getStatus();
 					
-					if(!isEmpty(statuses)) {
+					if (!isEmpty(statuses)) {
 						String[] arrStatuses = statuses.split(",");
 						partner.setArrStatuses(arrStatuses);
 					}
@@ -2003,10 +2003,10 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				Type 				partnerModelType = new TypeToken<PartnerMaster>(){}.getType();
 				PartnerMaster 		partnerModel	  = (PartnerMaster) fromJson(dataStr, partnerModelType);
 	
-				if(partnerModel.getStatus() != null) {
+				if (partnerModel.getStatus() != null) {
 					String statuses = partnerModel.getStatus();
 					
-					if(!isEmpty(statuses)) {
+					if (!isEmpty(statuses)) {
 						String[] arrStatuses = statuses.split(",");
 						partnerModel.setArrStatuses(arrStatuses);
 					}
@@ -2018,7 +2018,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				
 				Map<String, Object> partnerModelList =	 partnerService.getPartnerStatusList(partnerModel);
 				
-				if(isMaximumRowCheck((int) partnerModelList.get("records"))){
+				if (isMaximumRowCheck((int) partnerModelList.get("records"))){
 					downloadId	= getPartnerModelExcelId((List<PartnerMaster>) partnerModelList.get("rows"));
 				}
 				
@@ -2027,17 +2027,17 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				Type 			ProjectModelType = new TypeToken<Project>(){}.getType();
 				Project 		ProjectModel	 = (Project) fromJson(dataStr, ProjectModelType);
 				
-				if(!isEmpty(ProjectModel.getModelName())){
+				if (!isEmpty(ProjectModel.getModelName())){
 					String[] modelNames = ProjectModel.getModelName().split(",");
 					String[] productGroups = ProjectModel.getProductGroup().split(",");
 					List<String> modelListInfo = new ArrayList<String>();
 					List<String> productGroupListInfo = new ArrayList<String>();
 					
-					for(String modelName : modelNames){
+					for (String modelName : modelNames){
 						modelListInfo.add(modelName);
 					}
 					
-					for(String productGroup : productGroups){
+					for (String productGroup : productGroups){
 						productGroupListInfo.add(productGroup);
 					}
 					
@@ -2048,7 +2048,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				
 				Map<String, Object> map = complianceService.getModelList(ProjectModel);
 				
-				if(isMaximumRowCheck((int) map.get("records"))){
+				if (isMaximumRowCheck((int) map.get("records"))){
 					downloadId	= getModelStatusExcelId((List<Project>) map.get("rows"), ProjectModel);
 				}
 				
@@ -2061,7 +2061,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				
 				Map<String, Object> vulnerabilityMap =	 vulnerabilityService.getVulnerabilityList(vulnerability, true);
 				
-				if(isMaximumRowCheck((int) vulnerabilityMap.get("records"))){
+				if (isMaximumRowCheck((int) vulnerabilityMap.get("records"))){
 					downloadId = getVulnerabilityExcel((List<Vulnerability>) vulnerabilityMap.get("rows"));
 				}
 				
@@ -2074,7 +2074,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 
 				Map<String, Object> vulnerabilityPopupMap = vulnerabilityService.getVulnListByOssName(bean);
 
-				if(isMaximumRowCheck((int) vulnerabilityPopupMap.get("records"))){
+				if (isMaximumRowCheck((int) vulnerabilityPopupMap.get("records"))){
 					downloadId = getVulnerabilityExcel((List<Vulnerability>) vulnerabilityPopupMap.get("rows"));
 				}
 
@@ -2126,10 +2126,10 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			wb = WorkbookFactory.create(inFile);
 			sheet1 = wb.getSheetAt(0);
 			
-			if(list != null){
+			if (list != null){
 				List<String[]> rowDatas = new ArrayList<>();
 				
-				for(BinaryAnalysisResult bean : list) {
+				for (BinaryAnalysisResult bean : list) {
 					String[] rowParam = {
 							bean.getActionId()
 							, bean.getActionType()
@@ -2156,7 +2156,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				makeSheet(sheet1, rowDatas);
 			}
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e) {}
@@ -2217,7 +2217,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 
 			String strPrjName = projectInfo.getPrjName();
 
-			if(!isEmpty(projectInfo.getPrjVersion())) {
+			if (!isEmpty(projectInfo.getPrjVersion())) {
 				strPrjName += "-" + projectInfo.getPrjVersion();
 			}
 
@@ -2251,7 +2251,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				Cell cellDocumentNamespace = getCell(row, cellIdx); cellIdx++;
 				String spdxidentifier = "SPDXRef-" + strPrjName.replaceAll(" ", "") + "-" + createdTime;
 				String domain = CommonFunction.emptyCheckProperty("server.domain", "http://fosslight.org/");
-				if(!domain.endsWith("/")) {
+				if (!domain.endsWith("/")) {
 					domain += "/";
 				}
 				cellDocumentNamespace.setCellValue(domain + spdxidentifier);
@@ -2286,7 +2286,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 
 				boolean hideOssVersionFlag = CoConstDef.FLAG_YES.equals(ossNotice.getHideOssVersionYn());
 
-				if(sourceList != null && !sourceList.isEmpty()) {
+				if (sourceList != null && !sourceList.isEmpty()) {
 					noticeList.addAll(sourceList);
 				}
 
@@ -2294,10 +2294,10 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 
 				int rowIdx = 1;
 
-				for(OssComponents bean : noticeList) {
+				for (OssComponents bean : noticeList) {
 					Row row = sheetPackage.getRow(rowIdx);
 
-					if(row == null) {
+					if (row == null) {
 						row = sheetPackage.createRow(rowIdx);
 					}
 
@@ -2313,7 +2313,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellSPDXIdentifier = getCell(row, cellIdx); cellIdx++;
 					String ossName = bean.getOssName().replace("&#39;", "\'"); // ossName에 '가 들어갈 경우 정상적으로 oss Info를 찾지 못하는 증상이 발생하여 현재 값으로 치환.
 
-					if(ossName.equals("-")) {
+					if (ossName.equals("-")) {
 						cellSPDXIdentifier.setCellValue("SPDXRef-File-" + bean.getComponentId());
 						packageInfoidentifierList.add("SPDXRef-File-" + bean.getComponentId());
 					} else {
@@ -2344,12 +2344,12 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellPackageDownloadLocation = getCell(row, cellIdx); cellIdx++;
 					String downloadLocation = bean.getDownloadLocation();
 
-					if(downloadLocation.isEmpty()) {
+					if (downloadLocation.isEmpty()) {
 						downloadLocation = "NONE";
 					}
 
 					// Invalid download location is output as NONE
-					if(SpdxVerificationHelper.verifyDownloadLocation(downloadLocation) != null) {
+					if (SpdxVerificationHelper.verifyDownloadLocation(downloadLocation) != null) {
 						downloadLocation = "NONE";
 					}
 
@@ -2371,7 +2371,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellLicenseDeclared = getCell(row, cellIdx); cellIdx++;
 
 					OssMaster _ossBean = null;
-					if(ossName.equals("-")) {
+					if (ossName.equals("-")) {
 						String licenseStr = CommonFunction.licenseStrToSPDXLicenseFormat(bean.getLicenseName());
 						cellLicenseDeclared.setCellValue(licenseStr);
 						attributionText = bean.getAttribution();
@@ -2379,7 +2379,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 						_ossBean = CoCodeManager.OSS_INFO_UPPER.get( (ossName + "_" + avoidNull(bean.getOssVersion())).toUpperCase());
 						String licenseStr = CommonFunction.makeLicenseExpression(_ossBean.getOssLicenses(), false, true);
 
-						if(_ossBean.getOssLicenses().size() > 1) {
+						if (_ossBean.getOssLicenses().size() > 1) {
 							licenseStr = "(" + licenseStr + ")";
 						}
 
@@ -2391,21 +2391,21 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellLicenseConcluded = getCell(row, cellIdx); cellIdx++;
 					String srtLicenseName = "";
 
-					for(OssComponentsLicense liBean : bean.getOssComponentsLicense()) {
-						if(!isEmpty(srtLicenseName)) {
+					for (OssComponentsLicense liBean : bean.getOssComponentsLicense()) {
+						if (!isEmpty(srtLicenseName)) {
 							srtLicenseName += " AND ";
 						}
 
 						if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(liBean.getLicenseName()).toUpperCase())) {
 							LicenseMaster liMaster = CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(liBean.getLicenseName()).toUpperCase());
 
-							if(!isEmpty(liMaster.getShortIdentifier())) {
+							if (!isEmpty(liMaster.getShortIdentifier())) {
 								liBean.setLicenseName(liMaster.getShortIdentifier());
 							} else {
 								liBean.setLicenseName("LicenseRef-" + liBean.getLicenseName());
 							}
 
-							if(!isEmpty(attributionText)) {
+							if (!isEmpty(attributionText)) {
 								attributionText += "\n";
 							}
 
@@ -2416,7 +2416,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 						srtLicenseName += liBean.getLicenseName();
 					}
 
-					if(!bean.getOssComponentsLicense().isEmpty() && bean.getOssComponentsLicense().size() > 1) {
+					if (!bean.getOssComponentsLicense().isEmpty() && bean.getOssComponentsLicense().size() > 1) {
 						srtLicenseName = "(" + srtLicenseName + ")";
 					}
 
@@ -2425,7 +2425,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					// License Info From Files
 					Cell licenseInfoFromFiles = getCell(row, cellIdx); cellIdx++;
 
-					if(ossName.equals("-")) {
+					if (ossName.equals("-")) {
 						licenseInfoFromFiles.setCellValue(CommonFunction.licenseStrToSPDXLicenseFormat(bean.getLicenseName()));
 					} else {
 						licenseInfoFromFiles.setCellValue(CommonFunction.makeLicenseFromFiles(_ossBean, true)); // Declared & Detected License Info (중복제거)
@@ -2438,7 +2438,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellPackageCopyrightText = getCell(row, cellIdx); cellIdx++;
 					String copyrightText = StringUtil.substring(CommonFunction.brReplaceToLine(bean.getCopyrightText()), 0, 32762);
 
-					if(copyrightText.isEmpty() || copyrightText.equals("-")) {
+					if (copyrightText.isEmpty() || copyrightText.equals("-")) {
 						copyrightText = "NOASSERTION";
 					}
 
@@ -2472,20 +2472,20 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				List<OssComponents> noticeList = (List<OssComponents>) packageInfo.get("noticeObligationList");
 				Map<String, LicenseMaster> nonIdetifierNoticeList = new HashMap<>();
 
-				for(OssComponents ocBean : noticeList) {
+				for (OssComponents ocBean : noticeList) {
 					String ossName = ocBean.getOssName().replace("&#39;", "\'");
 
 					List<String> licenseList = new ArrayList<>();
-					if(ossName.equals("-")) {
+					if (ossName.equals("-")) {
 						licenseList = Arrays.asList(ocBean.getLicenseName());
 					} else {
 						OssMaster _ossBean = CoCodeManager.OSS_INFO_UPPER.get((ossName + "_" + avoidNull(ocBean.getOssVersion())).toUpperCase());
 						licenseList = Arrays.asList(CommonFunction.makeLicenseFromFiles(_ossBean, false).split(","));
 					}
 
-					for(String licenseNm : licenseList) {
+					for (String licenseNm : licenseList) {
 						LicenseMaster lmBean = CoCodeManager.LICENSE_INFO.get(licenseNm);
-						if(lmBean != null && isEmpty(lmBean.getShortIdentifier()) && !nonIdetifierNoticeList.containsKey(lmBean.getLicenseId())) {
+						if (lmBean != null && isEmpty(lmBean.getShortIdentifier()) && !nonIdetifierNoticeList.containsKey(lmBean.getLicenseId())) {
 							nonIdetifierNoticeList.put(lmBean.getLicenseId(), lmBean);
 						}
 					}
@@ -2493,12 +2493,12 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 
 				int rowIdx = 1;
 
-				for(LicenseMaster bean : nonIdetifierNoticeList.values()) {
+				for (LicenseMaster bean : nonIdetifierNoticeList.values()) {
 					int cellIdx = 0;
 
 					Row row = sheetLicense.getRow(rowIdx);
 
-					if(row == null) {
+					if (row == null) {
 						row = sheetLicense.createRow(rowIdx);
 					}
 
@@ -2532,21 +2532,21 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				List<OssComponents> noticeList = (List<OssComponents>) packageInfo.get("addOssComponentList");
 				List<OssComponents> nonIdetifierNoticeList = new ArrayList<>();
 
-				for(OssComponents bean : noticeList) {
+				for (OssComponents bean : noticeList) {
 					// set false because "Per file info sheet" is not currently output
-					if("-".equals(bean.getOssName()) && false) {
+					if ("-".equals(bean.getOssName()) && false) {
 						nonIdetifierNoticeList.add(bean);
 					}
 				}
 
 				int rowIdx = 1;
 
-				for(OssComponents bean : nonIdetifierNoticeList) {
+				for (OssComponents bean : nonIdetifierNoticeList) {
 					int cellIdx = 0;
 					String attributionText = "";
 					Row row = sheetPerFile.getRow(rowIdx);
 
-					if(row == null) {
+					if (row == null) {
 						row = sheetPerFile.createRow(rowIdx);
 					}
 
@@ -2572,20 +2572,20 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellLicenseConcluded = getCell(row, cellIdx); cellIdx++;
 					String srtLicenseName = "";
 
-					for(OssComponentsLicense liBean : bean.getOssComponentsLicense()) {
-						if(!isEmpty(srtLicenseName)) {
+					for (OssComponentsLicense liBean : bean.getOssComponentsLicense()) {
+						if (!isEmpty(srtLicenseName)) {
 							srtLicenseName += " AND ";
 						}
-						if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(liBean.getLicenseName()).toUpperCase())) {
+						if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(liBean.getLicenseName()).toUpperCase())) {
 							LicenseMaster liMaster = CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(liBean.getLicenseName()).toUpperCase());
 
-							if(!isEmpty(liMaster.getShortIdentifier())) {
+							if (!isEmpty(liMaster.getShortIdentifier())) {
 								liBean.setLicenseName(liMaster.getShortIdentifier());
 							} else {
 								liBean.setLicenseName("LicenseRef-" + liBean.getLicenseName());
 							}
 
-							if(!isEmpty(attributionText)) {
+							if (!isEmpty(attributionText)) {
 								attributionText += "\n";
 							}
 
@@ -2597,7 +2597,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 						srtLicenseName += liBean.getLicenseName();
 					}
 
-					if(!bean.getOssComponentsLicense().isEmpty() && bean.getOssComponentsLicense().size() > 1) {
+					if (!bean.getOssComponentsLicense().isEmpty() && bean.getOssComponentsLicense().size() > 1) {
 						srtLicenseName = "(" + srtLicenseName + ")";
 					}
 
@@ -2649,11 +2649,11 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			{
 				int rowIdx = 1;
 
-				for(String _identifierB : packageInfoidentifierList) {
+				for (String _identifierB : packageInfoidentifierList) {
 					int cellIdx = 0;
 
 					Row row = sheetRelationships.getRow(rowIdx);
-					if(row == null) {
+					if (row == null) {
 						row = sheetRelationships.createRow(rowIdx);
 					}
 					// SPDX Identifier A
@@ -2674,7 +2674,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e) {}
@@ -2730,7 +2730,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			String strPrjName = projectInfo.getPrjName();
 			
-			if(!isEmpty(projectInfo.getPrjVersion())) {
+			if (!isEmpty(projectInfo.getPrjVersion())) {
 				strPrjName += "-" + projectInfo.getPrjVersion();
 			}
 			
@@ -2764,7 +2764,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				Cell cellDocumentNamespace = getCell(row, cellIdx); cellIdx++;
 				String spdxidentifier = "SPDXRef-" + strPrjName.replaceAll(" ", "") + "-" + createdTime;
 				String domain = CommonFunction.emptyCheckProperty("server.domain", "http://fosslight.org/");
-				if(!domain.endsWith("/")) {
+				if (!domain.endsWith("/")) {
 					domain += "/";
 				}
 				cellDocumentNamespace.setCellValue(domain + spdxidentifier);
@@ -2800,7 +2800,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				boolean hideOssVersionFlag = CoConstDef.FLAG_YES.equals(ossNotice.getHideOssVersionYn());
 				
 				// permissive oss와 copyleft oss를 병합
-				if(sourceList != null && !sourceList.isEmpty()) {
+				if (sourceList != null && !sourceList.isEmpty()) {
 					noticeList.addAll(sourceList);
 				}
 				
@@ -2808,11 +2808,11 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				
 				int rowIdx = 1;
 				
-				for(OssComponents bean : noticeList) {
+				for (OssComponents bean : noticeList) {
 					
 					Row row = sheetPackage.getRow(rowIdx);
 					
-					if(row == null) {
+					if (row == null) {
 						row = sheetPackage.createRow(rowIdx);
 					}
 					
@@ -2828,7 +2828,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellSPDXIdentifier = getCell(row, cellIdx); cellIdx++;
 					String ossName = bean.getOssName().replace("&#39;", "\'"); // ossName에 '가 들어갈 경우 정상적으로 oss Info를 찾지 못하는 증상이 발생하여 현재 값으로 치환.
 
-					if(!isEmpty(bean.getOssId())) {
+					if (!isEmpty(bean.getOssId())) {
 						cellSPDXIdentifier.setCellValue("SPDXRef-Package-" + bean.getOssId());
 						packageInfoidentifierList.add("SPDXRef-Package-" + bean.getOssId());
 					} else {
@@ -2860,12 +2860,12 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellPackageDownloadLocation = getCell(row, cellIdx); cellIdx++;
 					String downloadLocation = bean.getDownloadLocation();
 
-					if(downloadLocation.isEmpty()) {
+					if (downloadLocation.isEmpty()) {
 						downloadLocation = "NONE";
 					}
 
 					// Invalid download location is output as NONE
-					if(SpdxVerificationHelper.verifyDownloadLocation(downloadLocation) != null) {
+					if (SpdxVerificationHelper.verifyDownloadLocation(downloadLocation) != null) {
 						downloadLocation = "NONE";
 					}
 
@@ -2887,17 +2887,17 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellLicenseDeclared = getCell(row, cellIdx); cellIdx++;
 
 					OssMaster _ossBean = null;
-					if(ossName.equals("-")) {
+					if (ossName.equals("-")) {
 						String licenseStr = CommonFunction.licenseStrToSPDXLicenseFormat(bean.getLicenseName());
 						cellLicenseDeclared.setCellValue(licenseStr);
 						attributionText = bean.getAttribution();
 					} else {
 						_ossBean = CoCodeManager.OSS_INFO_UPPER.get( (ossName + "_" + avoidNull(bean.getOssVersion())).toUpperCase());
 						
-						if(_ossBean != null) {
+						if (_ossBean != null) {
 							String licenseStr = CommonFunction.makeLicenseExpression(_ossBean.getOssLicenses(), false, true);
 	
-							if(_ossBean.getOssLicenses().size() > 1) {
+							if (_ossBean.getOssLicenses().size() > 1) {
 								licenseStr = "(" + licenseStr + ")";
 							}
 	
@@ -2914,21 +2914,21 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellLicenseConcluded = getCell(row, cellIdx); cellIdx++;
 					String srtLicenseName = "";
 					
-					for(OssComponentsLicense liBean : bean.getOssComponentsLicense()) {
-						if(!isEmpty(srtLicenseName)) {
+					for (OssComponentsLicense liBean : bean.getOssComponentsLicense()) {
+						if (!isEmpty(srtLicenseName)) {
 							srtLicenseName += " AND ";
 						}
 						
-						if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(liBean.getLicenseName()).toUpperCase())) {
+						if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(liBean.getLicenseName()).toUpperCase())) {
 							LicenseMaster liMaster = CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(liBean.getLicenseName()).toUpperCase());
 							
-							if(!isEmpty(liMaster.getShortIdentifier())) {
+							if (!isEmpty(liMaster.getShortIdentifier())) {
 								liBean.setLicenseName(liMaster.getShortIdentifier());
 							} else {
 								liBean.setLicenseName("LicenseRef-" + liBean.getLicenseName());
 							}
 							
-							if(!isEmpty(attributionText)) {
+							if (!isEmpty(attributionText)) {
 								attributionText += "\n";
 							}
 							
@@ -2939,7 +2939,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 						srtLicenseName += liBean.getLicenseName();
 					}
 					
-					if(!bean.getOssComponentsLicense().isEmpty() && bean.getOssComponentsLicense().size() > 1) {
+					if (!bean.getOssComponentsLicense().isEmpty() && bean.getOssComponentsLicense().size() > 1) {
 						srtLicenseName = "(" + srtLicenseName + ")";
 					}
 					
@@ -2948,9 +2948,9 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					// License Info From Files
 					Cell licenseInfoFromFiles = getCell(row, cellIdx); cellIdx++;
 
-					if(ossName.equals("-")) {
+					if (ossName.equals("-")) {
 						licenseInfoFromFiles.setCellValue(CommonFunction.licenseStrToSPDXLicenseFormat(bean.getLicenseName()));
-					} else if(_ossBean != null) {
+					} else if (_ossBean != null) {
 						licenseInfoFromFiles.setCellValue(CommonFunction.makeLicenseFromFiles(_ossBean, true)); // Declared & Detected License Info (중복제거)
 					} else {
 						licenseInfoFromFiles.setCellValue(""); // OSS Info가 없으므로 빈값이 들어감.
@@ -2963,7 +2963,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellPackageCopyrightText = getCell(row, cellIdx); cellIdx++;
 					String copyrightText = StringUtil.substring(CommonFunction.brReplaceToLine(bean.getCopyrightText()), 0, 32762);
 
-					if(copyrightText.isEmpty() || copyrightText.equals("-")) {
+					if (copyrightText.isEmpty() || copyrightText.equals("-")) {
 						copyrightText = "NOASSERTION";
 					}
 
@@ -2997,23 +2997,23 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				List<OssComponents> noticeList = (List<OssComponents>) packageInfo.get("noticeObligationList");
 				Map<String, LicenseMaster> nonIdetifierNoticeList = new HashMap<>();
 				
-				for(OssComponents ocBean : noticeList) {
+				for (OssComponents ocBean : noticeList) {
 					String ossName = ocBean.getOssName().replace("&#39;", "\'");
 
 					List<String> licenseList = new ArrayList<>();
-					if(ossName.equals("-")) {
+					if (ossName.equals("-")) {
 						licenseList = Arrays.asList(ocBean.getLicenseName());
 					} else {
 						OssMaster _ossBean = CoCodeManager.OSS_INFO_UPPER.get((ossName + "_" + avoidNull(ocBean.getOssVersion())).toUpperCase());
 						
-						if(_ossBean != null) {
+						if (_ossBean != null) {
 							licenseList = Arrays.asList(CommonFunction.makeLicenseFromFiles(_ossBean, false).split(","));
 						}
 					}
 					
-					for(String licenseNm : licenseList) {
+					for (String licenseNm : licenseList) {
 						LicenseMaster lmBean = CoCodeManager.LICENSE_INFO.get(licenseNm);
-						if(lmBean != null && isEmpty(lmBean.getShortIdentifier()) && !nonIdetifierNoticeList.containsKey(lmBean.getLicenseId())) {
+						if (lmBean != null && isEmpty(lmBean.getShortIdentifier()) && !nonIdetifierNoticeList.containsKey(lmBean.getLicenseId())) {
 							nonIdetifierNoticeList.put(lmBean.getLicenseId(), lmBean);
 						}
 					}
@@ -3021,12 +3021,12 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				
 				int rowIdx = 1;
 				
-				for(LicenseMaster bean : nonIdetifierNoticeList.values()) {
+				for (LicenseMaster bean : nonIdetifierNoticeList.values()) {
 					int cellIdx = 0;
 					
 					Row row = sheetLicense.getRow(rowIdx);
 					
-					if(row == null) {
+					if (row == null) {
 						row = sheetLicense.createRow(rowIdx);
 					}
 				
@@ -3060,21 +3060,21 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				List<OssComponents> noticeList = (List<OssComponents>) packageInfo.get("addOssComponentList");
 				List<OssComponents> nonIdetifierNoticeList = new ArrayList<>();
 				
-				for(OssComponents bean : noticeList) {
+				for (OssComponents bean : noticeList) {
 					// set false because "Per file info sheet" is not currently output
-					if("-".equals(bean.getOssName()) && false) {
+					if ("-".equals(bean.getOssName()) && false) {
 						nonIdetifierNoticeList.add(bean);
 					}
 				}
 				
 				int rowIdx = 1;
 				
-				for(OssComponents bean : nonIdetifierNoticeList) {
+				for (OssComponents bean : nonIdetifierNoticeList) {
 					int cellIdx = 0;
 					String attributionText = "";
 					Row row = sheetPerFile.getRow(rowIdx);
 					
-					if(row == null) {
+					if (row == null) {
 						row = sheetPerFile.createRow(rowIdx);
 					}
 				
@@ -3100,21 +3100,21 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					Cell cellLicenseConcluded = getCell(row, cellIdx); cellIdx++;
 					String srtLicenseName = "";
 					
-					for(OssComponentsLicense liBean : bean.getOssComponentsLicense()) {
-						if(!isEmpty(srtLicenseName)) {
+					for (OssComponentsLicense liBean : bean.getOssComponentsLicense()) {
+						if (!isEmpty(srtLicenseName)) {
 							srtLicenseName += " AND ";
 						}
 						
-						if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(liBean.getLicenseName()).toUpperCase())) {
+						if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(avoidNull(liBean.getLicenseName()).toUpperCase())) {
 							LicenseMaster liMaster = CoCodeManager.LICENSE_INFO_UPPER.get(avoidNull(liBean.getLicenseName()).toUpperCase());
 							
-							if(!isEmpty(liMaster.getShortIdentifier())) {
+							if (!isEmpty(liMaster.getShortIdentifier())) {
 								liBean.setLicenseName(liMaster.getShortIdentifier());
 							} else {
 								liBean.setLicenseName("LicenseRef-" + liBean.getLicenseName());
 							}
 							
-							if(!isEmpty(attributionText)) {
+							if (!isEmpty(attributionText)) {
 								attributionText += "\n";
 							}
 							
@@ -3126,7 +3126,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 						srtLicenseName += liBean.getLicenseName();
 					}
 					
-					if(!bean.getOssComponentsLicense().isEmpty() && bean.getOssComponentsLicense().size() > 1) {
+					if (!bean.getOssComponentsLicense().isEmpty() && bean.getOssComponentsLicense().size() > 1) {
 						srtLicenseName = "(" + srtLicenseName + ")";
 					}
 					
@@ -3178,11 +3178,11 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			{
 				int rowIdx = 1;
 				
-				for(String _identifierB : packageInfoidentifierList) {
+				for (String _identifierB : packageInfoidentifierList) {
 					int cellIdx = 0;
 					
 					Row row = sheetRelationships.getRow(rowIdx);
-					if(row == null) {
+					if (row == null) {
 						row = sheetRelationships.createRow(rowIdx);
 					}
 					// SPDX Identifier A
@@ -3203,7 +3203,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e) {}
@@ -3216,7 +3216,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 	private static Cell getCell(Row row, int cellIdx) {
 		Cell cell = row.getCell(cellIdx);
 		
-		if(cell == null) {
+		if (cell == null) {
 			cell = row.createCell(cellIdx);
 		}
 		
@@ -3261,7 +3261,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e) {}
@@ -3275,7 +3275,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		downloadpath = filepath;
 		String downloadId = null;
 		
-		if(isMaximumRowCheck(ossMapper.selectOssMasterTotalCount(oss))){
+		if (isMaximumRowCheck(ossMapper.selectOssMasterTotalCount(oss))){
 			oss.setStartIndex(0);
 			oss.setPageListSize(MAX_RECORD_CNT);
 			oss.setSearchFlag(CoConstDef.FLAG_NO); // 화면 검색일 경우 "Y" export시 "N"
@@ -3301,25 +3301,25 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			// 화면상에 편집가능한 path 정보를 제외하고는 componentid로 DB정보를 참조한다.
 			OssComponents param = new OssComponents();
 			
-			for(ProjectIdentification bean : verificationList) {
+			for (ProjectIdentification bean : verificationList) {
 				param.addOssComponentsIdList(bean.getComponentId());
 			}
 			
 			Map<String, OssComponents> dbDataMap = new HashMap<>();
 			List<OssComponents> list = projectService.selectOssComponentsListByComponentIds(param);
 			
-			if(list != null) {
-				for(OssComponents bean : list) {
+			if (list != null) {
+				for (OssComponents bean : list) {
 					dbDataMap.put(bean.getComponentId(), bean);
 				}
 			}
 			
 			List<String[]> rows = new ArrayList<>();
 			
-			for(ProjectIdentification bean : verificationList) {
+			for (ProjectIdentification bean : verificationList) {
 				OssComponents dbBean = null;
 				
-				if(dbDataMap.containsKey(bean.getComponentId())) {
+				if (dbDataMap.containsKey(bean.getComponentId())) {
 					dbBean = dbDataMap.get(bean.getComponentId());
 				}
 				
@@ -3342,7 +3342,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			return makeExcelFileId(wb,"PackagingOSSList");
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e) {
@@ -3367,7 +3367,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			List<Project> selfCheckList = selfCheckMapper.getSelfCheckList(project);
 			List<String[]> rows = new ArrayList<>();
 			
-			for(int i = 0; i < selfCheckList.size(); i++){
+			for (int i = 0; i < selfCheckList.size(); i++){
 				Project param = selfCheckList.get(i);
 				
 				String[] rowParam = {
@@ -3430,21 +3430,21 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			try {
 				Sheet vulnSheet = wb.getSheetAt(1);
 				
-				if(vulnSheet == null) {
+				if (vulnSheet == null) {
 					vulnSheet = wb.createSheet("Vulnerability");
 				}
 
 				List<Vulnerability> vulnList = selfCheckService.getAllVulnListWithProject(projectInfo.getPrjId());
 				List<String[]> vulnRows = new ArrayList<>();
 				
-				if(vulnList != null && !vulnList.isEmpty()) {
+				if (vulnList != null && !vulnList.isEmpty()) {
 					String _host = CommonFunction.emptyCheckProperty("server.domain", "http://fosslight.org");
-					for(Vulnerability vulnBean : vulnList) {
+					for (Vulnerability vulnBean : vulnList) {
 						List<String> params = new ArrayList<>();
 						String url = _host+"/vulnerability/vulnpopup?ossName=";
 												
 						// PRODUCT
-						if(!isEmpty(vulnBean.getOssName())) {
+						if (!isEmpty(vulnBean.getOssName())) {
 							// nick name에 의해 조회된 경우
 							params.add(vulnBean.getOssName());
 							params.add(avoidNull(vulnBean.getProduct()));
@@ -3461,7 +3461,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 						params.add(avoidNull(vulnBean.getCvssScore()));
 						// vulnpopup url
 						
-						if(!isEmpty(vulnBean.getVersion()) && !"-".equals(vulnBean.getVersion())) {
+						if (!isEmpty(vulnBean.getVersion()) && !"-".equals(vulnBean.getVersion())) {
 							url += "&ossVersion=" + vulnBean.getVersion(); // + "&vulnType=v"; 사용하지 않는 parameter
 						}
 												
@@ -3471,14 +3471,14 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 					}
 				}
 				
-				if(vulnRows != null && !vulnRows.isEmpty()) {
+				if (vulnRows != null && !vulnRows.isEmpty()) {
 					makeSheet(vulnSheet, vulnRows, 2, true);
 				}
 			} catch (Exception e) {
 				log.error(e.getMessage(), e);
 			}
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e) {}
@@ -3494,7 +3494,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		Sheet sheet = null;
 		String fileName = "VulnerabilityList";
 		
-		try(
+		try (
 			FileInputStream inFile= new FileInputStream(new File(downloadpath+"/VulnerabilityReport.xlsx"));
 		) {
 			try {wb = new XSSFWorkbook(inFile);} catch (IOException e) {log.error(e.getMessage());}
@@ -3504,7 +3504,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			List<String[]> rows = new ArrayList<>();
 			Set<String> ossName = new HashSet<>();
 
-			for(Vulnerability param : vulnerabilityList){
+			for (Vulnerability param : vulnerabilityList){
 				String[] rowParam = {
 					param.getProduct()
 					, param.getVersion()
@@ -3520,7 +3520,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			}
 			//시트 만들기
 			makeSheet(sheet, rows);
-			if(ossName.size() == 1) {
+			if (ossName.size() == 1) {
 				fileName += "_" + ossName.toString().substring(1,ossName.toString().length()-1);
 			}
 		} catch (FileNotFoundException e) {
@@ -3532,7 +3532,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 	private static boolean isMaximumRowCheck(int totalRow){
 		final String RowCnt = CoCodeManager.getCodeExpString(CoConstDef.CD_EXCEL_DOWNLOAD, CoConstDef.CD_MAX_ROW_COUNT);
 		
-		if(totalRow > Integer.parseInt(RowCnt)){
+		if (totalRow > Integer.parseInt(RowCnt)){
 			return false;
 		}
 		
@@ -3549,7 +3549,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		boolean projectUseFlag = CommonFunction.propertyFlagCheck("menu.project.use.flag", CoConstDef.FLAG_YES);
 		boolean partnerUseFlag = CommonFunction.propertyFlagCheck("menu.partner.use.flag", CoConstDef.FLAG_YES);
 		
-		if(projectUseFlag) {
+		if (projectUseFlag) {
 			ChartData.setCategoryType("STT");
 			result = (Statistics) statisticsService.getDivisionalProjectChartData(ChartData).get("chartData");
 			
@@ -3577,7 +3577,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		
 		chartDataMap.put("updatedLicenseChart", (Statistics) statisticsService.getUpdatedLicenseChartData(ChartData).get("chartData"));
 		
-		if(partnerUseFlag) {
+		if (partnerUseFlag) {
 			ChartData.setCategoryType("3rdSTT");
 			result = (Statistics) statisticsService.getTrdPartyRelatedChartData(ChartData).get("chartData");
 			
@@ -3613,8 +3613,8 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			inFile= new FileInputStream(new File(downloadpath+"/chartDataList.xlsx"));
 			wb = new XSSFWorkbook(inFile);
 			String[] sheetIdxList = new String[] {"divisionalProjectChart", "mostUsedOssChart", "mostUsedLicenseChart", "updatedOssChart", "updatedLicenseChart", "trdPartyRelatedChart", "userRelatedChart"};
-			if(chartDataMap != null && !chartDataMap.isEmpty()) {
-				for(String key : chartDataMap.keySet()) {
+			if (chartDataMap != null && !chartDataMap.isEmpty()) {
+				for (String key : chartDataMap.keySet()) {
 					String chartName = key;
 					int idx = 1;
 					sheet = wb.getSheetAt((int) Arrays.asList(sheetIdxList).indexOf(chartName));
@@ -3630,7 +3630,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 							Statistics chartData = (Statistics) chartDataMap.get(chartName);
 							List<String> divisionList = new ArrayList<String>();
 							
-							if(!chartName.startsWith("updated")) {
+							if (!chartName.startsWith("updated")) {
 								divisionList = CoCodeManager.getCodeNames(CommonFunction.getCoConstDefVal("CD_USER_DIVISION"));
 							}
 							
@@ -3639,24 +3639,24 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 							params.add("NO");  // seq
 							params.add(!chartName.startsWith("updated") ? "Division" : "Date"); // divisionNm
 							
-							for(String title : chartData.getTitleArray()) {
+							for (String title : chartData.getTitleArray()) {
 								params.add(title); // category
 							}
 							
 							rows.add(params.toArray(new String[params.size()]));
 							
 							/* Data */
-							for(int seq = 0, length = chartData.getDataArray().get(0).size() ; seq < length ; seq++) {
+							for (int seq = 0, length = chartData.getDataArray().get(0).size() ; seq < length ; seq++) {
 								params = new ArrayList<>();
 								params.add(Integer.toString(idx));  // seq
 								
-								if(!chartName.startsWith("updated")) {
+								if (!chartName.startsWith("updated")) {
 									params.add(divisionList.get(seq)); // category
 								}else {
 									params.add(chartData.getCategoryList().get(seq)); // category
 								}
 								
-								for(List<Integer> arr : chartData.getDataArray()) {
+								for (List<Integer> arr : chartData.getDataArray()) {
 									params.add(Integer.toString(arr.get(seq))); // category Cnt
 								}
 								
@@ -3676,7 +3676,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 							
 							rows.add(params.toArray(new String[params.size()]));
 							
-							for(Statistics stat : (List<Statistics>) chartDataMap.get(chartName)) {
+							for (Statistics stat : (List<Statistics>) chartDataMap.get(chartName)) {
 								params = new ArrayList<>();
 								params.add(Integer.toString(idx));  // seq
 								params.add(stat.getColumnName());	// OSS Name || License Name
@@ -3697,7 +3697,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 							
 							rows.add(params.toArray(new String[params.size()]));
 							
-							for(Statistics stat : (List<Statistics>) chartDataMap.get(chartName)) {
+							for (Statistics stat : (List<Statistics>) chartDataMap.get(chartName)) {
 								params = new ArrayList<>();
 								params.add(Integer.toString(idx));  // seq
 								params.add(stat.getDivisionNm());	// Division
@@ -3719,7 +3719,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -3744,7 +3744,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			
 			List<String[]> rows = new ArrayList<>();
 
-			for(OssAnalysis param : analysisList){
+			for (OssAnalysis param : analysisList){
 				String[] rowParam = {
 					param.getGridId()
 					, param.getOssName()
@@ -3762,7 +3762,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (FileNotFoundException e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(inFile != null) {
+			if (inFile != null) {
 				try {
 					inFile.close();
 				} catch (Exception e2) {
@@ -3819,7 +3819,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 				log.error(e.getMessage(), e);
 			}
 			
-			if((List<ProjectIdentification>) beforeBom.get("rows") == null || (List<ProjectIdentification>) afterBom.get("rows") == null) {// before, after값 중 하나라도 null이 있으면 비교 불가함. 
+			if ((List<ProjectIdentification>) beforeBom.get("rows") == null || (List<ProjectIdentification>) afterBom.get("rows") == null) {// before, after값 중 하나라도 null이 있으면 비교 불가함. 
 				throw new Exception(); 
 			}
 			
@@ -3834,7 +3834,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			  
 				List<String[]> rows = new ArrayList<String[]>();
 			  
-				for(int i = 0; i < bomCompareListExcel.size(); i++){ 
+				for (int i = 0; i < bomCompareListExcel.size(); i++){ 
 					String[] rowParam = {
 							bomCompareListExcel.get(i).get("status"),
 							bomCompareListExcel.get(i).get("beforeossname"),
@@ -3850,7 +3850,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 			} catch (FileNotFoundException e) {
 				log.error(e.getMessage(), e); 
 			} finally { 
-				if(inFile != null) { 
+				if (inFile != null) { 
 					try {inFile.close();} 
 					catch (Exception e2) {} 
 				}
@@ -3872,7 +3872,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		FileOutputStream outFile = null;
 		
 		try {
-			if(!Files.exists(Paths.get(excelFilePath))) {
+			if (!Files.exists(Paths.get(excelFilePath))) {
 				Files.createDirectories(Paths.get(excelFilePath));
 			}
 			outFile = new FileOutputStream(excelFilePath + logiFileName);
@@ -3883,7 +3883,7 @@ public class ExcelDownLoadUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(outFile != null) {
+			if (outFile != null) {
 				try {
 					outFile.close();
 				} catch (Exception e2) {}

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -96,13 +96,13 @@ public class ExcelUtil extends CoTopComponent {
 		String codeExt[] = StringUtil.split(codeMapper.selectExtType("12"),",");
 		int count = 0;
 		
-		for(int i = 0; i < codeExt.length; i++){
-			if(codeExt[i].equalsIgnoreCase(extType)){
+		for (int i = 0; i < codeExt.length; i++){
+			if (codeExt[i].equalsIgnoreCase(extType)){
 				count++;
 			};
 		}
 		
-		if(count != 1) {
+		if (count != 1) {
 			sheetNameList = null;
 		} else {
 			File file = new File(excelLocalPath + "/" + fileName);
@@ -113,12 +113,12 @@ public class ExcelUtil extends CoTopComponent {
 				wb = WorkbookFactory.create(file);
 				int sheetNum = wb.getNumberOfSheets();
 				
-				for(int i = 0; i < sheetNum; i++){
+				for (int i = 0; i < sheetNum; i++){
 					String no = String.valueOf(i);
 					String name = wb.getSheetName(i);
 					
 					// Excel내 sheet이름이 "."으로 시작되는 경우 (예: .Data), 사용자가 선택하도록 보여주는 list에서 제외하여 주시기 바랍니다.
-					if(avoidNull(name).trim().startsWith(".")) {
+					if (avoidNull(name).trim().startsWith(".")) {
 						continue;
 					}
 					
@@ -143,7 +143,7 @@ public class ExcelUtil extends CoTopComponent {
 		Iterator<String> fileNames = req.getFileNames();
 		List<OssComponents> ossList = new ArrayList<OssComponents>();
 		
-		while(fileNames.hasNext()){
+		while (fileNames.hasNext()){
 			//파일 만들기
 			MultipartFile multipart = req.getFile(fileNames.next());
 			String fileName = multipart.getOriginalFilename();
@@ -162,7 +162,7 @@ public class ExcelUtil extends CoTopComponent {
 			
 			if (extType.isEmpty()) {
 				return null;
-			} else if("xls".equals(extType) || "XLS".equals(extType)) {
+			} else if ("xls".equals(extType) || "XLS".equals(extType)) {
 				try{
 					wbHSSF = new HSSFWorkbook(new FileInputStream(file));
 					
@@ -171,7 +171,7 @@ public class ExcelUtil extends CoTopComponent {
 					String originalCom = "";
 					int totalSize = 0;
 					
-					for(rowindex = 0; rowindex < sheet.getPhysicalNumberOfRows(); rowindex++) {
+					for (rowindex = 0; rowindex < sheet.getPhysicalNumberOfRows(); rowindex++) {
 						HSSFRow row = sheet.getRow(rowindex);
 						int maxcols = row.getLastCellNum();
 						OssComponents ossCom = new OssComponents();
@@ -179,50 +179,50 @@ public class ExcelUtil extends CoTopComponent {
 						//다중 라이센스 여부
 						String emptyYN = CoConstDef.FLAG_NO;
 						
-						for(colindex = 0; colindex < maxcols; colindex++) {
+						for (colindex = 0; colindex < maxcols; colindex++) {
 							HSSFCell cell = row.getCell(colindex);
 							String value = getCellData(cell);
 							
-							if(rowindex != 0){
+							if (rowindex != 0){
 								//oss name
-								if(colindex == 1) {
-									if("null".equals(value) || "".equals(value)){
+								if (colindex == 1) {
+									if ("null".equals(value) || "".equals(value)){
 										emptyYN = CoConstDef.FLAG_YES;
 									}else{
 										ossCom.setOssName(value);	
 									}
-								} else if(colindex == 2) { // oss version
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 2) { // oss version
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossCom.setOssVersion(value);
 									}
-								} else if(colindex == 3) { // download location
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 3) { // download location
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossCom.setDownloadLocation(value);
 									}
-								} else if(colindex == 4) { // homepage
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 4) { // homepage
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossCom.setHomepage(value);
 									}
-								} else if(colindex == 5){ // license
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 5){ // license
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossLicense.setLicenseName(value);
 									}
-								} else if(colindex == 6){ // license text
-									if("null".equals(value) || "".equals(value)){
+								} else if (colindex == 6){ // license text
+									if ("null".equals(value) || "".equals(value)){
 									} else {
 										ossLicense.setLicenseText(value);
 									}
-								} else if(colindex == 7) { // copyright text
-									if("null".equals(value) || "".equals(value)){
+								} else if (colindex == 7) { // copyright text
+									if ("null".equals(value) || "".equals(value)){
 									} else {
 										ossLicense.setCopyrightText(value);
 									}
-								} else if(colindex == 8) { // path or file
-									if("null".equals(value) || "".equals(value)){
+								} else if (colindex == 8) { // path or file
+									if ("null".equals(value) || "".equals(value)){
 									} else {
 										ossCom.setFilePath(value);
 									}
@@ -230,16 +230,16 @@ public class ExcelUtil extends CoTopComponent {
 							}
 						}
 						
-						if(rowindex == 1) {
+						if (rowindex == 1) {
 							ossList.add(ossCom);
 							ossLicList.add(ossLicense);
 							originalCom = "0";
 							totalSize = 0;
-						} else if(rowindex == 0) {
+						} else if (rowindex == 0) {
 							
 						} else {
-							if(rowindex == sheet.getPhysicalNumberOfRows()) {
-								if(CoConstDef.FLAG_YES.equals(emptyYN)) {
+							if (rowindex == sheet.getPhysicalNumberOfRows()) {
+								if (CoConstDef.FLAG_YES.equals(emptyYN)) {
 									ossLicList.add(ossLicense);
 									ossList.get(totalSize-1).setOssComponentsLicense(new ArrayList<OssComponentsLicense>());
 									ossList.get(totalSize-1).getOssComponentsLicense().addAll(ossLicList);
@@ -254,13 +254,13 @@ public class ExcelUtil extends CoTopComponent {
 									ossList.get(totalSize).getOssComponentsLicense().addAll(ossLicList);
 								}
 							} else {
-								if(CoConstDef.FLAG_YES.equals(emptyYN)){
+								if (CoConstDef.FLAG_YES.equals(emptyYN)){
 									ossLicList.add(ossLicense);
 								} else {
 									ossList.add(ossCom);
 									totalSize = totalSize+1;
 									
-									if("".equals(originalCom)){
+									if ("".equals(originalCom)){
 										ossList.get(totalSize-1).setOssComponentsLicense(new ArrayList<OssComponentsLicense>());
 										ossList.get(totalSize-1).getOssComponentsLicense().addAll(ossLicList);
 									} else {
@@ -283,7 +283,7 @@ public class ExcelUtil extends CoTopComponent {
 						wbHSSF.close();
 					}catch(Exception e) {}
 				}
-			} else if("xlsx".equals(extType) || "XLSX".equals(extType)) {
+			} else if ("xlsx".equals(extType) || "XLSX".equals(extType)) {
 				try{
 					wbXSSF = new XSSFWorkbook(new FileInputStream(file));
 					
@@ -292,7 +292,7 @@ public class ExcelUtil extends CoTopComponent {
 					String originalCom = "";
 					int totalSize = 0;
 					
-					for(rowindex = 0; rowindex <= sheet.getPhysicalNumberOfRows(); rowindex++){
+					for (rowindex = 0; rowindex <= sheet.getPhysicalNumberOfRows(); rowindex++){
 						XSSFRow row = sheet.getRow(rowindex);
 						int maxcols = row.getLastCellNum();
 						OssComponents ossCom = new OssComponents();
@@ -300,49 +300,49 @@ public class ExcelUtil extends CoTopComponent {
 						//다중 라이센스 여부
 						String emptyYN = CoConstDef.FLAG_NO;
 						
-						for(colindex = 0; colindex < maxcols; colindex++){
+						for (colindex = 0; colindex < maxcols; colindex++){
 							XSSFCell cell = row.getCell(colindex);
 							String value = getCellData(cell);
 							
-							if(rowindex != 0){
-								if(colindex == 1){ // oss name
-									if("null".equals(value) || "".equals(value)) {
+							if (rowindex != 0){
+								if (colindex == 1){ // oss name
+									if ("null".equals(value) || "".equals(value)) {
 										emptyYN = CoConstDef.FLAG_YES;
 									} else {
 										ossCom.setOssName(value);	
 									}
-								} else if(colindex == 2) { // oss version
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 2) { // oss version
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossCom.setOssVersion(value);
 									}
-								} else if(colindex == 3) { // download location
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 3) { // download location
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossCom.setDownloadLocation(value);
 									}
-								} else if(colindex == 4) { // homepage
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 4) { // homepage
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossCom.setHomepage(value);
 									}
-								} else if(colindex == 5) { // license
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 5) { // license
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossLicense.setLicenseName(value);
 									}
-								} else if(colindex == 6) { // license text
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 6) { // license text
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossLicense.setLicenseText(value);
 									}
-								} else if(colindex == 7) { // copyright text
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 7) { // copyright text
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossLicense.setCopyrightText(value);
 									}
-								} else if(colindex == 8) { // path or file
-									if("null".equals(value) || "".equals(value)) {
+								} else if (colindex == 8) { // path or file
+									if ("null".equals(value) || "".equals(value)) {
 									} else {
 										ossCom.setFilePath(value);
 									}
@@ -350,16 +350,16 @@ public class ExcelUtil extends CoTopComponent {
 							}
 						}
 						
-						if(rowindex == 1){
+						if (rowindex == 1){
 							ossList.add(ossCom);
 							ossLicList.add(ossLicense);
 							originalCom = "0";
 							totalSize = 0;
-						} else if(rowindex == 0) {
+						} else if (rowindex == 0) {
 							
 						} else {
-							if(rowindex == sheet.getPhysicalNumberOfRows()) {
-								if(CoConstDef.FLAG_YES.equals(emptyYN)){
+							if (rowindex == sheet.getPhysicalNumberOfRows()) {
+								if (CoConstDef.FLAG_YES.equals(emptyYN)){
 									ossLicList.add(ossLicense);
 									ossList.get(totalSize-1).setOssComponentsLicense(new ArrayList<OssComponentsLicense>());
 									ossList.get(totalSize-1).getOssComponentsLicense().addAll(ossLicList);
@@ -374,13 +374,13 @@ public class ExcelUtil extends CoTopComponent {
 									ossList.get(totalSize).getOssComponentsLicense().addAll(ossLicList);
 								}
 							} else {
-								if(CoConstDef.FLAG_YES.equals(emptyYN)) {
+								if (CoConstDef.FLAG_YES.equals(emptyYN)) {
 									ossLicList.add(ossLicense);
 								} else {
 									ossList.add(ossCom);
 									totalSize = totalSize+1;
 									
-									if("".equals(originalCom)) {
+									if ("".equals(originalCom)) {
 										ossList.get(totalSize-1).setOssComponentsLicense(new ArrayList<OssComponentsLicense>());
 										ossList.get(totalSize-1).getOssComponentsLicense().addAll(ossLicList);
 									} else {
@@ -412,16 +412,16 @@ public class ExcelUtil extends CoTopComponent {
 	public static String getCellData(HSSFCell cell) {
 		String value = "";
 		
-		if(cell == null) {
+		if (cell == null) {
 			value = null;
 		} else {
 			CellType cellType = cell.getCellType();
 			switch (cellType) {
 				case FORMULA:
-					if(CellType.NUMERIC == cell.getCachedFormulaResultType()) {
+					if (CellType.NUMERIC == cell.getCachedFormulaResultType()) {
 						cell.setCellType(CellType.STRING);
 						value = cell.getStringCellValue();	
-					} else if(CellType.STRING == cell.getCachedFormulaResultType()) {
+					} else if (CellType.STRING == cell.getCachedFormulaResultType()) {
 						value = cell.getStringCellValue();	
 					}
 					
@@ -454,17 +454,17 @@ public class ExcelUtil extends CoTopComponent {
 	public static String getCellData(XSSFCell cell) {
 		String value = "";
 		
-		if(cell == null) {
+		if (cell == null) {
 			value = null;
 		} else {
 			CellType cellType = cell.getCellType();
 			
 			switch (cellType) {
 				case FORMULA:
-					if(CellType.NUMERIC == cell.getCachedFormulaResultType()) {
+					if (CellType.NUMERIC == cell.getCachedFormulaResultType()) {
 						cell.setCellType(CellType.STRING);
 						value = cell.getStringCellValue();	
-					} else if(CellType.STRING == cell.getCachedFormulaResultType()) {
+					} else if (CellType.STRING == cell.getCachedFormulaResultType()) {
 						value = cell.getStringCellValue();	
 					}
 					
@@ -508,18 +508,18 @@ public class ExcelUtil extends CoTopComponent {
 	        List<OssComponents> list,List<String> errMsgList) {
 		
 		T2File fileInfo = fileService.selectFileInfo(fileSeq);
-		if(fileInfo == null) {
+		if (fileInfo == null) {
 			log.error("파일정보를 찾을 수 없습니다. fileSeq : " + avoidNull(fileSeq));
 			errMsgList.add("파일 정보를 찾을 수 없습니다.");
 			return false;
 		}
-		if(!Arrays.asList("XLS", "XLSX", "XLSM", "CSV").contains(avoidNull(fileInfo.getExt()).toUpperCase())) {
+		if (!Arrays.asList("XLS", "XLSX", "XLSM", "CSV").contains(avoidNull(fileInfo.getExt()).toUpperCase())) {
 			log.error("허용하지 않는 파일 입니다. fileSeq : " + avoidNull(fileSeq));
 			errMsgList.add("허용하지 않는 파일 입니다.");
 			return false;
 		}
 		File file = new File(fileInfo.getLogiPath() + "/" + fileInfo.getLogiNm());
-		if(!file.exists() || !file.isFile()) {
+		if (!file.exists() || !file.isFile()) {
 			log.error("파일정보를 찾을 수 없습니다. fileSeq : " + avoidNull(fileSeq));
 			errMsgList.add("파일 정보를 찾을 수 없습니다.");
 			return false;
@@ -533,7 +533,7 @@ public class ExcelUtil extends CoTopComponent {
 			 	다만, 확장자를 변경시 정상동작을 하고 있어서 해당 code는 주석처리를 해둠.
 			    //ZipSecureFile.setMinInflateRatio(-1.0d);
 			 */
-			if(fileInfo.getExt().equals("csv")) {
+			if (fileInfo.getExt().equals("csv")) {
 				wb = CsvUtil.csvFileToExcelWorkbook(file, readType);
 			} else {
 				wb = WorkbookFactory.create(file);
@@ -554,15 +554,15 @@ public class ExcelUtil extends CoTopComponent {
 				List<String> targetSheetNumsArrayList = new ArrayList<String>();
 
 				int idx = 0;
-				for(String sheetName : sheetNames){
-					for(String type : types){
-						if(sheetName.startsWith(type)){
+				for (String sheetName : sheetNames){
+					for (String type : types){
+						if (sheetName.startsWith(type)){
 							targetSheetNumsArrayList.add(Integer.toString(idx));
 						}
 					}
 					idx++;
 				}
-				if(targetSheetNumsArrayList.isEmpty()){
+				if (targetSheetNumsArrayList.isEmpty()){
 					targetSheetNums[0] = "-1";
 				}else{
 					targetSheetNums = targetSheetNumsArrayList.toArray(new String[0]);
@@ -570,51 +570,51 @@ public class ExcelUtil extends CoTopComponent {
 
 			}
 			
-			if(hasFileListSheet(targetSheetNums, wb)) {
+			if (hasFileListSheet(targetSheetNums, wb)) {
 				// 1. final list sheet data 취득
 				Sheet sheet = wb.getSheet("Final List");
 				Map<String, String> finalListErrMsg = new HashMap<>();
 				finalListErrMsg = readSheet(sheet, list, true, readType, errMsgList);
-				if(!finalListErrMsg.isEmpty()) {
+				if (!finalListErrMsg.isEmpty()) {
 					errList.add(finalListErrMsg);
 				}
 				Map<String, OssComponents> allDataMap = new HashMap<>();
 				// path 경로 확인
-				if(!list.isEmpty()) {
+				if (!list.isEmpty()) {
 					// 모든 시트의 정보를 읽는다.(No는 중복될 수 없다는 전제)
 					for (int i = 0; i < wb.getNumberOfSheets(); i++) {
 						// final list는 제외
 						Sheet _sheet = wb.getSheetAt(i);
-						if("Final List".equalsIgnoreCase(_sheet.getSheetName())) {
+						if ("Final List".equalsIgnoreCase(_sheet.getSheetName())) {
 							continue;
 						}
 						List<OssComponents> _list = new ArrayList<>();
 						Map<String, String> errMsg = new HashMap<>();
 						errMsg = readSheet(_sheet, _list, true, readType, errMsgList);
-						if(!errMsg.isEmpty()) {
+						if (!errMsg.isEmpty()) {
 							errList.add(errMsg);
 						}
-						for(OssComponents data : _list) {
+						for (OssComponents data : _list) {
 							 allDataMap.put(data.getReportKey(), data);
 						}
 					}
 					
 					// ref col에서 참조하고 있는 File path가 다른 경우
 					List<OssComponents> addDiffRefList = new ArrayList<>();
-					for(OssComponents bean : list) {
-						if(bean.getFinalListRefList() != null && !bean.getFinalListRefList().isEmpty()) {
+					for (OssComponents bean : list) {
+						if (bean.getFinalListRefList() != null && !bean.getFinalListRefList().isEmpty()) {
 							
 							// file 단위로 입력되어 있기 때문에, ref col 이 1개 이상일 경우 path단위로 그룹핑
-							if(bean.getFinalListRefList().size() > 1) {
+							if (bean.getFinalListRefList().size() > 1) {
 								List<String> _keyList = new ArrayList<>();
-								for(String refKey : bean.getFinalListRefList()) {
-									if(allDataMap.containsKey(refKey)) {
+								for (String refKey : bean.getFinalListRefList()) {
+									if (allDataMap.containsKey(refKey)) {
 										// file 단위로 입력되어 있기 때문에, ref col 이 1개 이상일 경우 path단위로 그룹핑
 										// path 취득
 										String _path = allDataMap.get(refKey).getFilePath();
 										
-										if(!_keyList.contains(_path)) {
-											if(!isEmpty(bean.getFilePath()) && !_keyList.contains(bean.getFilePath())) {
+										if (!_keyList.contains(_path)) {
+											if (!isEmpty(bean.getFilePath()) && !_keyList.contains(bean.getFilePath())) {
 												addDiffRefList.add(bean);
 											} else {
 												bean.setFilePath(_path);
@@ -625,7 +625,7 @@ public class ExcelUtil extends CoTopComponent {
 								}	
 							} else {
  								String refKey = bean.getFinalListRefList().get(0);
-								if(allDataMap.containsKey(refKey)) {
+								if (allDataMap.containsKey(refKey)) {
 									bean.setFilePath(allDataMap.get(refKey).getFilePath());	
 								}
 							}
@@ -633,7 +633,7 @@ public class ExcelUtil extends CoTopComponent {
 						}
 					}
 					
-					if(!addDiffRefList.isEmpty()) {
+					if (!addDiffRefList.isEmpty()) {
 						list.addAll(addDiffRefList);
 					}
 					
@@ -641,19 +641,19 @@ public class ExcelUtil extends CoTopComponent {
 				// 2. ref sheet
 			} else {
 				for (String sheetIdx : targetSheetNums) {
-					if(StringUtil.isNotNumeric(sheetIdx)) {
+					if (StringUtil.isNotNumeric(sheetIdx)) {
 						continue;
 					}
 					// get target sheet
 					Sheet sheet = wb.getSheetAt(StringUtil.string2integer(sheetIdx));
 					Map<String, String> errMsg = new HashMap<>();
 					errMsg = readSheet(sheet, list, false, readType, errMsgList);
-					if(!errMsg.isEmpty()) {
+					if (!errMsg.isEmpty()) {
 						errList.add(errMsg);
 					}
 				}				
 			}
-			if(!errList.isEmpty()) { // sheet 별로 저장 된 에러 메시지를 에러 종류 별로 재 가공
+			if (!errList.isEmpty()) { // sheet 별로 저장 된 에러 메시지를 에러 종류 별로 재 가공
 				String returnMsg = "";
 				String missHeader = "";
 				List<String> dupCol = new ArrayList<>();
@@ -661,45 +661,45 @@ public class ExcelUtil extends CoTopComponent {
 				List<String> errRow = new ArrayList<>();
 				String emptySheet = "";
 				boolean newLineYn = false;
-				for(Map<String, String> item : errList) {
+				for (Map<String, String> item : errList) {
 					missHeader += item.containsKey("missHeader")?(isEmpty(missHeader)?"":", ").concat(item.get("missHeader")):"";
-					if(item.containsKey("dupCol")) {
+					if (item.containsKey("dupCol")) {
 						dupCol.add(item.get("dupCol"));
 					}
-					if(item.containsKey("reqCol")) {
+					if (item.containsKey("reqCol")) {
 						reqCol.add(item.get("reqCol"));
 					}
-					if(item.containsKey("errRow")) {
+					if (item.containsKey("errRow")) {
 						errRow.add(item.get("errRow"));
 					}
 					emptySheet += item.containsKey("emptySheet")?(isEmpty(emptySheet)?"":", ").concat(item.get("emptySheet")):"";
 				}
-				if(!isEmpty(missHeader)) {
+				if (!isEmpty(missHeader)) {
 					returnMsg += "Can not found Header Row, Sheet Name : [".concat(missHeader).concat("]");
 					newLineYn = true;
 				}
-				if(!dupCol.isEmpty()) {
+				if (!dupCol.isEmpty()) {
 					returnMsg += newLineYn?"<br/><br/>":"";
-					for(int i = 0 ; i < dupCol.size() ; i++) {
+					for (int i = 0 ; i < dupCol.size() ; i++) {
 						returnMsg += (i==0?"":"<br/>").concat(dupCol.get(i));
 					}
 					newLineYn = true;
 				}
-				if(!reqCol.isEmpty()) {
+				if (!reqCol.isEmpty()) {
 					returnMsg += newLineYn?"<br/><br/>":"";
-					for(int i = 0 ; i < reqCol.size() ; i++) {
+					for (int i = 0 ; i < reqCol.size() ; i++) {
 						returnMsg += (i==0?"":"<br/>").concat(reqCol.get(i));
 					}
 					newLineYn = true;
 				}
-				if(!errRow.isEmpty()) {
+				if (!errRow.isEmpty()) {
 					returnMsg += newLineYn?"<br/><br/>":"";
-					for(int i = 0 ; i < errRow.size() ; i++) {
+					for (int i = 0 ; i < errRow.size() ; i++) {
 						returnMsg += (i==0?"":"<br/>").concat(errRow.get(i));
 					}
 					newLineYn = true;
 				}
-				if(!isEmpty(emptySheet)) {
+				if (!isEmpty(emptySheet)) {
 					returnMsg += newLineYn?"<br/><br/>":"";
 					returnMsg += "There are no OSS listed. Sheet Name : [".concat(emptySheet).concat("]");
 					returnMsg += "<br><br>";
@@ -731,7 +731,7 @@ public class ExcelUtil extends CoTopComponent {
 		
 		
 		// 사용자 입력 값을 기준으로 OSS Master 정보를 비교 ID를 설정한다.
-		if(checkId && list != null && !list.isEmpty()) {
+		if (checkId && list != null && !list.isEmpty()) {
 
 			// AutoIdentification  처리중 라이선스명이 사용자설정 명칭(닉네임)이 DB에 등록된 정식명칭등으로 치환되는 내용을 사용자에게 표시하기 위해 
 			// 엑셀 파일의 원본 내용을 보관한다.
@@ -786,8 +786,8 @@ public class ExcelUtil extends CoTopComponent {
 		
 		DefaultHeaderRowIndex = findHeaderRowIndex(sheet);
 		
-		if(DefaultHeaderRowIndex < 0) {
-			if(!readNoCol) {
+		if (DefaultHeaderRowIndex < 0) {
+			if (!readNoCol) {
 				log.warn("Can not found Header Row, Sheet Name : " + sheet.getSheetName());
 				errMsg.put("missHeader", sheet.getSheetName());
 			}
@@ -809,7 +809,7 @@ public class ExcelUtil extends CoTopComponent {
 					case "OSS NAME ( OPEN SOURCE SOFTWARE NAME )":
 					case "OSS COMPONENT":
 					case "PACKAGE NAME":
-						if(ossNameCol > -1) {
+						if (ossNameCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -818,7 +818,7 @@ public class ExcelUtil extends CoTopComponent {
 						break;
 					case "OSS VERSION":
 					case "PACKAGE VERSION":
-						if(ossVersionCol > -1) {
+						if (ossVersionCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -827,7 +827,7 @@ public class ExcelUtil extends CoTopComponent {
 						break;
 					case "DOWNLOAD LOCATION":
 					case "PACKAGE DOWNLOAD LOCATION":
-						if(downloadLocationCol > -1) {
+						if (downloadLocationCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -837,7 +837,7 @@ public class ExcelUtil extends CoTopComponent {
 					case "HOMEPAGE":
 					case "OSS WEBSITE":
 					case "HOME PAGE":
-						if(homepageCol > -1) {
+						if (homepageCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -846,7 +846,7 @@ public class ExcelUtil extends CoTopComponent {
 						break;
 					case "LICENSE":
 					case "LICENSE CONCLUDED":
-						if(licenseCol > -1) {
+						if (licenseCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -854,7 +854,7 @@ public class ExcelUtil extends CoTopComponent {
 						
 						break;
 					case "LICENSE TEXT":
-						if(licenseTextCol > -1) {
+						if (licenseTextCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -865,7 +865,7 @@ public class ExcelUtil extends CoTopComponent {
 					case "COPYRIGHT & LICENSE":
 					case "PACKAGE COPYRIGHT TEXT":
 					case "FILE COPYRIGHT TEXT":
-						if(copyrightTextCol > -1) {
+						if (copyrightTextCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -882,26 +882,26 @@ public class ExcelUtil extends CoTopComponent {
 					case "BINARY NAME OR (IF DELIVERY FORM IS SOURCE CODE) SOURCE PATH":
 					case "FILE NAME OR PATH":
 					case "SOURCE NAME OR PATH":
-						if(pathOrFileCol > -1) {
+						if (pathOrFileCol > -1) {
 							dupColList.add(value);
 						}
 						pathOrFileCol = colIdx;
 						break;
 					case "BINARY NAME OR SOURCE PATH":
-						if("BIN".equalsIgnoreCase(readType)) {
-							if(binaryNameCol > -1) {
+						if ("BIN".equalsIgnoreCase(readType)) {
+							if (binaryNameCol > -1) {
 								dupColList.add(value);
 							}
 							binaryNameCol = colIdx;
 						} else {
-							if(pathOrFileCol > -1) {
+							if (pathOrFileCol > -1) {
 								dupColList.add(value);
 							}
 							pathOrFileCol = colIdx;
 						}
 						break;
 					case "LOADED ON PRODUCT":
-						if(loadOnProductCol > -1) {
+						if (loadOnProductCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -909,7 +909,7 @@ public class ExcelUtil extends CoTopComponent {
 						
 						break;
 					case "REF. COLUMNS":
-						if(finalListRefCol > -1) {
+						if (finalListRefCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -918,7 +918,7 @@ public class ExcelUtil extends CoTopComponent {
 						break;
 					case "NO":
 					case "ID":
-						if(noCol > -1) {
+						if (noCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -928,7 +928,7 @@ public class ExcelUtil extends CoTopComponent {
 					case "BINARY FILE":
 					case "BINARY/LIBRARY FILE":
 					case "BINARY NAME":
-						if(binaryNameCol > -1) {
+						if (binaryNameCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -936,7 +936,7 @@ public class ExcelUtil extends CoTopComponent {
 						
 						break;
 					case "EXCLUDE":
-						if(excludeCol > -1) {
+						if (excludeCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -945,7 +945,7 @@ public class ExcelUtil extends CoTopComponent {
 						break;
 					case "COMMENT":
 					case "LICENSE COMMENTS":
-						if(commentCol > -1) {
+						if (commentCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -953,7 +953,7 @@ public class ExcelUtil extends CoTopComponent {
 						
 						break;
 					case "NICK NAME":
-						if(nickNameCol > -1) {
+						if (nickNameCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -961,13 +961,13 @@ public class ExcelUtil extends CoTopComponent {
 						
 						break;
 					case "FILE NAME":
-						if(binaryNameCol > -1) {
+						if (binaryNameCol > -1) {
 							dupColList.add(value);
 						}
 						
 						binaryNameCol = colIdx;
 						
-						if(pathOrFileCol > -1) {
+						if (pathOrFileCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -975,7 +975,7 @@ public class ExcelUtil extends CoTopComponent {
 						
 						break;
 					case "PACKAGE IDENTIFIER":
-						if(packageIdentifierCol > -1) {
+						if (packageIdentifierCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -983,7 +983,7 @@ public class ExcelUtil extends CoTopComponent {
 						
 						break;
 					case "SPDX IDENTIFIER":
-						if(spdxIdentifierCol > -1) {
+						if (spdxIdentifierCol > -1) {
 							dupColList.add(value);
 						}
 						
@@ -996,7 +996,7 @@ public class ExcelUtil extends CoTopComponent {
 			}
 			
 			// header 중복 체크
-			if(!dupColList.isEmpty()) {
+			if (!dupColList.isEmpty()) {
 				String msg = dupColList.toString();
 				msg = "There are duplicated. Sheet Name : [".concat(sheet.getSheetName()).concat("],  Filed Name : ").concat(msg);
 				
@@ -1005,20 +1005,20 @@ public class ExcelUtil extends CoTopComponent {
 			
 			// 필수 header 누락 시 Exception
 			List<String> colNames = new ArrayList<String>();
-			if(licenseCol < 0) {
+			if (licenseCol < 0) {
 				colNames.add("LICENSE");
 			}
 			// Per file info sheet of SPDX Spreadsheet does not proceed
-			if(packageIdentifierCol < 0) {
-				if(ossNameCol < 0) {
+			if (packageIdentifierCol < 0) {
+				if (ossNameCol < 0) {
 					colNames.add("OSS NAME");
 				}
 
-				if(ossVersionCol < 0) {
+				if (ossVersionCol < 0) {
 					colNames.add("OSS VERSION");
 				}
 			}
-			if(!colNames.isEmpty()) {
+			if (!colNames.isEmpty()) {
 				String msg = colNames.toString();
 				msg = "No required fields were found. Sheet Name : [".concat(sheet.getSheetName()).concat("],  Filed Name : ").concat(msg);
 				errMsg.put("reqCol", msg);
@@ -1033,40 +1033,40 @@ public class ExcelUtil extends CoTopComponent {
 			List<String> duplicateCheckList = new ArrayList<>();
 			List<String> errRow = new ArrayList<>();
 			
-			for(int rowIdx = DefaultHeaderRowIndex+1; rowIdx < sheet.getPhysicalNumberOfRows(); rowIdx++) {
+			for (int rowIdx = DefaultHeaderRowIndex+1; rowIdx < sheet.getPhysicalNumberOfRows(); rowIdx++) {
 			    try {
     				// final list의 ref Data를 찾을 경우, No Cell이 없는 시트는 무시
-    				if(readNoCol && noCol < 0) {
+    				if (readNoCol && noCol < 0) {
     					continue;
     				}
     				
     				Row row = sheet.getRow(rowIdx);
     				
-    				if(row == null) {
+    				if (row == null) {
     					continue;
     				}
     				
     				// 신분석결과서 대응 (작성 가이드 row는 제외)
-    				if(noCol > -1 &&  "-".equals(avoidNull(getCellData(row.getCell(noCol))))) {
+    				if (noCol > -1 &&  "-".equals(avoidNull(getCellData(row.getCell(noCol))))) {
     					continue;
     				}
     				
     				OssComponents bean = new OssComponents();
 
     				// The SPDX Spradsheet reads the same row as the Package Identifier of the Per File Info sheet and the Spdx Identifier of the Package Info sheet
-    				if(ossNameCol < 0) {
+    				if (ossNameCol < 0) {
     					bean.setBinaryName(binaryNameCol < 0 ? "" : avoidNull(getCellData(row.getCell(binaryNameCol))).trim().replaceAll("\t", ""));
     					bean.setCopyrightText(copyrightTextCol < 0 ? "" : getCellData(row.getCell(copyrightTextCol)));
     					bean.setComments(commentCol < 0 ? getCellData(row.getCell(licenseCol)) : getCellData(row.getCell(licenseCol)) + ", " + getCellData(row.getCell(commentCol)));
     					bean.setFilePath(pathOrFileCol < 0 ? "" : avoidNull(getCellData(row.getCell(pathOrFileCol))).trim().replaceAll("\t", ""));
-    					if(bean.getCopyrightText() == ""){
+    					if (bean.getCopyrightText() == ""){
     						bean.setCopyrightText(" ");
     					}
     					String packageIdentifier = getCellData(row.getCell(packageIdentifierCol));
     					boolean nullCheck = true;
-    					for(int beanIndex = 0; beanIndex < list.size(); beanIndex++) {
+    					for (int beanIndex = 0; beanIndex < list.size(); beanIndex++) {
     						OssComponents temp = list.get(beanIndex);
-    						if(packageIdentifier.equals(temp.getSpdxIdentifier())){
+    						if (packageIdentifier.equals(temp.getSpdxIdentifier())){
     							nullCheck = false;
     							bean.setOssName(temp.getOssName());
     							bean.setOssVersion(temp.getOssVersion());
@@ -1075,7 +1075,7 @@ public class ExcelUtil extends CoTopComponent {
     							break;
     						}
     					}
-    					if(nullCheck) {
+    					if (nullCheck) {
     						bean.setOssName("");
     						bean.setOssVersion("");
     						bean.setDownloadLocation("");
@@ -1087,7 +1087,7 @@ public class ExcelUtil extends CoTopComponent {
     					bean.setOssVersion(ossVersionCol < 0 ? "" : avoidNull(getCellData(row.getCell(ossVersionCol))).trim().replaceAll("\t", ""));
     					
     					String downloadLocation = avoidNull(getCellData(row.getCell(downloadLocationCol))).trim().replaceAll("\t", "");
-    					if(downloadLocation.equals("NONE") || downloadLocation.equals("NOASSERTION") || downloadLocationCol < 0) {
+    					if (downloadLocation.equals("NONE") || downloadLocation.equals("NOASSERTION") || downloadLocationCol < 0) {
     						bean.setDownloadLocation("");
     					} else {
     						bean.setDownloadLocation(downloadLocation);
@@ -1098,7 +1098,7 @@ public class ExcelUtil extends CoTopComponent {
     					bean.setBinaryName(binaryNameCol < 0 ? "" : avoidNull(getCellData(row.getCell(binaryNameCol))).trim().replaceAll("\t", ""));
     
     					String copyrightText = getCellData(row.getCell(copyrightTextCol));
-    					if(copyrightText.equals("NONE") || copyrightText.equals("NOASSERTION") || copyrightTextCol < 0) {
+    					if (copyrightText.equals("NONE") || copyrightText.equals("NOASSERTION") || copyrightTextCol < 0) {
     						bean.setCopyrightText("");
     					} else {
     						bean.setCopyrightText(copyrightText);
@@ -1110,25 +1110,25 @@ public class ExcelUtil extends CoTopComponent {
     				duplicateCheckList.add(avoidNull(bean.getOssName()) + "-" + avoidNull(bean.getOssVersion()) + "-" + avoidNull(bean.getLicenseName()));
     				
     				// final list인 경우
-    				if(finalListRefCol > 0) {
+    				if (finalListRefCol > 0) {
     					bean.setFinalListRefList(Arrays.asList(avoidNull(getCellData(row.getCell(finalListRefCol))).split(",")));
     				}
     				
-    				if(readNoCol) {
+    				if (readNoCol) {
     					bean.setReportKey(getCellData(row.getCell(noCol)));
     				}
 
     				String licenseConcluded = getCellData(row.getCell(licenseCol));
-    				if(isSPDXSpreadsheet(sheet) && (licenseConcluded.contains("AND") || licenseConcluded.contains("OR"))) {
+    				if (isSPDXSpreadsheet(sheet) && (licenseConcluded.contains("AND") || licenseConcluded.contains("OR"))) {
     					String licenseComment = getCellData(row.getCell(commentCol));
     					String comment = "";
 
-    					if(!licenseConcluded.isEmpty()) {
+    					if (!licenseConcluded.isEmpty()) {
     						comment += licenseConcluded;
     					}
 
-    					if(!licenseComment.isEmpty()) {
-    						if(licenseConcluded.isEmpty()) {
+    					if (!licenseComment.isEmpty()) {
+    						if (licenseConcluded.isEmpty()) {
     							comment += licenseComment;
     						} else {
     							comment += " / " + licenseComment;
@@ -1143,17 +1143,17 @@ public class ExcelUtil extends CoTopComponent {
     				// oss Name을 입력하지 않거나, 이전 row와 oss name, oss version이 동일한 경우, 멀티라이선스로 판단
     				OssComponentsLicense subBean = new OssComponentsLicense();
     				String licenseName = getCellData(row.getCell(licenseCol));
-    				if(isSPDXSpreadsheet(sheet)){
+    				if (isSPDXSpreadsheet(sheet)){
     					licenseName = StringUtil.join(Arrays.asList(licenseName.split("\\(|\\)| ")).stream().filter(l -> !isEmpty(l) && !l.equals("AND") && !l.equals("OR")).collect(Collectors.toList()), ",");
     				} else if (licenseName.contains(",")) {
     					licenseName = StringUtil.join(Arrays.asList(licenseName.split(",")).stream().filter(l -> !isEmpty(l)).collect(Collectors.toList()), ",");
     				}
     				
-    				if(!licenseName.matches("\\A\\p{ASCII}*\\z")) {
+    				if (!licenseName.matches("\\A\\p{ASCII}*\\z")) {
 						byte[] asciiValues = licenseName.getBytes(StandardCharsets.US_ASCII);
 						byte[] asciiValuesRetry = new byte[asciiValues.length];
-						for(int i=0; i < asciiValues.length ; i++) {
-							if(asciiValues[i] == 63) {
+						for (int i=0; i < asciiValues.length ; i++) {
+							if (asciiValues[i] == 63) {
 								asciiValuesRetry[i] = 32;
 							} else {
 								asciiValuesRetry[i] = asciiValues[i];
@@ -1166,22 +1166,22 @@ public class ExcelUtil extends CoTopComponent {
     				subBean.setLicenseName(licenseCol < 0 ? "" : licenseName);
     				subBean.setLicenseText(licenseTextCol < 0 ? "" : getCellData(row.getCell(licenseTextCol)));
     				
-    				if("false".equals(subBean.getLicenseText()) || "-".equals(subBean.getLicenseText())) {
+    				if ("false".equals(subBean.getLicenseText()) || "-".equals(subBean.getLicenseText())) {
     					subBean.setLicenseText("");
     				}
     				
-    				if("false".equals(bean.getCopyrightText())) {
+    				if ("false".equals(bean.getCopyrightText())) {
     					bean.setCopyrightText("");
     				}
     				
     				// file path에 개행이 있는 경우 콤마로 변경
-    				if(!isEmpty(bean.getFilePath()) && (bean.getFilePath().indexOf("\r\n") > -1 || bean.getFilePath().indexOf("\n") > -1)) {
+    				if (!isEmpty(bean.getFilePath()) && (bean.getFilePath().indexOf("\r\n") > -1 || bean.getFilePath().indexOf("\n") > -1)) {
     					String _tmpFilePath = bean.getFilePath().trim().replaceAll("\r\n", "\n");
     					String _replaceFilePath = "";
     					
-    					for(String s : _tmpFilePath.split("\n")) {
-    						if(!isEmpty(s)) {
-    							if(!isEmpty(_replaceFilePath)) {
+    					for (String s : _tmpFilePath.split("\n")) {
+    						if (!isEmpty(s)) {
+    							if (!isEmpty(_replaceFilePath)) {
     								_replaceFilePath += ",";
     							}
     							
@@ -1193,14 +1193,14 @@ public class ExcelUtil extends CoTopComponent {
     				}
     				
     				// empty row check
-    				if(isEmpty(bean.getOssName()) && isEmpty(bean.getOssVersion()) && isEmpty(subBean.getLicenseName()) && isEmpty(bean.getBinaryName()) && isEmpty(bean.getFilePath())
+    				if (isEmpty(bean.getOssName()) && isEmpty(bean.getOssVersion()) && isEmpty(subBean.getLicenseName()) && isEmpty(bean.getBinaryName()) && isEmpty(bean.getFilePath())
     						&& isEmpty(bean.getDownloadLocation()) && isEmpty(bean.getHomepage()) && isEmpty(bean.getCopyrightText())) {
     					continue;
     				}
     
     				// 기존 레포트에서 load on product 칼럼이 있는 경우, X선택된 row는 제외
     				// 또는 신분석결과서의 exclude 칼럼
-    				if( (loadOnProductCol > 0 && "X".equalsIgnoreCase(getCellData(row.getCell(loadOnProductCol)))) 
+    				if ( (loadOnProductCol > 0 && "X".equalsIgnoreCase(getCellData(row.getCell(loadOnProductCol)))) 
     						|| (excludeCol > -1 && "Exclude".equalsIgnoreCase(getCellData(row.getCell(excludeCol)))) ) {
     					bean.setExcludeYn(CoConstDef.FLAG_YES);
     				}
@@ -1209,7 +1209,7 @@ public class ExcelUtil extends CoTopComponent {
     				bean.setExcludeYn(avoidNull(bean.getExcludeYn(), CoConstDef.FLAG_NO));
     
     				// homepage와 download location이 http://로 시작하지 않을 경우 자동으로 체워줌
-//    				if(!isEmpty(bean.getHomepage()) 
+//    				if (!isEmpty(bean.getHomepage()) 
 //    						&& !(bean.getHomepage().toLowerCase().startsWith("http://") 
 //    								|| bean.getHomepage().toLowerCase().startsWith("https://") 
 //    								|| bean.getHomepage().toLowerCase().startsWith("ftp://"))
@@ -1217,7 +1217,7 @@ public class ExcelUtil extends CoTopComponent {
 //    					bean.setHomepage("http://" + bean.getHomepage());
 //    				}
 //    				
-//    				if(!isEmpty(bean.getDownloadLocation()) 
+//    				if (!isEmpty(bean.getDownloadLocation()) 
 //    						&& !(bean.getDownloadLocation().toLowerCase().startsWith("http://") 
 //    								|| bean.getDownloadLocation().toLowerCase().startsWith("https://")  
 //    								|| bean.getDownloadLocation().toLowerCase().startsWith("ftp://")
@@ -1241,12 +1241,12 @@ public class ExcelUtil extends CoTopComponent {
 			    }
 			}
 			
-			if(!errRow.isEmpty()) {
+			if (!errRow.isEmpty()) {
 				String msg = errRow.toString();
 				msg = "Error Sheet. Sheet Name : [".concat(sheet.getSheetName()).concat("],  ").concat(msg);
 				errMsg.put("errRow", msg);
 			}
-			if(list.isEmpty()) {
+			if (list.isEmpty()) {
 				errMsg.put("emptySheet", sheet.getSheetName());
 			}
 		}
@@ -1259,31 +1259,31 @@ public class ExcelUtil extends CoTopComponent {
 	}
 
 	private static boolean hasSameLicense(OssComponents ossComponents, OssComponentsLicense subBean) {
-		if(ossComponents != null && subBean != null) {
-			if(ossComponents.getOssComponentsLicense() == null || ossComponents.getOssComponentsLicense().isEmpty()) {
+		if (ossComponents != null && subBean != null) {
+			if (ossComponents.getOssComponentsLicense() == null || ossComponents.getOssComponentsLicense().isEmpty()) {
 				return false;
 			}
 			
 			// license name이 닉네임으로 등록될 수 있어서 알단, DB에 등록되어 있는 라이선스의 경우 정식 명칭을 기준으로 비교
 			// 둘중에 하나라도 db에 등록되어 있지 않은 경우, 원본을 기준으로 비교
-			for(OssComponentsLicense license : ossComponents.getOssComponentsLicense()) {
-				if(avoidNull(subBean.getLicenseName()).equalsIgnoreCase(license.getLicenseName())) {
+			for (OssComponentsLicense license : ossComponents.getOssComponentsLicense()) {
+				if (avoidNull(subBean.getLicenseName()).equalsIgnoreCase(license.getLicenseName())) {
 					return true;
 				}
 				
 				String _temp1 = avoidNull(license.getLicenseName());
 				
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(_temp1.toUpperCase())) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(_temp1.toUpperCase())) {
 					_temp1 = CoCodeManager.LICENSE_INFO_UPPER.get(_temp1.toUpperCase()).getLicenseId();
 				}
 				
 				String _temp2 = avoidNull(subBean.getLicenseName());
 				
-				if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(_temp2.toUpperCase())) {
+				if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(_temp2.toUpperCase())) {
 					_temp2 = CoCodeManager.LICENSE_INFO_UPPER.get(_temp2.toUpperCase()).getLicenseId();
 				}
 				
-				if(_temp1.equals(_temp2)) {
+				if (_temp1.equals(_temp2)) {
 					return true;
 				}
 			}
@@ -1314,7 +1314,7 @@ public class ExcelUtil extends CoTopComponent {
 		
 		DefaultHeaderRowIndex = findHeaderRowIndex(sheet);
 		
-		if(DefaultHeaderRowIndex < 0) {
+		if (DefaultHeaderRowIndex < 0) {
 			errMsgList.add("Can not found Header Row, Sheet Name : " + sheet.getSheetName());
 			
 			return;
@@ -1334,7 +1334,7 @@ public class ExcelUtil extends CoTopComponent {
 			switch (value) {
 				case "OSS COMPONENT":
 				case "OSS NAME":
-					if(ossNameCol > -1) {
+					if (ossNameCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1342,7 +1342,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "OSS VERSION":
-					if(ossVersionCol > -1) {
+					if (ossVersionCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1350,7 +1350,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "DOWNLOAD LOCATION":
-					if(downloadLocationCol > -1) {
+					if (downloadLocationCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1359,7 +1359,7 @@ public class ExcelUtil extends CoTopComponent {
 					break;
 				case "HOMEPAGE":
 				case "OSS WEBSITE":
-					if(homepageCol > -1) {
+					if (homepageCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1367,7 +1367,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "LICENSE":
-					if(licenseCol > -1) {
+					if (licenseCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1375,7 +1375,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "LICENSE TEXT":
-					if(licenseTextCol > -1) {
+					if (licenseTextCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1384,7 +1384,7 @@ public class ExcelUtil extends CoTopComponent {
 					break;
 				case "COPYRIGHT TEXT":
 				case "COPYRIGHT & LICENSE":
-					if(copyrightTextCol > -1) {
+					if (copyrightTextCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1393,7 +1393,7 @@ public class ExcelUtil extends CoTopComponent {
 					break;
 				case "BINARY/LIBRARY FILE":
 				case "BINARY NAME":
-					if(binaryFileCol > -1) {
+					if (binaryFileCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1402,7 +1402,7 @@ public class ExcelUtil extends CoTopComponent {
 					break;
 				case "DIRECTORY":
 				case "SOURCE CODE PATH":
-					if(pathOrFileCol > -1) {
+					if (pathOrFileCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1410,7 +1410,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "LOADED ON PRODUCT":
-					if(loadOnProductCol > -1) {
+					if (loadOnProductCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1419,7 +1419,7 @@ public class ExcelUtil extends CoTopComponent {
 					break;
 				case "NO":
 				case "ID":
-					if(noCol > -1) {
+					if (noCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1427,7 +1427,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "NOTICE.HTML":
-					if(noticeHtmlCol > -1) {
+					if (noticeHtmlCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1435,7 +1435,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "EXCLUDE":
-					if(excludeCol > -1) {
+					if (excludeCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1443,7 +1443,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "COMMENT":
-					if(commentCol > -1) {
+					if (commentCol > -1) {
 						throw new ColumnNameDuplicateException(sheet.getSheetName() + "." + value);
 					}
 					
@@ -1459,22 +1459,22 @@ public class ExcelUtil extends CoTopComponent {
 		
 		// 필수 header 누락 시 Exception
 		List<String> colNames = new ArrayList<String>();
-		if(ossNameCol < 0) {
+		if (ossNameCol < 0) {
 			colNames.add("OSS NAME");
 		}
 		
-		if(ossVersionCol < 0) {
+		if (ossVersionCol < 0) {
 			colNames.add("OSS VERSION");
 		}
 		
-		if(licenseCol < 0) {
+		if (licenseCol < 0) {
 			colNames.add("LICENSE");
 		}
 		
-		if(colNames.size() > 0) {
+		if (colNames.size() > 0) {
 			String colNameTxt = "";
 			
-			for(int j = 0 ; j < colNames.size() ; j++) {
+			for (int j = 0 ; j < colNames.size() ; j++) {
 				colNameTxt += (j==0?"":", ") + colNames.get(j);
 			}
 			
@@ -1486,12 +1486,12 @@ public class ExcelUtil extends CoTopComponent {
 		String lastFilePath = "";
 		String lastBinaryName = "";
 		
-		for(int rowIdx = DefaultHeaderRowIndex+1; rowIdx < sheet.getPhysicalNumberOfRows(); rowIdx++) {
+		for (int rowIdx = DefaultHeaderRowIndex+1; rowIdx < sheet.getPhysicalNumberOfRows(); rowIdx++) {
 		    try {
     			Row row = sheet.getRow(rowIdx);
     			
     			// 신분석결과서 대응 (작성 가이드 row는 제외)
-    			if(noCol > -1 &&  "-".equals(avoidNull(getCellData(row.getCell(noCol))))) {
+    			if (noCol > -1 &&  "-".equals(avoidNull(getCellData(row.getCell(noCol))))) {
     				continue;
     			}
     			
@@ -1514,7 +1514,7 @@ public class ExcelUtil extends CoTopComponent {
     			
     			// android 의 경우는 list에는 포함시키고 exclude하는 것으로 변경
     			// 기존 레포트에서 load on product 칼럼이 있는 경우, X선택된 row는 제외
-    			if( (loadOnProductCol > 0 && "X".equalsIgnoreCase(getCellData(row.getCell(loadOnProductCol)))) 
+    			if ( (loadOnProductCol > 0 && "X".equalsIgnoreCase(getCellData(row.getCell(loadOnProductCol)))) 
     					|| (excludeCol > -1 && "Exclude".equalsIgnoreCase(getCellData(row.getCell(excludeCol))) ) ) {
     				bean.setExcludeYn(CoConstDef.FLAG_YES);
     			}
@@ -1526,35 +1526,35 @@ public class ExcelUtil extends CoTopComponent {
     			// license 정보
     			OssComponentsLicense subBean = new OssComponentsLicense();
     			String licenseName = getCellData(row.getCell(licenseCol));
-    			if(licenseName.contains(",")) {
+    			if (licenseName.contains(",")) {
 					licenseName = StringUtil.join(Arrays.asList(licenseName.split(",")).stream().filter(l -> !isEmpty(l)).collect(Collectors.toList()), ",");
 				}
 				
 				subBean.setLicenseName(licenseCol < 0 ? "" : licenseName);
     			subBean.setLicenseText(licenseTextCol < 0 ? "" : getCellData(row.getCell(licenseTextCol)));
     			
-    			if("false".equals(subBean.getLicenseText()) || "-".equals(subBean.getLicenseText())) {
+    			if ("false".equals(subBean.getLicenseText()) || "-".equals(subBean.getLicenseText())) {
     				subBean.setLicenseText("");
     			}
     			
-    			if("false".equals(bean.getCopyrightText())) {
+    			if ("false".equals(bean.getCopyrightText())) {
     				bean.setCopyrightText("");
     			}
     
-    			if(isEmpty(bean.getBinaryName()) && isEmpty(bean.getOssName()) && isEmpty(bean.getOssVersion()) && isEmpty(subBean.getLicenseName()) && isEmpty(bean.getFilePath()) 
+    			if (isEmpty(bean.getBinaryName()) && isEmpty(bean.getOssName()) && isEmpty(bean.getOssVersion()) && isEmpty(subBean.getLicenseName()) && isEmpty(bean.getFilePath()) 
     					&& isEmpty(bean.getDownloadLocation()) && isEmpty(bean.getHomepage()) && isEmpty(bean.getCopyrightText())) {
     				continue;
     			}
     			
     			// homepage와 download location이 http://로 시작하지 않을 경우 자동으로 체워줌(* download location의 경우 git으로 시작 시 http://를 붙이지 않음.)
-//    			if(!isEmpty(bean.getHomepage()) 
+//    			if (!isEmpty(bean.getHomepage()) 
 //    					&& !(bean.getHomepage().toLowerCase().startsWith("http://") 
 //    							|| bean.getHomepage().toLowerCase().startsWith("https://"))
 //    					&& !bean.getDownloadLocation().toLowerCase().startsWith("git://")) {
 //    				bean.setHomepage("http://" + bean.getHomepage());
 //    			}
 //    			
-//    			if(!isEmpty(bean.getDownloadLocation()) 
+//    			if (!isEmpty(bean.getDownloadLocation()) 
 //    					&& !(bean.getDownloadLocation().toLowerCase().startsWith("http://") 
 //    							|| bean.getDownloadLocation().toLowerCase().startsWith("https://"))
 //    					&& !bean.getDownloadLocation().toLowerCase().startsWith("git://")) {
@@ -1572,7 +1572,7 @@ public class ExcelUtil extends CoTopComponent {
 		    }
 		}
 		
-		if(list.isEmpty()) {
+		if (list.isEmpty()) {
 			errMsgList.add("There are no OSS listed. Sheet Name : " + sheet.getSheetName());
 		}
 	}
@@ -1584,13 +1584,13 @@ public class ExcelUtil extends CoTopComponent {
 	 */
 	private static boolean hasFileListSheet(String[] targetSheetNums, Workbook wb) {
 		for (String sheetIdx : targetSheetNums) {
-			if(StringUtil.isNotNumeric(sheetIdx)) {
+			if (StringUtil.isNotNumeric(sheetIdx)) {
 				continue;
 			}
 			
 			Sheet sheet = wb.getSheetAt(Integer.parseInt(sheetIdx));
 			
-			if("Final List".equalsIgnoreCase(sheet.getSheetName()) && hasCol(sheet, "Ref. Columns")) {
+			if ("Final List".equalsIgnoreCase(sheet.getSheetName()) && hasCol(sheet, "Ref. Columns")) {
 				return true;
 			}
 		}
@@ -1614,18 +1614,18 @@ public class ExcelUtil extends CoTopComponent {
 			int cellcnt = 0;
 			
 			for (Cell cell : row) {
-				if(colVal.equalsIgnoreCase(getCellData(cell))) {
+				if (colVal.equalsIgnoreCase(getCellData(cell))) {
 					return true;
 				}
 				
-				if(cellcnt > cellCheckMaxCnt) {
+				if (cellcnt > cellCheckMaxCnt) {
 					break;
 				}
 				
 				cellcnt ++;
 			}
 			
-			if(rowCnt > rowCheckMaxCnt ) {
+			if (rowCnt > rowCheckMaxCnt ) {
 				break;
 			}
 			
@@ -1649,11 +1649,11 @@ public class ExcelUtil extends CoTopComponent {
 			for (Cell cell : row) {
 				String id = avoidNull(getCellData(cell)).trim().toUpperCase();
 				
-				if("NO".equalsIgnoreCase(id) || "ID".equalsIgnoreCase(id) || "PACKAGE NAME".equalsIgnoreCase(id) || "FILE NAME".equalsIgnoreCase(id)) {
+				if ("NO".equalsIgnoreCase(id) || "ID".equalsIgnoreCase(id) || "PACKAGE NAME".equalsIgnoreCase(id) || "FILE NAME".equalsIgnoreCase(id)) {
 					return row.getRowNum();
 				}
 				
-				if(maxCnt > 5) {
+				if (maxCnt > 5) {
 					break;
 				}
 			}
@@ -1666,16 +1666,16 @@ public class ExcelUtil extends CoTopComponent {
 	private static String getCellData(Cell cell) {
 		String value = "";
 		
-		if(cell == null) {
+		if (cell == null) {
 			
 		} else {
 			CellType cellType = cell.getCellType();
 			switch (cellType) {
 				case FORMULA:
-					if(CellType.NUMERIC == cell.getCachedFormulaResultType()) {
+					if (CellType.NUMERIC == cell.getCachedFormulaResultType()) {
 						cell.setCellType(CellType.STRING);
 						value = cell.getStringCellValue();	
-					} else if(CellType.STRING == cell.getCachedFormulaResultType()) {
+					} else if (CellType.STRING == cell.getCachedFormulaResultType()) {
 						value = cell.getStringCellValue();	
 					}
 					
@@ -1687,7 +1687,7 @@ public class ExcelUtil extends CoTopComponent {
 					_tempCell.setCellType(CellType.STRING);
 					String _temp = _tempCell.getStringCellValue();
 					
-					if(_temp.indexOf(".") == -1 && value.indexOf(".") > -1) {
+					if (_temp.indexOf(".") == -1 && value.indexOf(".") > -1) {
 						value = value.substring(0, value.indexOf("."));
 					}
 					
@@ -1713,7 +1713,7 @@ public class ExcelUtil extends CoTopComponent {
 			}
 		}
 		
-		if(value == null) {
+		if (value == null) {
 			value = "";
 		}
 		
@@ -1941,7 +1941,7 @@ public class ExcelUtil extends CoTopComponent {
 		List<ProjectIdentification> result = new ArrayList<ProjectIdentification>();
 		Iterator<String> fileNames = req.getFileNames();
 		
-		while(fileNames.hasNext()){
+		while (fileNames.hasNext()){
 			MultipartFile multipart = req.getFile(fileNames.next());
 			String fileName = multipart.getOriginalFilename();
 
@@ -1956,7 +1956,7 @@ public class ExcelUtil extends CoTopComponent {
 				Sheet sheet = wb.getSheetAt(0);
 				int startRowIdx = findHeaderRowIndex(sheet);
 				
-				if(startRowIdx < 0) {
+				if (startRowIdx < 0) {
 					log.warn("Can not found Header Row, fileName : " + fileName + " , Sheet Name : " + sheet.getSheetName());
 					
 					return null;
@@ -1987,14 +1987,14 @@ public class ExcelUtil extends CoTopComponent {
 					colIdx++;
 				}
 				
-				if(_componentId < 0 || _filePath < 0) {
+				if (_componentId < 0 || _filePath < 0) {
 					return null;
 				}
 			
-				for(int rowIdx = startRowIdx +1; rowIdx <= sheet.getPhysicalNumberOfRows(); rowIdx++){
+				for (int rowIdx = startRowIdx +1; rowIdx <= sheet.getPhysicalNumberOfRows(); rowIdx++){
 					Row row = sheet.getRow(rowIdx);
 					
-					if(row == null) {
+					if (row == null) {
 						continue;
 					}
 					
@@ -2005,7 +2005,7 @@ public class ExcelUtil extends CoTopComponent {
 					param.setOssVersion(getCellData(row.getCell(_ossVersion)));
 					param.setLicenseName(getCellData(row.getCell(_license)));
 					
-					if(!StringUtil.isEmpty(param.getComponentId())){
+					if (!StringUtil.isEmpty(param.getComponentId())){
 						result.add(param);	
 					}
 				}
@@ -2031,7 +2031,7 @@ public class ExcelUtil extends CoTopComponent {
 	public static boolean readAndroidBuildImage(String readType, boolean checkId, String[] targetSheetNums, String fileSeq, String resultFileSeq, List<OssComponents> list, List<String> errMsgList, Map<String, Object> checkHeaderSheetName) {
 		T2File fileInfo = fileService.selectFileInfoById(fileSeq);
 		
-		if(fileInfo == null) {
+		if (fileInfo == null) {
 			log.error("파일정보를 찾을 수 없습니다. fileSeq : " + avoidNull(fileSeq));
 			
 			errMsgList.add("파일 정보를 찾을 수 없습니다.");
@@ -2039,7 +2039,7 @@ public class ExcelUtil extends CoTopComponent {
 			return false;
 		}
 		
-		if(!Arrays.asList("XLS", "XLSX", "XLSM").contains(avoidNull(fileInfo.getExt()).toUpperCase())) {
+		if (!Arrays.asList("XLS", "XLSX", "XLSM").contains(avoidNull(fileInfo.getExt()).toUpperCase())) {
 			log.error("허용하지 않는 파일 입니다. fileSeq : " + avoidNull(fileSeq));
 			
 			errMsgList.add("허용하지 않는 파일 입니다.");
@@ -2049,7 +2049,7 @@ public class ExcelUtil extends CoTopComponent {
 		
 		File file = new File(fileInfo.getLogiPath() + "/" + fileInfo.getLogiNm());
 		
-		if(!file.exists() || !file.isFile()) {
+		if (!file.exists() || !file.isFile()) {
 			log.error("파일정보를 찾을 수 없습니다. fileSeq : " + avoidNull(fileSeq));
 			
 			errMsgList.add("파일 정보를 찾을 수 없습니다.");
@@ -2104,7 +2104,7 @@ public class ExcelUtil extends CoTopComponent {
 		}
 		
 		// 사용자 입력 값을 기준으로 OSS Master 정보를 비교 ID를 설정한다.
-		if(checkId && list != null && !list.isEmpty()) {
+		if (checkId && list != null && !list.isEmpty()) {
 			// result.txt를 기준으로 삭제 또는 추가
 			// result text가 있는 경우
 			// <Removed>로 시작하는 row는 삭제
@@ -2112,11 +2112,11 @@ public class ExcelUtil extends CoTopComponent {
 			List<OssComponents> addCheckList = new ArrayList<>();
 			List<String> existsResultTextBinaryName = null;
 			
-			if(!isEmpty(resultFileSeq)) {
+			if (!isEmpty(resultFileSeq)) {
 				List<String> existsBinaryName = new ArrayList<>();
 				
-				for(OssComponents bean : list) {
-					if(!isEmpty(bean.getBinaryName())) {
+				for (OssComponents bean : list) {
+					if (!isEmpty(bean.getBinaryName())) {
 						existsBinaryName.add(bean.getBinaryName());
 					}
 				}
@@ -2124,15 +2124,15 @@ public class ExcelUtil extends CoTopComponent {
 				T2File resultFileInfo = fileService.selectFileInfoById(resultFileSeq);
 				Map<String, Object> _resultFileInfoMap = CommonFunction.getAndroidResultFileInfo(resultFileInfo, existsBinaryName);
 				
-				if(_resultFileInfoMap.containsKey("removedCheckList")) {
+				if (_resultFileInfoMap.containsKey("removedCheckList")) {
 					removedCheckList = (List<String>) _resultFileInfoMap.get("removedCheckList");
 				}
 				
-				if(_resultFileInfoMap.containsKey("addCheckList")) {
+				if (_resultFileInfoMap.containsKey("addCheckList")) {
 					addCheckList = (List<OssComponents>) _resultFileInfoMap.get("addCheckList");
 				}
 				
-				if(_resultFileInfoMap.containsKey("existsResultTextBinaryNameList")) {
+				if (_resultFileInfoMap.containsKey("existsResultTextBinaryNameList")) {
 					existsResultTextBinaryName = (List<String>) _resultFileInfoMap.get("existsResultTextBinaryNameList"); 
 				}
 			}
@@ -2143,21 +2143,21 @@ public class ExcelUtil extends CoTopComponent {
 			// result text에서 추가된 binary
 			// result.txt에 있으나 OSS Report에 없는 경우 => load되는 OSS List에 해당 Binary를 추가. 팝업을 띄우고 Comment로 추가된 binary목록을 남김.
 			
-			if(!addCheckList.isEmpty()) {
+			if (!addCheckList.isEmpty()) {
 				list.addAll(addCheckList);
 				addedByResultTxtStr = "<b>The following binaries were added to OSS List automatically because they exist in the fosslight_binary.txt.</b>";
 				
-				for(OssComponents bean : addCheckList) {
+				for (OssComponents bean : addCheckList) {
 					addedByResultTxtStr += "<br> - " + bean.getBinaryName();
 				}
 			}
 			
 			
 			// 더이상 사용하지 않음
-			if(!removedCheckList.isEmpty()) {
+			if (!removedCheckList.isEmpty()) {
 				// result list에서 삭제 대상 제외
-				for(OssComponents bean : list) {
-					if(removedCheckList.contains(bean.getBinaryName())) {
+				for (OssComponents bean : list) {
+					if (removedCheckList.contains(bean.getBinaryName())) {
 						bean.setExcludeYn(CoConstDef.FLAG_YES);
 						
 						deletedByResultTxtStr += bean.getBinaryName() + " is excluded by fosslight_binary.txt file.<br>";
@@ -2166,12 +2166,12 @@ public class ExcelUtil extends CoTopComponent {
 			}
 			
 			// result.txt에 있으나 OSS Report에서 exclude 처리된 경우 => Exclude체크 된 것을 유지. 2번의 Comment내용과 함께 팝업에도 뜨고 Comment로 exclude되어있음을 남김.
-			if(existsResultTextBinaryName != null) {
+			if (existsResultTextBinaryName != null) {
 				boolean isFirst = true;
 				
-				for(OssComponents bean : list) {
-					if(existsResultTextBinaryName.contains(bean.getBinaryName()) && CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
-						if(isFirst) {
+				for (OssComponents bean : list) {
+					if (existsResultTextBinaryName.contains(bean.getBinaryName()) && CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+						if (isFirst) {
 							excludeCheckResultTxtStr = "<b>The following binaries are written to the OSS report as excluded, but they are in the fosslight_binary.txt. Make sure it is not included in the final firmware.</b>";
 							
 							isFirst = false;
@@ -2185,23 +2185,23 @@ public class ExcelUtil extends CoTopComponent {
 			// result.txt에 의해 추가 삭제된 oss의 경우 세션에 격납
 			// client 화면에 표시 및 save시 코멘트 내용에 추가함
 
-			if(!isEmpty(addedByResultTxtStr) || !isEmpty(deletedByResultTxtStr) || !isEmpty(excludeCheckResultTxtStr)) {
+			if (!isEmpty(addedByResultTxtStr) || !isEmpty(deletedByResultTxtStr) || !isEmpty(excludeCheckResultTxtStr)) {
 				String _sessionData = "<b>OSS List has been changed by fosslight_binary.txt file. </b><br><br>";
 				
-				if(!isEmpty(addedByResultTxtStr)) {
+				if (!isEmpty(addedByResultTxtStr)) {
 					_sessionData += addedByResultTxtStr;
 				}
 				
-				if(!isEmpty(deletedByResultTxtStr)) {
-					if(!isEmpty(_sessionData)) {
+				if (!isEmpty(deletedByResultTxtStr)) {
+					if (!isEmpty(_sessionData)) {
 						_sessionData += "<br><br>";
 					}
 					
 					_sessionData += deletedByResultTxtStr;
 				}
 				
-				if(!isEmpty(excludeCheckResultTxtStr)) {
-					if(!isEmpty(_sessionData)) {
+				if (!isEmpty(excludeCheckResultTxtStr)) {
+					if (!isEmpty(_sessionData)) {
 						_sessionData += "<br><br>";
 					}
 					
@@ -2238,21 +2238,21 @@ public class ExcelUtil extends CoTopComponent {
 		Map<String, String> orgLikeMap = new HashMap<>();
 		List<String> licenseCheckParam = new ArrayList<>();
 		
-		for(OssComponents bean : orgList) {
-			if(isEmpty(bean.getOssName())) {
+		for (OssComponents bean : orgList) {
+			if (isEmpty(bean.getOssName())) {
 				continue;
 			}
 			
 			String _key = avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion());
 			
-			if(bean.getOssComponentsLicense() != null) {
-				for(OssComponentsLicense license : bean.getOssComponentsLicense()) {
-					if(!isEmpty(license.getLicenseName()) && !licenseCheckParam.contains(license.getLicenseName())) {
+			if (bean.getOssComponentsLicense() != null) {
+				for (OssComponentsLicense license : bean.getOssComponentsLicense()) {
+					if (!isEmpty(license.getLicenseName()) && !licenseCheckParam.contains(license.getLicenseName())) {
 						licenseCheckParam.add(license.getLicenseName());
 					}
 					
 					// bsd-like, mit-like 처리
-					if(!orgLikeMap.containsKey(_key) 
+					if (!orgLikeMap.containsKey(_key) 
 							&& !isEmpty(license.getLicenseName()) 
 							&& (license.getLicenseName().toUpperCase().startsWith("MIT-LIKE") || license.getLicenseName().toUpperCase().startsWith("BSD-LIKE"))) {
 						orgLikeMap.put(_key, license.getLicenseName());
@@ -2263,17 +2263,17 @@ public class ExcelUtil extends CoTopComponent {
 
 		List<String> licenseNickNameCheckResult = new ArrayList<>();
 		
-		for(String licenseName : licenseCheckParam) {
-			if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
+		for (String licenseName : licenseCheckParam) {
+			if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
 				LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO_UPPER.get(licenseName.toUpperCase());
 				
-				if(licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
-					for(String s : licenseMaster.getLicenseNicknameList()) {
+				if (licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
+					for (String s : licenseMaster.getLicenseNicknameList()) {
 						String newName = avoidNull(licenseMaster.getShortIdentifier(), licenseMaster.getLicenseName());
-						if(licenseName.equalsIgnoreCase(s) && !licenseName.equals(newName)) {
+						if (licenseName.equalsIgnoreCase(s) && !licenseName.equals(newName)) {
 							String disp = licenseName + " => " + newName;
 							
-							if(!licenseNickNameCheckResult.contains(disp)) {
+							if (!licenseNickNameCheckResult.contains(disp)) {
 								licenseNickNameCheckResult.add(disp);
 								
 								break;
@@ -2284,20 +2284,20 @@ public class ExcelUtil extends CoTopComponent {
 			}
 		}
 		
-		if(!orgLikeMap.isEmpty()) {
+		if (!orgLikeMap.isEmpty()) {
 			Map<String, String> convertLikeMap = new HashMap<>();
 			// bsd, mit like 계열의 라이선스가 포함되어 있으면, convert된 list에서 like계열의 라이선스 정보를 격납한다.
 			
-			for(OssComponents bean : list) {
-				if(isEmpty(bean.getOssName())) {
+			for (OssComponents bean : list) {
+				if (isEmpty(bean.getOssName())) {
 					continue;
 				}
 				
-				if(bean.getOssComponentsLicense() != null) {
+				if (bean.getOssComponentsLicense() != null) {
 					String _key = avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion());
 					
-					for(OssComponentsLicense license : bean.getOssComponentsLicense()) {
-						if(!convertLikeMap.containsKey(_key) 
+					for (OssComponentsLicense license : bean.getOssComponentsLicense()) {
+						if (!convertLikeMap.containsKey(_key) 
 								&& !isEmpty(license.getLicenseName()) 
 								&& (license.getLicenseName().toUpperCase().startsWith("MIT-LIKE") || license.getLicenseName().toUpperCase().startsWith("BSD-LIKE"))) {
 							convertLikeMap.put(_key, license.getLicenseName());
@@ -2306,12 +2306,12 @@ public class ExcelUtil extends CoTopComponent {
 				}
 			}
 			
-			for(String ossKey : orgLikeMap.keySet()) {
-				if(convertLikeMap.containsKey(ossKey)) {
-					if(!orgLikeMap.get(ossKey).equals(convertLikeMap.get(ossKey))) {
+			for (String ossKey : orgLikeMap.keySet()) {
+				if (convertLikeMap.containsKey(ossKey)) {
+					if (!orgLikeMap.get(ossKey).equals(convertLikeMap.get(ossKey))) {
 						String disp = orgLikeMap.get(ossKey) + " => " + convertLikeMap.get(ossKey);
 						
-						if(!licenseNickNameCheckResult.contains(disp)) {
+						if (!licenseNickNameCheckResult.contains(disp)) {
 							licenseNickNameCheckResult.add(disp);
 						}
 					}
@@ -2320,12 +2320,12 @@ public class ExcelUtil extends CoTopComponent {
 		}
 		
 
-		if(!licenseNickNameCheckResult.isEmpty()) {
+		if (!licenseNickNameCheckResult.isEmpty()) {
 			StringBuffer changedNick = new StringBuffer();
 			changedNick.append("<b>The following license names will be changed to names registered on the system for efficient management.</b><br><br>");
 			changedNick.append("<b>License Names</b><br>");
 			
-			for(String s : licenseNickNameCheckResult) {
+			for (String s : licenseNickNameCheckResult) {
 				changedNick.append(s).append("<br>");
 			}
 			
@@ -2337,7 +2337,7 @@ public class ExcelUtil extends CoTopComponent {
 		List<Project> result = new ArrayList<Project>();
 		Iterator<String> fileNames = req.getFileNames();
 		
-		while(fileNames.hasNext()){
+		while (fileNames.hasNext()){
 			MultipartFile multipart = req.getFile(fileNames.next());
 			String fileName = multipart.getOriginalFilename();
 	
@@ -2353,7 +2353,7 @@ public class ExcelUtil extends CoTopComponent {
 				Sheet sheet = wb.getSheetAt(sheetIdx);
 				int startRowIdx = findHeaderRowIndex(sheet);
 				
-				if(startRowIdx < 0) {
+				if (startRowIdx < 0) {
 					log.warn("Can not found Header Row, fileName : " + fileName + " , Sheet Name : " + sheet.getSheetName());
 					return null;
 				}
@@ -2377,14 +2377,14 @@ public class ExcelUtil extends CoTopComponent {
 					colIdx++;
 				}
 				
-				if(modelName < 0) {
+				if (modelName < 0) {
 					return null;
 				}
 			
-				for(int rowIdx = startRowIdx +1; rowIdx <= sheet.getPhysicalNumberOfRows(); rowIdx++){
+				for (int rowIdx = startRowIdx +1; rowIdx <= sheet.getPhysicalNumberOfRows(); rowIdx++){
 					Row row = sheet.getRow(rowIdx);
 					
-					if(row == null) {
+					if (row == null) {
 						continue;
 					}
 					
@@ -2392,7 +2392,7 @@ public class ExcelUtil extends CoTopComponent {
 					param.setModelName(getCellData(row.getCell(modelName)));
 					param.setProductGroup(getCellData(row.getCell(productGroup)));
 					
-					if(!StringUtil.isEmpty(param.getModelName())){
+					if (!StringUtil.isEmpty(param.getModelName())){
 						result.add(param);	
 					}
 				}
@@ -2409,14 +2409,14 @@ public class ExcelUtil extends CoTopComponent {
 		Map<String, Object> readData = new HashMap<>();
 		File file = new File(analysisResultListPath);
 		
-		if(!file.exists()) {
+		if (!file.exists()) {
 			log.error("파일정보를 찾을 수 없습니다. file path : " + analysisResultListPath);
 			
 			return map;
 		}
 		
-		for(File f : file.listFiles()) {
-			if(f.isFile()) {
+		for (File f : file.listFiles()) {
+			if (f.isFile()) {
 				String[] fileName = f.getName().split("\\.");
 				String fileExt = (fileName[fileName.length-1]).toUpperCase();
 				
@@ -2433,7 +2433,7 @@ public class ExcelUtil extends CoTopComponent {
 			}
 		}
 
-		try(
+		try (
 			FileReader csvFile = new FileReader(file); // CSV File만 가능함.
 			CSVReader csvReader = new CSVReader(csvFile, '|');
 		) {
@@ -2441,9 +2441,9 @@ public class ExcelUtil extends CoTopComponent {
 			
 			readData = readAnalysisList(allData, (List<OssAnalysis>) map.get("rows"));
 			
-			if(!readData.isEmpty()) {
+			if (!readData.isEmpty()) {
 				// isValid - false(throws 발생) || true(data 조합)
-				if((boolean) readData.get("isValid")) {
+				if ((boolean) readData.get("isValid")) {
 					CommonFunction.setAnalysisResultList(readData);
 					readData.put("page", (int) map.get("page"));
 					readData.put("total", (int) map.get("total"));
@@ -2490,7 +2490,7 @@ public class ExcelUtil extends CoTopComponent {
 			// 기존 report와 해더 칼럼명 호환 처리가 필요한 경우 여기에 추가
 			switch (col) {
 				case "ID":
-					if(gridIdCol > -1) {
+					if (gridIdCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2498,7 +2498,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "RESULT":
-					if(resultCol > -1) {
+					if (resultCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2506,7 +2506,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "OSS NAME":
-					if(ossNameCol > -1) {
+					if (ossNameCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2514,7 +2514,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "NICKNAME":
-					if(nickNameCol > -1) {
+					if (nickNameCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2522,7 +2522,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "OSS VERSION":
-					if(ossVersionCol > -1) {
+					if (ossVersionCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2530,7 +2530,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "LICENSE":
-					if(licenseCol > -1) {
+					if (licenseCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2538,7 +2538,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "CONCLUDED LICENSE":
-					if(concludedLicenseCol > -1) {
+					if (concludedLicenseCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2546,7 +2546,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "MAIN LICENSE":
-					if(askalonoLicenseCol > -1) {
+					if (askalonoLicenseCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2554,7 +2554,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "LICENSE(SCANCODE)":
-					if(scancodeLicenseCol > -1) {
+					if (scancodeLicenseCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2562,7 +2562,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "NEED REVIEW LICENSE(ASKALONO)":
-					if(needReviewLicenseAskalonoCol > -1) {
+					if (needReviewLicenseAskalonoCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2570,7 +2570,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "NEED REVIEW LICENSE(SCANCODE)":
-					if(needReviewLicenseScancodeCol > -1) {
+					if (needReviewLicenseScancodeCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2578,7 +2578,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "DOWNLOAD LOCATION":
-					if(downloadLocationCol > -1) {
+					if (downloadLocationCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2586,7 +2586,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "HOMEPAGE":
-					if(homepageCol > -1) {
+					if (homepageCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2594,7 +2594,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "COPYRIGHT TEXT":
-					if(copyrightTextCol > -1) {
+					if (copyrightTextCol > -1) {
 						dupColList.add(col);
 					}
 					
@@ -2602,7 +2602,7 @@ public class ExcelUtil extends CoTopComponent {
 					
 					break;
 				case "COMMENT":
-					if(commentCol > -1) {
+					if (commentCol > -1) {
 						dupColList.add(col);
 					}
 					commentCol = colIdx;
@@ -2615,7 +2615,7 @@ public class ExcelUtil extends CoTopComponent {
 		}
 		
 		// header 중복 체크
-		if(!dupColList.isEmpty()) {
+		if (!dupColList.isEmpty()) {
 			String msg = dupColList.toString();
 			msg = "There are duplicated. Filed Name : ".concat(msg);
 			result.put("isValid", false);
@@ -2627,19 +2627,19 @@ public class ExcelUtil extends CoTopComponent {
 		// 필수 header 누락 시 Exception
 		List<String> colNames = new ArrayList<String>();
 		
-		if(ossNameCol < 0) {
+		if (ossNameCol < 0) {
 			colNames.add("OSS NAME");
 		}
 		
-		if(ossVersionCol < 0) {
+		if (ossVersionCol < 0) {
 			colNames.add("OSS VERSION");
 		}
 		
-		if(licenseCol < 0) {
+		if (licenseCol < 0) {
 			colNames.add("LICENSE");
 		}
 		
-		if(!colNames.isEmpty()) {
+		if (!colNames.isEmpty()) {
 			String msg = colNames.toString();
 			msg = "Column Name Empty : ".concat(msg);
 			result.put("isValid", false);
@@ -2651,15 +2651,15 @@ public class ExcelUtil extends CoTopComponent {
 		List<String> errRow = new ArrayList<>();
 		List<String> analysisListIds = new ArrayList<String>();
 		
-		for(OssAnalysis analysisBean : analysisList) {
+		for (OssAnalysis analysisBean : analysisList) {
 			analysisListIds.add(analysisBean.getGridId());
 		}
 		
 		int rowSeq = 0;
 		
-		for(String[] row : csvDataList) {
+		for (String[] row : csvDataList) {
 		    try {
-				if(rowSeq < 2) {
+				if (rowSeq < 2) {
 					rowSeq++;
 					
 					continue;
@@ -2671,7 +2671,7 @@ public class ExcelUtil extends CoTopComponent {
 				String gridId = gridIdCol < 0 ? "" : avoidNull(row[gridIdCol]).trim().replaceAll("\t", "");
 				int checkLength = analysisListIds.stream().filter(a -> a.equals(gridId)).collect(Collectors.toList()).size();
 				
-				if(checkLength == 1) {
+				if (checkLength == 1) {
 					bean.setGridId(gridId);
 					bean.setResult(resultCol < 0 ? "" : avoidNull(row[resultCol]).trim().replaceAll("\t", ""));
 					bean.setOssName(ossNameCol < 0 ? "" : avoidNull(row[ossNameCol]).trim().replaceAll("\t", ""));
@@ -2695,7 +2695,7 @@ public class ExcelUtil extends CoTopComponent {
 		    }
 		}
 		
-		if(!errRow.isEmpty()) {
+		if (!errRow.isEmpty()) {
 			String msg = errRow.toString();
 			msg = "Error Row : ".concat(msg);
 			result.put("isValid", false);
@@ -2704,7 +2704,7 @@ public class ExcelUtil extends CoTopComponent {
 			return result;
 		}
 		
-		if(analysisResultList.isEmpty()) {
+		if (analysisResultList.isEmpty()) {
 			result.put("isValid", false);
 			result.put("errorMsg", "empty Row");
 			
@@ -3077,7 +3077,7 @@ public class ExcelUtil extends CoTopComponent {
 			int ossVersionCnt = 0;
 			int licenseNameCnt = 0;
 			
-			for(Cell cell : row) {
+			for (Cell cell : row) {
 				String header = avoidNull(getCellData(cell)).trim().toUpperCase();
 				switch(header) {
 					case "BINARY/LIBRARY FILE":
@@ -3101,8 +3101,8 @@ public class ExcelUtil extends CoTopComponent {
 				}
 			}
 			
-			if(binaryNameCnt == 0 || sourceCodePathCnt == 0 || ossNameCnt == 0 || ossVersionCnt == 0 || licenseNameCnt == 0) {
-				if(checkHeaderSheetName.containsKey("checkHeaderSheetName")) {
+			if (binaryNameCnt == 0 || sourceCodePathCnt == 0 || ossNameCnt == 0 || ossVersionCnt == 0 || licenseNameCnt == 0) {
+				if (checkHeaderSheetName.containsKey("checkHeaderSheetName")) {
 					String orgSheetName = (String) checkHeaderSheetName.get("checkHeaderSheetName");
 					checkHeaderSheetName.put("checkHeaderSheetName", orgSheetName + ", " + sheet.getSheetName());
 				} else {
@@ -3116,14 +3116,14 @@ public class ExcelUtil extends CoTopComponent {
 		String analysisResultListPath = (String) map.get("analysisResultListPath");
 		File file = new File(analysisResultListPath);
 		
-		if(!file.exists()) {
+		if (!file.exists()) {
 			log.error("파일정보를 찾을 수 없습니다. file path : " + analysisResultListPath);
 			map.clear();
 			return map;
 		}
 		
-		for(File f : file.listFiles()) {
-			if(f.isFile()) {
+		for (File f : file.listFiles()) {
+			if (f.isFile()) {
 				String[] fileName = f.getName().split("\\.");
 				String fileExt = (fileName[fileName.length-1]).toUpperCase();
 				
@@ -3140,19 +3140,19 @@ public class ExcelUtil extends CoTopComponent {
 			}
 		}
 
-		try(
+		try (
 			FileReader csvFile = new FileReader(file); // CSV File만 가능함.
 			CSVReader csvReader = new CSVReader(csvFile, '|');
 		) {
 			List<String[]> allData = csvReader.readAll();
-			if(allData != null) {
+			if (allData != null) {
 				map.put("csvData", allData);
 				List<Integer> componentIdsForCsvData = new ArrayList<>();
 				
 				String componentId = "";
 				int idx = 0;
-				for(String[] csvArr : allData) {
-					if(idx < 2) {
+				for (String[] csvArr : allData) {
+					if (idx < 2) {
 						idx++;
 						continue;
 					}
@@ -3161,7 +3161,7 @@ public class ExcelUtil extends CoTopComponent {
 					componentIdsForCsvData.add(Integer.parseInt(componentId));
 				}
 				
-				if(componentIdsForCsvData.size() > 0) {
+				if (componentIdsForCsvData.size() > 0) {
 					int[] csvComponentIdList = componentIdsForCsvData.stream().mapToInt(Integer::intValue).toArray();
 					ossMaster.setCsvComponentIdList(csvComponentIdList);
 				}

--- a/src/main/java/oss/fosslight/util/FileUtil.java
+++ b/src/main/java/oss/fosslight/util/FileUtil.java
@@ -61,7 +61,7 @@ public class FileUtil {
 	public static File writeFile(MultipartFile multipart, String fPath, String fName) {
 		File file = null;
 		
-		if(multipart != null && fPath != null && fName != null) {
+		if (multipart != null && fPath != null && fName != null) {
 			try {
 				file = new File(fPath+ "/" + fName);
 				
@@ -82,7 +82,7 @@ public class FileUtil {
 	}
 
 	public static boolean transferTo(MultipartFile multipart, File file) {
-		if(multipart != null && file != null) {
+		if (multipart != null && file != null) {
 			try {
 				multipart.transferTo(file);
 				
@@ -105,13 +105,13 @@ public class FileUtil {
 	}
 	
 	public static boolean moveTo(String srcFilePath, String copyFilePath, String copyFileName) {
-		if(!StringUtil.isEmpty(srcFilePath) && !StringUtil.isEmpty(copyFilePath)) {
+		if (!StringUtil.isEmpty(srcFilePath) && !StringUtil.isEmpty(copyFilePath)) {
 			try {
 				Path srcFile = Paths.get(srcFilePath);
 				Path copyPath = Paths.get(copyFilePath);
 				
-				if(!StringUtil.isEmpty(copyFileName)) {
-					if(!Files.exists(copyPath)) {
+				if (!StringUtil.isEmpty(copyFileName)) {
+					if (!Files.exists(copyPath)) {
 						Files.createDirectory(copyPath);
 					}
 					
@@ -135,7 +135,7 @@ public class FileUtil {
 		try {
 			File dir = new File(filePath);
 			
-			if(!dir.exists()) {
+			if (!dir.exists()) {
 				dir.mkdirs();
 			}
 			
@@ -149,7 +149,7 @@ public class FileUtil {
 			
 			return false;
 		} finally {
-			if(fw != null) {
+			if (fw != null) {
 				try {
 					fw.close();
 				} catch (Exception e) {}
@@ -163,7 +163,7 @@ public class FileUtil {
 		try {
 			File dir = new File(filePath);
 
-			if(!dir.exists()) {
+			if (!dir.exists()) {
 				dir.mkdirs();
 			}
 
@@ -186,7 +186,7 @@ public class FileUtil {
      * @return
      */
     public static boolean isValidFileName(String fileName) {
-        if(fileName == null || fileName.trim().length() == 0) {
+        if (fileName == null || fileName.trim().length() == 0) {
         	return false;
         }
         
@@ -201,7 +201,7 @@ public class FileUtil {
      * @return
      */
     public static String makeValidFileName(String fileName, String replaceStr) {
-        if(fileName == null || fileName.trim().length() == 0 || replaceStr == null) {
+        if (fileName == null || fileName.trim().length() == 0 || replaceStr == null) {
             return String.valueOf(System.currentTimeMillis());      
         }
  
@@ -211,7 +211,7 @@ public class FileUtil {
 	public static void zip(String inputFolder, String filePath, String zipName, String zipRootEntryName) throws Exception {
 		// 압축파일을 저장할 파일을 선언한다.
 		File file = new File(filePath + File.separator + zipName);
-		try(			
+		try (			
 			FileOutputStream fileOutputStream = new FileOutputStream(file);
 			// ZipOutputStream 선언
 			ZipOutputStream zipOutputStream = new ZipOutputStream(fileOutputStream);
@@ -234,19 +234,19 @@ public class FileUtil {
 	public static void zipFolder(ZipOutputStream zipOutputStream, File inputFile, String parentName, String zipEntryName) throws Exception {
 		String myName = parentName + inputFile.getName() + File.separator;
 		
-		if(zipEntryName != null && zipEntryName.trim().length() > 0) {
+		if (zipEntryName != null && zipEntryName.trim().length() > 0) {
 			myName = zipEntryName + File.separator;
 		}
 		
 		// ZipEntry를 생성 후 zip 메소드에서 인자값으로 받은 파일의 구성 정보를 생성한다.
-		ZipEntry folderZipEntry = new ZipEntry(myName);
-		zipOutputStream.putNextEntry(folderZipEntry);
+		ZipEntry folderZipEntry = new ZipEntry (myName);
+		zipOutputStream.putNextEntry (folderZipEntry);
 		// zip 메소드에서 인자값으로 전달받은 파일의 구성파일들을 list형식으로 저장한다.
 		File[] contents = inputFile.listFiles();
 		
 		// inputFolder의 구성파일이 파일이면 zipFile 메소드를 호출하고,
 		// 폴더일 경우 현재 zipFolder 메소드를 재귀호출
-		if(contents != null) {
+		if (contents != null) {
 			for (File file : contents) {
 				if (file.isFile()) {
 					zipFile(zipOutputStream, file, myName);
@@ -254,18 +254,18 @@ public class FileUtil {
 					zipFolder(zipOutputStream, file, myName, "");
 				}
 				
-				zipOutputStream.closeEntry();
+				zipOutputStream.closeEntry ();
 			}
 		}
 	}
 
 	public static void zipFile(ZipOutputStream zipOutputStream, File inputFile, String parentName) throws Exception {
-		ZipEntry zipEntry = new ZipEntry(parentName + inputFile.getName());
-		try(
+		ZipEntry zipEntry = new ZipEntry (parentName + inputFile.getName());
+		try (
 			FileInputStream fileInputStream = new FileInputStream(inputFile);
 		){
 			// ZipEntry생성 후 zip 메소드에서 인자값으로 전달받은 파일의 구성 정보를 생성한다.
-			zipOutputStream.putNextEntry(zipEntry);
+			zipOutputStream.putNextEntry (zipEntry);
 			byte[] buf = new byte[4096];
 			int byteRead;
 			// 압축대상 파일을 설정된 사이즈만큼 읽어들인다.
@@ -279,18 +279,18 @@ public class FileUtil {
 	}
 	
 	public static boolean copyFile(String srcFilePath, String copyFilePath, String copyFileName) {
-		if(!StringUtil.isEmpty(srcFilePath) && !StringUtil.isEmpty(copyFilePath)) {
+		if (!StringUtil.isEmpty(srcFilePath) && !StringUtil.isEmpty(copyFilePath)) {
 			try {
 				File dir = new File(copyFilePath);
 				
-				if(!dir.exists()) {
+				if (!dir.exists()) {
 					dir.mkdirs();
 				}
 				
 				Path srcFile = Paths.get(srcFilePath);
 				Path copyPath = Paths.get(copyFilePath);
 				
-				if(!StringUtil.isEmpty(copyFileName)) {
+				if (!StringUtil.isEmpty(copyFileName)) {
 					copyPath = copyPath.resolve(copyFileName);
 				}
 				
@@ -343,7 +343,7 @@ public class FileUtil {
                 inputStream = httpConn.getInputStream();
                 String saveFilePath = saveDir + File.separator + fileName;
 
-                if(!Files.exists(Paths.get(saveDir))) {
+                if (!Files.exists(Paths.get(saveDir))) {
                     Files.createDirectories(Paths.get(saveDir));
                 }
 
@@ -359,18 +359,18 @@ public class FileUtil {
             	throw new Exception("No file to download. Server replied HTTP code: " + responseCode);
             }			
 		} finally {
-			if(httpConn != null) {
+			if (httpConn != null) {
 				try {
 					httpConn.disconnect();
 				} catch (Exception e) {}
 			}
 
-			if(outputStream != null) {
+			if (outputStream != null) {
 				try {
 					outputStream.close();
 				} catch (Exception e) {}
 			}
-			if(inputStream != null) {
+			if (inputStream != null) {
 				try {
 					inputStream.close();
 				} catch (Exception e) {}
@@ -395,7 +395,7 @@ public class FileUtil {
             fis = new FileInputStream(zipFile);
             zis = new ZipInputStream(fis);
             
-            while ((zipentry = zis.getNextEntry()) != null) {
+            while ((zipentry = zis.getNextEntry ()) != null) {
                 String filename = zipentry.getName();
                 File file = new File(directory, filename);
                 
@@ -451,11 +451,11 @@ public class FileUtil {
 			Path zipPath = Paths.get(sourceFilePath);
 			Path movePath = Paths.get(destPath);
 			
-			if(!Files.exists(movePath)) {
+			if (!Files.exists(movePath)) {
 				Files.createDirectories(movePath);
 			}
 			
-			if(Files.exists(zipPath)) {
+			if (Files.exists(zipPath)) {
 				Files.move(zipPath, movePath.resolve(zipPath.getFileName() + "_" + CommonFunction.getCurrentDateTime("yyyyMMddHHmmss")));
 			}
 		} catch (Exception e) {

--- a/src/main/java/oss/fosslight/util/OssComponentUtil.java
+++ b/src/main/java/oss/fosslight/util/OssComponentUtil.java
@@ -28,7 +28,7 @@ public class OssComponentUtil {
 	private boolean USE_AUTOCOMPLETE_LICENSE_TEXT = "true".equalsIgnoreCase(CommonFunction.getProperty("use.autocomplete.licensetext"));
 	
 	public static OssComponentUtil getInstance () {
-		if(instance == null) {
+		if (instance == null) {
 			instance = new OssComponentUtil();
 		}
 		
@@ -52,8 +52,8 @@ public class OssComponentUtil {
 		List<String> ossNameList = new ArrayList<>();
 		
 		// ossName 정보만 취득
-		for(OssComponents bean : selectedData) {
-			if(!StringUtil.isEmpty(bean.getOssName()) && !ossNameList.contains(bean.getOssName())) {
+		for (OssComponents bean : selectedData) {
+			if (!StringUtil.isEmpty(bean.getOssName()) && !ossNameList.contains(bean.getOssName())) {
 				ossNameList.add(bean.getOssName());
 			}
 		}
@@ -67,26 +67,26 @@ public class OssComponentUtil {
 		Map<String, String> ossNameInfo = CoCodeManager.OSS_INFO_UPPER_NAMES;
 		
 		// DB 정보를 기준으로 Merge
-		for(OssComponents bean : selectedData) {
+		for (OssComponents bean : selectedData) {
 			String key = (bean.getOssName() + "_" + StringUtil.nvl(bean.getOssVersion())).toUpperCase();
 			
 			// 분석결과서 업로드시 OSS VERSION을 N/A로 사용자가 지정한 경우, OSS VERSION이 공백인 OSS가 존재함에도 불구하고, 다른 OSS로 인식하여 멀티라이선스로 적용되지 않는 현상
 			// N/A인 경우 공백이 VERSION이 존재하는지 체크하고 존해할 경우 자동 치환한다.
-			if("AWS IoT Device SDK for C".equals(bean.getOssName())) {
+			if ("AWS IoT Device SDK for C".equals(bean.getOssName())) {
 				System.out.println();
 			}
 			
-			if(regData.containsKey(key)) {
+			if (regData.containsKey(key)) {
 				// 사용자가 입력한 oss 가 db에 존재한다면
 				// DB + 입력정보
 				fillList.addAll(mergeOssAndLicense(regData.get(key), bean, replaceDownloadHomepage));				
-			} else if("N/A".equalsIgnoreCase(bean.getOssVersion()) && regData.containsKey((bean.getOssName() + "_").toUpperCase()))  {
+			} else if ("N/A".equalsIgnoreCase(bean.getOssVersion()) && regData.containsKey((bean.getOssName() + "_").toUpperCase()))  {
 				bean.setOssVersion("");
 				fillList.addAll(mergeOssAndLicense(regData.get((bean.getOssName() + "_").toUpperCase()), bean, replaceDownloadHomepage));	
 			} else {
 				// DB에서 확인되지 않은 OSS
 				// 라이선스별로 row 등록
-				for(OssComponentsLicense userLicense : bean.getOssComponentsLicense()) {
+				for (OssComponentsLicense userLicense : bean.getOssComponentsLicense()) {
 					List<OssComponentsLicense> _list = new ArrayList<>();
 					_list.add(fillLicenseInfo(userLicense));
 					OssComponents newBean = (OssComponents) BeanUtils.cloneBean(bean);
@@ -97,11 +97,11 @@ public class OssComponentUtil {
 			}
 		}
 		
- 		if(!newList.isEmpty()) {
+ 		if (!newList.isEmpty()) {
 			fillList.addAll(newList);
 		}
 		
-		if(!fillList.isEmpty()) {
+		if (!fillList.isEmpty()) {
 			selectedData.clear();
 			selectedData.addAll(fillList);
 		}
@@ -119,14 +119,14 @@ public class OssComponentUtil {
 		setOssBasicInfo(ossComponent, master, replaceDownloadHomepage);
 		
 		// 멀티라이선스인 경우
-		if(CoConstDef.LICENSE_DIV_MULTI.equals(master.getLicenseDiv())) {
+		if (CoConstDef.LICENSE_DIV_MULTI.equals(master.getLicenseDiv())) {
 			mergeOssLicenseInfo(ossComponent, master);
 			
 			list.add(ossComponent);
-		} else if(CoConstDef.LICENSE_DIV_SINGLE.equals(master.getLicenseDiv()) && ossComponent.getOssComponentsLicense() != null && ossComponent.getOssComponentsLicense().size() > 1) {
+		} else if (CoConstDef.LICENSE_DIV_SINGLE.equals(master.getLicenseDiv()) && ossComponent.getOssComponentsLicense() != null && ossComponent.getOssComponentsLicense().size() > 1) {
 			// 싱글로 등록되어 있는 oss인데, 라이선스를 복수개 등록한 경우 별개의 row로 분할
 			// 사용자가 입력한 라이선스별로 별도의 row로 구성
-			for(OssComponentsLicense comLicense : ossComponent.getOssComponentsLicense()) {
+			for (OssComponentsLicense comLicense : ossComponent.getOssComponentsLicense()) {
 				OssComponents newBean = (OssComponents) BeanUtils.cloneBean(ossComponent);
 				newBean.setOssComponentsLicense(null);
 				newBean.addOssComponentsLicense(comLicense);
@@ -145,21 +145,21 @@ public class OssComponentUtil {
 	}
 	
 	private void setOssBasicInfo(OssComponents ossComponent, OssMaster master, boolean replaceDownloadHomepage) {
-		if(StringUtil.isEmpty(ossComponent.getOssId())) {
+		if (StringUtil.isEmpty(ossComponent.getOssId())) {
 			ossComponent.setOssId(master.getOssId());
 		}
 		
-		if(!replaceDownloadHomepage) {
-			if(StringUtil.isEmpty(ossComponent.getDownloadLocation())) {
+		if (!replaceDownloadHomepage) {
+			if (StringUtil.isEmpty(ossComponent.getDownloadLocation())) {
 				ossComponent.setDownloadLocation(master.getDownloadLocation());
 			}
 			
-			if(StringUtil.isEmpty(ossComponent.getHomepage())) {
+			if (StringUtil.isEmpty(ossComponent.getHomepage())) {
 				ossComponent.setHomepage(master.getHomepage());
 			}
 		}
 
-		if(StringUtil.isEmpty(ossComponent.getCopyrightText())) {
+		if (StringUtil.isEmpty(ossComponent.getCopyrightText())) {
 			ossComponent.setCopyrightText(master.getCopyright());
 		}
 		
@@ -172,12 +172,12 @@ public class OssComponentUtil {
 		List<OssComponentsLicense> subList = new ArrayList<>();
 		List<String> selectedLicenseList = new ArrayList<>();
 
-		if(CoConstDef.LICENSE_DIV_MULTI.equals(master.getLicenseDiv())) {
-			for(OssLicense subBean : master.getOssLicenses()) {
+		if (CoConstDef.LICENSE_DIV_MULTI.equals(master.getLicenseDiv())) {
+			for (OssLicense subBean : master.getOssLicenses()) {
 				OssComponentsLicense componentLicenseBean = findOssLicense(subBean, ossComponent);
 				
 				// 등록되어있는 license인 경우
-				if(componentLicenseBean != null && !selectedLicenseList.contains(componentLicenseBean.getLicenseId())) {
+				if (componentLicenseBean != null && !selectedLicenseList.contains(componentLicenseBean.getLicenseId())) {
 					selectedLicenseList.add(componentLicenseBean.getLicenseId());
 					componentLicenseBean.setExcludeYn(CoConstDef.FLAG_NO);
 				} else {
@@ -191,11 +191,11 @@ public class OssComponentUtil {
 				componentLicenseBean.setLicensetype(subBean.getLicenseType());
 				componentLicenseBean.setOssLicenseComb(subBean.getOssLicenseComb());
 				
-				if(USE_AUTOCOMPLETE_LICENSE_TEXT && StringUtil.isEmpty(componentLicenseBean.getLicenseText())) {
+				if (USE_AUTOCOMPLETE_LICENSE_TEXT && StringUtil.isEmpty(componentLicenseBean.getLicenseText())) {
 					componentLicenseBean.setLicenseText(subBean.getOssLicenseText());
 				}
 				
-				if(StringUtil.isEmpty(componentLicenseBean.getCopyrightText())) {
+				if (StringUtil.isEmpty(componentLicenseBean.getCopyrightText())) {
 					componentLicenseBean.setCopyrightText(subBean.getOssCopyright());
 				}
 				
@@ -208,7 +208,7 @@ public class OssComponentUtil {
 			OssComponentsLicense componentLicenseBean = findOssLicense(master.getOssLicenses().get(0), ossComponent);
 			
 			// 등록되어있는 license인 경우
-			if(componentLicenseBean != null && !selectedLicenseList.contains(componentLicenseBean.getLicenseId())) {
+			if (componentLicenseBean != null && !selectedLicenseList.contains(componentLicenseBean.getLicenseId())) {
 				selectedLicenseList.add(componentLicenseBean.getLicenseId());
 				
 				// DB에 등록되지 않은 라이선스가 포함된 경우 마지막 row로 추가
@@ -226,14 +226,14 @@ public class OssComponentUtil {
 	}
 	
 	private OssComponentsLicense fillLicenseInfo(OssComponentsLicense componentLicenseBean) {
-		if(CoCodeManager.LICENSE_INFO.containsKey(componentLicenseBean.getLicenseName())) {
+		if (CoCodeManager.LICENSE_INFO.containsKey(componentLicenseBean.getLicenseName())) {
 			LicenseMaster license = CoCodeManager.LICENSE_INFO.get(componentLicenseBean.getLicenseName());
 			
-			if(StringUtil.isEmpty(componentLicenseBean.getLicenseId())) {
+			if (StringUtil.isEmpty(componentLicenseBean.getLicenseId())) {
 				componentLicenseBean.setLicenseId(license.getLicenseId());
 			}
 			
-			if(USE_AUTOCOMPLETE_LICENSE_TEXT && StringUtil.isEmpty(componentLicenseBean.getLicenseText())) {
+			if (USE_AUTOCOMPLETE_LICENSE_TEXT && StringUtil.isEmpty(componentLicenseBean.getLicenseText())) {
 				componentLicenseBean.setLicenseText(license.getLicenseText());
 			}
 		}
@@ -246,25 +246,25 @@ public class OssComponentUtil {
 		List<OssComponentsLicense> returnList = new ArrayList<>();
 		List<String> ossMasterLicenseIdList = new ArrayList<>();
 		
-		for(OssLicense liBean : master.getOssLicenses()) {
+		for (OssLicense liBean : master.getOssLicenses()) {
 			ossMasterLicenseIdList.add(liBean.getLicenseId());
 		}
 		
-		for(OssComponentsLicense bean : ossComponent.getOssComponentsLicense()) {
+		for (OssComponentsLicense bean : ossComponent.getOssComponentsLicense()) {
 			boolean addflag = true;
 			
 			// 닉네임, short identify 모두 비교
-			if(CoCodeManager.LICENSE_INFO.containsKey(bean.getLicenseName())) {
+			if (CoCodeManager.LICENSE_INFO.containsKey(bean.getLicenseName())) {
 				String selectedLicenseId = CoCodeManager.LICENSE_INFO.get(bean.getLicenseName()).getLicenseId();
 				
-				if(ossMasterLicenseIdList.contains(selectedLicenseId)) {
+				if (ossMasterLicenseIdList.contains(selectedLicenseId)) {
 					addflag = false;
 				}
 			} else {
 				// 미등록 라이선스
 			}
 			
-			if(addflag && !StringUtil.isEmpty(bean.getLicenseName())) {
+			if (addflag && !StringUtil.isEmpty(bean.getLicenseName())) {
 				bean.setEditable(CoConstDef.FLAG_YES);
 				returnList.add(fillLicenseInfo(bean));
 			}
@@ -274,39 +274,39 @@ public class OssComponentUtil {
 	}
 	
 	private OssComponentsLicense findOssLicense(OssLicense dbData, OssComponents userDataList) {
-		for(OssComponentsLicense bean : userDataList.getOssComponentsLicense()) {
+		for (OssComponentsLicense bean : userDataList.getOssComponentsLicense()) {
 			String selectedLicenseId = "";
 			
 			// 대소문자 구분으로 인한 문제로, 만약 일치하는 라이선스가 있을 경우
 			// 사용자 입력 라이선스 명을 DB 명으로 변경한다.
 			String inputLicenseName = bean.getLicenseName().trim();
 			
-			if(CoCodeManager.LICENSE_INFO_UPPER.containsKey(inputLicenseName.toUpperCase())) {
+			if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(inputLicenseName.toUpperCase())) {
 				bean.setLicenseName(CoCodeManager.LICENSE_INFO_UPPER.get(inputLicenseName.toUpperCase()).getLicenseName());
 			}
 			
 			// 확인 가능한 라이선스 이면
-			if(CoCodeManager.LICENSE_INFO.containsKey(bean.getLicenseName())) {
+			if (CoCodeManager.LICENSE_INFO.containsKey(bean.getLicenseName())) {
 				LicenseMaster licenseMaster = CoCodeManager.LICENSE_INFO.get(bean.getLicenseName());
 
 				List<String> compareList = new ArrayList<>();
 				compareList.add(licenseMaster.getLicenseName());
 				
-				if(!StringUtil.isEmpty(licenseMaster.getShortIdentifier())) {
+				if (!StringUtil.isEmpty(licenseMaster.getShortIdentifier())) {
 					compareList.add(licenseMaster.getShortIdentifier());
 				}
 				
-				if(licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
+				if (licenseMaster.getLicenseNicknameList() != null && !licenseMaster.getLicenseNicknameList().isEmpty()) {
 					compareList.addAll(licenseMaster.getLicenseNicknameList());
 				}
 				
-				if(compareList.contains(bean.getLicenseName())) {
+				if (compareList.contains(bean.getLicenseName())) {
 					selectedLicenseId = licenseMaster.getLicenseId();
 				}
 			}
 			
 			// 라이선스가 라이선스 마스터에 등록되어 있어야하고, oss에 포함되는 라이선스이어야만 반환
-			if(selectedLicenseId.equals(dbData.getLicenseId())) {
+			if (selectedLicenseId.equals(dbData.getLicenseId())) {
 				bean.setLicenseId(dbData.getLicenseId());
 				
 				return bean;
@@ -321,21 +321,21 @@ public class OssComponentUtil {
 		boolean isfirst = true;
 		List<String> isSelectedDuplicatedLicenseCheckList = new ArrayList<>();
 		
-		for(OssComponentsLicense bean : allList) {
+		for (OssComponentsLicense bean : allList) {
 			boolean onSelected = CoConstDef.FLAG_YES.equals(bean.getEditable()) || selectedLicenseList.contains(bean.getLicenseId());
 			
 			// license id가 없다는 것은 사용자가 등록되지 않은 라이선스를 입력한 경우 => license master에 존재하는 경우 license id를 설정하기 때문에, Editable flag로 판단한다.
 			// 복수개의 라이선스가 설정되어 있고(OSS는 DB에 존재한다는 뜻), 처음이 아닌경우 OR 조건으로 추가한다.
-			if( CoConstDef.FLAG_YES.equals(bean.getEditable())) {
-				if(!isfirst && StringUtil.isEmpty(bean.getOssLicenseComb())) {
+			if ( CoConstDef.FLAG_YES.equals(bean.getEditable())) {
+				if (!isfirst && StringUtil.isEmpty(bean.getOssLicenseComb())) {
 					bean.setOssLicenseComb("OR");
 				}
 			}
 			
-			if(!onSelected || isSelectedDuplicatedLicenseCheckList.contains(bean.getLicenseId()) || CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+			if (!onSelected || isSelectedDuplicatedLicenseCheckList.contains(bean.getLicenseId()) || CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 				bean.setExcludeYn(CoConstDef.FLAG_YES);
 			} else {
-				if(null != bean.getLicenseId()) {
+				if (null != bean.getLicenseId()) {
 					isSelectedDuplicatedLicenseCheckList.add(bean.getLicenseId());
 				}
 				

--- a/src/main/java/oss/fosslight/util/PdfUtil.java
+++ b/src/main/java/oss/fosslight/util/PdfUtil.java
@@ -39,7 +39,7 @@ public final class PdfUtil extends CoTopComponent {
     private static ProjectMapper projectMapper;
 
     public static PdfUtil getInstance() {
-        if(instance == null) {
+        if (instance == null) {
             instance = new PdfUtil();
             licenseMapper = (LicenseMapper) getWebappContext().getBean(LicenseMapper.class);
             ossMapper = (OssMapper) getWebappContext().getBean(OssMapper.class);
@@ -82,7 +82,7 @@ public final class PdfUtil extends CoTopComponent {
 
         Map<String, Object> map = projectService.getIdentificationGridList(_param, true);
         List<ProjectIdentification> list = (List<ProjectIdentification>) map.get("rows");
-        for(ProjectIdentification projectIdentification : list) {
+        for (ProjectIdentification projectIdentification : list) {
             //OssMasterReview
             OssMaster ossMaster = new OssMaster();
             ossMaster.setOssId(projectIdentification.getOssId());
@@ -129,7 +129,7 @@ public final class PdfUtil extends CoTopComponent {
                 licenseMasterMap.put(license.getLicenseName(), license);
             }
         }
-        for(LicenseMaster licenseMaster : licenseMasterMap.values()) {
+        for (LicenseMaster licenseMaster : licenseMasterMap.values()) {
             licenseReview.add(licenseMaster);
         }
 
@@ -153,8 +153,8 @@ public final class PdfUtil extends CoTopComponent {
         VelocityEngine vf = new VelocityEngine();
         Properties props = new Properties();
 
-        for(String key : model.keySet()) {
-            if(!"templateUrl".equals(key)) {
+        for (String key : model.keySet()) {
+            if (!"templateUrl".equals(key)) {
                 context.put(key, model.get(key));
             }
         }

--- a/src/main/java/oss/fosslight/util/RequestUtil.java
+++ b/src/main/java/oss/fosslight/util/RequestUtil.java
@@ -257,7 +257,7 @@ public class RequestUtil {
 
 			List<String> ignoreParamList = new ArrayList<>();
 			if (ignoreParams != null) {
-				for(String s : Arrays.asList(ignoreParams)) {
+				for (String s : Arrays.asList(ignoreParams)) {
 					// 대소문자무시
 					ignoreParamList.add(s.toUpperCase());
 				}
@@ -265,7 +265,7 @@ public class RequestUtil {
 			
 			StringBuilder result = new StringBuilder();
 
-			if(params != null && !params.isEmpty()) {
+			if (params != null && !params.isEmpty()) {
 				for (Map.Entry<String, Object> entry : params.entrySet()) {
 					String _key = entry.getKey();
 					if (ignoreParamList.contains(_key.toUpperCase())) {
@@ -275,7 +275,7 @@ public class RequestUtil {
 						continue;
 					}
 					
-					if(convertCamelCase) {
+					if (convertCamelCase) {
 						_key = StringUtil.convert2CamelCase(_key);
 					}
 					
@@ -315,29 +315,29 @@ public class RequestUtil {
 	public static String post(String url, Map<String, Object> params, boolean convertCamalCase, String[] ignoreParams) {
 		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
 		List<String> ignoreParamList = new ArrayList<>();
-		if(ignoreParams != null) {
-			for(String s : Arrays.asList(ignoreParams)) {
+		if (ignoreParams != null) {
+			for (String s : Arrays.asList(ignoreParams)) {
 				ignoreParamList.add(s.toUpperCase());
 			}
 		}
-		if(params != null) {
-			for(String _k : params.keySet()) {
+		if (params != null) {
+			for (String _k : params.keySet()) {
 				
-				if(ignoreParamList.contains(_k.toUpperCase())) {
+				if (ignoreParamList.contains(_k.toUpperCase())) {
 					continue;
 				}
 				
 				Object _v = params.get(_k);
-				if(_v == null) {
+				if (_v == null) {
 					continue;
 				}
-				if(convertCamalCase) {
+				if (convertCamalCase) {
 					_k = StringUtil.convert2CamelCase(_k);
 				}
 				
 				if (_v instanceof List<?> || _v instanceof String) {
 					parts.add(_k, _v);
-				} else if(_v instanceof String[]) {
+				} else if (_v instanceof String[]) {
 					//2019-06-04 Javaroid 배열로 값을 전송하기 위한 처리. 고객 그룹 등록 등 일괄 처리를 위한 작업 때문에 추가하였다.
 					String[] _value = (String[])_v;
 					for (String value : _value) {

--- a/src/main/java/oss/fosslight/util/StringUtil.java
+++ b/src/main/java/oss/fosslight/util/StringUtil.java
@@ -731,7 +731,7 @@ public final class StringUtil {
 	}
 	
 	public static String deleteWhitespaceWithSpecialChar(String str) {
-		if(str == null) {
+		if (str == null) {
 			return "";
 		}
 		
@@ -4347,18 +4347,18 @@ public final class StringUtil {
 	public static String getRandom(String type, int loopCount) {
 		String dummyString="1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijlmnopqrstuvwxyz";
 		
-		if(type != null){
-			if(type.equals("123")) {
+		if (type != null){
+			if (type.equals("123")) {
 				dummyString = "1234567890";
-			} else if(type.equals("abc")) {
+			} else if (type.equals("abc")) {
 				dummyString = "abcdefghijlmnopqrstuvwxyz";
-			} else if(type.equals("ABC")) {
+			} else if (type.equals("ABC")) {
 				dummyString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-			} else if(type.equals("ABC123") || type.equals("123ABC")) {
+			} else if (type.equals("ABC123") || type.equals("123ABC")) {
 				dummyString = "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-			} else if(type.equals("abc123") || type.equals("123abc")) {
+			} else if (type.equals("abc123") || type.equals("123abc")) {
 				dummyString = "1234567890abcdefghijklmnopqrstuvwxyz";
-			} else if(type.equals("aA1!")) {
+			} else if (type.equals("aA1!")) {
 				dummyString = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@#$%_-";
 			}
 		}
@@ -4369,7 +4369,7 @@ public final class StringUtil {
 		int randomInt;
 		char tempChar;
 		
-		for(int loop=0; loop<loopCount; loop++) {
+		for (int loop=0; loop<loopCount; loop++) {
 			randomInt=random.nextInt(dummyString.length());
 			tempChar=dummyString.charAt(randomInt);
 			tempBuilder.append(tempChar);

--- a/src/main/java/oss/fosslight/util/YamlUtil.java
+++ b/src/main/java/oss/fosslight/util/YamlUtil.java
@@ -81,7 +81,7 @@ public class YamlUtil extends CoTopComponent {
 		_param.setReferenceDiv(type);
 		_param.setReferenceId(projectBean.getPrjId());
 		
-		if(CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
+		if (CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
 			_param.setMerge(CoConstDef.FLAG_NO);
 		}
 		
@@ -90,8 +90,8 @@ public class YamlUtil extends CoTopComponent {
 		List<ProjectIdentification> list = (List<ProjectIdentification>) map.get(CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type) ? "rows" : "mainData");
 		String jsonStr = "";
 		
-		if(list != null) {
-			if(CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
+		if (list != null) {
+			if (CoConstDef.CD_DTL_COMPONENT_ID_BOM.equals(type)) {
 				jsonStr = toJson(checkYamlFormat(projectService.setMergeGridData(list), type));
 			} else {
 				jsonStr = toJson(checkYamlFormat(setMergeData(list, type)));
@@ -118,7 +118,7 @@ public class YamlUtil extends CoTopComponent {
 		list = (List<ProjectIdentification>) map.get("mainData");
 		
 		String jsonStr = "";
-		if(list != null) {
+		if (list != null) {
 			jsonStr = toJson(checkYamlFormat(setMergeData(list, typeCode)));
 		}
 		
@@ -142,7 +142,7 @@ public class YamlUtil extends CoTopComponent {
 		list = (List<ProjectIdentification>) map.get("mainData");
 		
 		String jsonStr = "";
-		if(list != null) {
+		if (list != null) {
 			jsonStr = toJson(checkYamlFormat(setMergeData(list, typeCode)));
 		}
 		
@@ -158,21 +158,21 @@ public class YamlUtil extends CoTopComponent {
 	public static LinkedHashMap<String, List<Map<String, Object>>> checkYamlFormat(List<ProjectIdentification> list, String typeCode) {
 		LinkedHashMap<String, List<Map<String, Object>>> result = new LinkedHashMap<>();
 		
-		for(ProjectIdentification bean : list) {
+		for (ProjectIdentification bean : list) {
 			List<Map<String, Object>> ossNameResult = new ArrayList<>();
 			LinkedHashMap<String, Object> yamlFormat = new LinkedHashMap<>();
 				
-			if(!isEmpty(bean.getOssVersion())) {
+			if (!isEmpty(bean.getOssVersion())) {
 				yamlFormat.put("version", bean.getOssVersion());
 			} else{
 				yamlFormat.put("version", "");
 			}
 
-			if(isEmpty(typeCode)) {
-				if(!isEmpty(bean.getBinaryName())) {
+			if (isEmpty(typeCode)) {
+				if (!isEmpty(bean.getBinaryName())) {
 					String binaryNameStr = bean.getBinaryName();
 					yamlFormat.put("source name or path", binaryNameStr.contains("\n") ? binaryNameStr.split("\n") : binaryNameStr);
-				} else if(!isEmpty(bean.getFilePath())) {
+				} else if (!isEmpty(bean.getFilePath())) {
 					String filePathStr = bean.getFilePath();
 					yamlFormat.put("source name or path", filePathStr.contains("\n") ? filePathStr.split("\n") : filePathStr);
 				}
@@ -181,31 +181,31 @@ public class YamlUtil extends CoTopComponent {
 			String licenseNameStr = bean.getLicenseName();
 			yamlFormat.put("license",	licenseNameStr.contains(",") ? licenseNameStr.split(",") : licenseNameStr);
 
-			if(!isEmpty(bean.getDownloadLocation())) {
+			if (!isEmpty(bean.getDownloadLocation())) {
 				yamlFormat.put("download location", bean.getDownloadLocation());
 			}
 
-			if(!isEmpty(bean.getHomepage())) {
+			if (!isEmpty(bean.getHomepage())) {
 				yamlFormat.put("homepage", 	bean.getHomepage());
 			}
 
-			if(!isEmpty(bean.getCopyrightText())) {
+			if (!isEmpty(bean.getCopyrightText())) {
 				String copyrightStr = bean.getCopyrightText();
 				yamlFormat.put("copyright text", copyrightStr.contains("\n") ? Arrays.asList(copyrightStr.split("\n")) : copyrightStr);
 			}
 			
-			if(CoConstDef.FLAG_YES.equals(avoidNull(bean.getExcludeYn(), CoConstDef.FLAG_NO))) {
+			if (CoConstDef.FLAG_YES.equals(avoidNull(bean.getExcludeYn(), CoConstDef.FLAG_NO))) {
 				yamlFormat.put("exclude", true);
 			}
 			
-			if(!isEmpty(bean.getComments())) {
+			if (!isEmpty(bean.getComments())) {
 				yamlFormat.put("comment", bean.getComments());
 			}
 			String ossNameStr = bean.getOssName();
-			if(ossNameStr.length() == 0) {
+			if (ossNameStr.length() == 0) {
 				ossNameStr = "-";
 			}
-			if(result.containsKey(ossNameStr)) {
+			if (result.containsKey(ossNameStr)) {
 				ossNameResult = result.get(ossNameStr);
 			}
 			ossNameResult.add(yamlFormat);
@@ -222,13 +222,13 @@ public class YamlUtil extends CoTopComponent {
 		String yamlStr = "";
 		
 		try {
-			if(!isEmpty(jsonStr)) {
+			if (!isEmpty(jsonStr)) {
 				JsonNode jsonNodeTree = new ObjectMapper().readTree(jsonStr);
 		        // save it as YAML
 				yamlStr = new YAMLMapper().writeValueAsString(jsonNodeTree);
 				yamlStr = yamlStr.replaceAll("---","").trim();
 				// 접두사 존재시 추가
-				if(!isEmpty(suffix)) {
+				if (!isEmpty(suffix)) {
 					yamlStr = suffix + yamlStr;
 				}
 			}
@@ -243,7 +243,7 @@ public class YamlUtil extends CoTopComponent {
 		String jsonStr = "";
 		
 		try {
-			if(!isEmpty(yamlStr)) {
+			if (!isEmpty(yamlStr)) {
 			
 				ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
 			    Object obj = yamlReader.readValue(yamlStr, Object.class);
@@ -267,7 +267,7 @@ public class YamlUtil extends CoTopComponent {
 		FileOutputStream outFile = null;
 		
 		try {
-			if(!Files.exists(Paths.get(filePath))) {
+			if (!Files.exists(Paths.get(filePath))) {
 				Files.createDirectories(Paths.get(filePath));
 			}
 			outFile = new FileOutputStream(filePath + logiFileName);
@@ -278,7 +278,7 @@ public class YamlUtil extends CoTopComponent {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		} finally {
-			if(outFile != null) {
+			if (outFile != null) {
 				try {
 					outFile.close();
 				} catch (Exception e2) {}
@@ -305,18 +305,18 @@ public class YamlUtil extends CoTopComponent {
 			}
 		});
 		
-		for(ProjectIdentification info : list) {
-			if(isEmpty(groupColumn)) {
+		for (ProjectIdentification info : list) {
+			if (isEmpty(groupColumn)) {
 				groupColumn = makeMergeKey(info, typeCode);
 			}
 			
-			if("-".equals(groupColumn)) {
-				if("NA".equals(info.getLicenseType())) {
+			if ("-".equals(groupColumn)) {
+				if ("NA".equals(info.getLicenseType())) {
 					ossNameEmptyFlag = true;
 				}
 			}
 			
-			if(groupColumn.equals(makeMergeKey(info, typeCode)) // 같은 groupColumn이면 데이터를 쌓음
+			if (groupColumn.equals(makeMergeKey(info, typeCode)) // 같은 groupColumn이면 데이터를 쌓음
 					&& !ossNameEmptyFlag) { // 단, OSS Name: - 이면서, License Type: Proprietary이 아닌 경우 Row를 합치지 않음.
 				tempData.add(info);
 			} else { // 다른 grouping
@@ -335,11 +335,11 @@ public class YamlUtil extends CoTopComponent {
 	}
 	
 	public static void setMergeData(List<ProjectIdentification> tempData, List<ProjectIdentification> resultGridData){
-		if(tempData.size() > 0) {
+		if (tempData.size() > 0) {
 			Collections.sort(tempData, new Comparator<ProjectIdentification>() {
 				@Override
 				public int compare(ProjectIdentification o1, ProjectIdentification o2) {
-					if(o1.getLicenseName().length() >= o2.getLicenseName().length()) { // license name이 같으면 bomList조회해온 순서 그대로 유지함. license name이 다르면 순서변경
+					if (o1.getLicenseName().length() >= o2.getLicenseName().length()) { // license name이 같으면 bomList조회해온 순서 그대로 유지함. license name이 다르면 순서변경
 						return 1;
 					}else {
 						return -1;
@@ -349,16 +349,16 @@ public class YamlUtil extends CoTopComponent {
 			
 			ProjectIdentification rtnBean = null;
 			
-			for(ProjectIdentification temp : tempData) {
-				if(rtnBean == null) {
+			for (ProjectIdentification temp : tempData) {
+				if (rtnBean == null) {
 					rtnBean = temp;
 					continue;
 				}
 				
 				String key = temp.getOssName() + "-" + temp.getLicenseType();
 				
-				if("--NA".equals(key)) {
-					if(!rtnBean.getLicenseName().contains(temp.getLicenseName())) {
+				if ("--NA".equals(key)) {
+					if (!rtnBean.getLicenseName().contains(temp.getLicenseName())) {
 						resultGridData.add(rtnBean);
 						rtnBean = temp;
 						continue;
@@ -366,17 +366,17 @@ public class YamlUtil extends CoTopComponent {
 				}
 				
 				// 동일한 oss name과 version일 경우 license 정보를 중복제거하여 merge 함.
-				for(String licenseName : temp.getLicenseName().split(",")) {
+				for (String licenseName : temp.getLicenseName().split(",")) {
 					boolean equalFlag = false;
 					
-					for(String rtnLicenseName : rtnBean.getLicenseName().split(",")) {
-						if(rtnLicenseName.equals(licenseName)) {
+					for (String rtnLicenseName : rtnBean.getLicenseName().split(",")) {
+						if (rtnLicenseName.equals(licenseName)) {
 							equalFlag = true;
 							break;
 						}
 					}
 					
-					if(!equalFlag) {
+					if (!equalFlag) {
 						rtnBean.setLicenseName(rtnBean.getLicenseName() + "," + licenseName);
 					}
 				}

--- a/src/main/java/oss/fosslight/validation/T2BasicValidator.java
+++ b/src/main/java/oss/fosslight/validation/T2BasicValidator.java
@@ -11,15 +11,15 @@ public abstract class T2BasicValidator extends T2CoValidator{
 	protected String PROC_MODE;
 	
     public void setAppendix(String key, Object obj){
-    	if(!isEmpty(key) && obj != null) {
-    		if("PROC_MODE".equals(key)) {
+    	if (!isEmpty(key) && obj != null) {
+    		if ("PROC_MODE".equals(key)) {
     			this.PROC_MODE = (String) obj;
     		}
     	}
     }
     
     protected String treatment(String paramvalue){
-        if(paramvalue == null) {
+        if (paramvalue == null) {
           return null;
         }
 

--- a/src/main/java/oss/fosslight/validation/T2CoValidMap.java
+++ b/src/main/java/oss/fosslight/validation/T2CoValidMap.java
@@ -13,7 +13,7 @@ public class T2CoValidMap<K,V> extends HashMap<K, V> {
     public V get(Object o){
         V v = (V)super.get(o);
         
-        if(v == null) {
+        if (v == null) {
         	throw new IllegalArgumentException("key " + o + " doesn't exist");
         }
         

--- a/src/main/java/oss/fosslight/validation/T2CoValidationConfig.java
+++ b/src/main/java/oss/fosslight/validation/T2CoValidationConfig.java
@@ -55,7 +55,7 @@ public class T2CoValidationConfig extends CoTopComponent {
     }
     
     public static T2CoValidationConfig getInstance(){
-        if(instance == null){
+        if (instance == null){
             throw new IllegalStateException("not initialized");
         }
         
@@ -96,23 +96,23 @@ public class T2CoValidationConfig extends CoTopComponent {
     		}
         }
         
-        for(Object oKey : map.keySet()){
+        for (Object oKey : map.keySet()){
             String key = (String)oKey;
             
-            if(key.indexOf(".") < 0 ){
+            if (key.indexOf(".") < 0 ){
                 continue;
             }
             
             String val = (String) map.get(key);
 
-            while(val.matches(".*\\$\\{[\\w\\d_]+\\}.*")){
+            while (val.matches(".*\\$\\{[\\w\\d_]+\\}.*")){
                 String refKey = val.replaceFirst(".*\\$\\{([\\w\\d]+)\\}.*", "$1");
                 String refVal = ((String) map.get(key)).replaceAll("\\\\", "\\\\\\\\");//escape 재처리
                 val = val.replaceAll("\\$\\{" + refKey + "\\}", refVal);
             }
 
             //Map에 값추가
-            if(key.endsWith(".MSG")){
+            if (key.endsWith(".MSG")){
                 String ruleKey = key.substring(0, key.length() - 4);//.MSG제거
                 messageConfigMap.put(ruleKey.toUpperCase(), val);
             }else{
@@ -120,10 +120,10 @@ public class T2CoValidationConfig extends CoTopComponent {
                 String ruleType = key.substring(ruleKey.length() + 1).toUpperCase();
                 ruleKey = ruleKey.replaceAll("\\\\\\.", "\\.");//.을 escape 해서 제거
 
-                if(ruleTypeDef.contains(ruleType)){
+                if (ruleTypeDef.contains(ruleType)){
                     Map<String, String> rule = ruleMap.get(ruleKey);
                     
-                    if(rule == null){
+                    if (rule == null){
                         rule = new HashMap<>();
                         ruleMap.put(ruleKey.toUpperCase(), rule);
                     }
@@ -142,7 +142,7 @@ public class T2CoValidationConfig extends CoTopComponent {
     }
     
     public void reload() throws IOException{
-        if(instance != null){
+        if (instance != null){
         	instance.load();
         }else{
             throw new IllegalStateException("not initialized.");

--- a/src/main/java/oss/fosslight/validation/T2CoValidationResult.java
+++ b/src/main/java/oss/fosslight/validation/T2CoValidationResult.java
@@ -51,7 +51,7 @@ public class T2CoValidationResult {
     }
     
     public Map<String, String> getErrorCodeMap(){
-        if(errMap == null){
+        if (errMap == null){
             return new HashMap<String, String>();
         }else{
             return errMap;
@@ -59,7 +59,7 @@ public class T2CoValidationResult {
     }
     
     public Map<String, String> getWarningCodeMap(){
-        if(diffMap == null){
+        if (diffMap == null){
             return new HashMap<String, String>();
         }else{
             return diffMap;
@@ -67,7 +67,7 @@ public class T2CoValidationResult {
     }
     
     public Map<String, String> getInfoCodeMap(){
-        if(infoMap == null){
+        if (infoMap == null){
             return new HashMap<String, String>();
         }else{
             return infoMap;
@@ -95,7 +95,7 @@ public class T2CoValidationResult {
     }
     
     public Map<String, String> getValidDataMap(){
-        if(isValid()){
+        if (isValid()){
             return validDataMap;
         }
         
@@ -117,15 +117,15 @@ public class T2CoValidationResult {
     public String getValidMessage(String key){
         boolean printErrCd = false;
         
-        if(errMap == null || !errMap.containsKey(key)){
+        if (errMap == null || !errMap.containsKey(key)){
             return "";
-        }else if(messageMap == null || !messageMap.containsKey(errMap.get(key))){
+        }else if (messageMap == null || !messageMap.containsKey(errMap.get(key))){
             return errMap.get(key);
         }else{
             String errCd = errMap.get(key);
             String msg;
             
-            if(errCd.endsWith(".LENGTH")){
+            if (errCd.endsWith(".LENGTH")){
                 Map<String,String> rule = ruleMap.get(key);
 
                 // key에 해당ㅇ하는 rule이 없을 경우
@@ -134,7 +134,7 @@ public class T2CoValidationResult {
                     String rootKey = key.replaceFirst("\\.\\d+", "");
                     rule = ruleMap.get(rootKey);
                     
-                    if(rule == null && key.indexOf(".") > -1) {
+                    if (rule == null && key.indexOf(".") > -1) {
                     	rootKey = key.substring(0, key.indexOf("."));
                     	rule = ruleMap.get(rootKey);
                     }
@@ -150,7 +150,7 @@ public class T2CoValidationResult {
     }
     
     public String format(String str){
-        if(str == null || "".equals(str)) {
+        if (str == null || "".equals(str)) {
         	return "";
         }
         
@@ -162,24 +162,24 @@ public class T2CoValidationResult {
     }
     
     public Map<String, String> getFormattedMessageMap(){
-        if(errMap == null) {
+        if (errMap == null) {
         	return new HashMap<>();
         }
 
         Map<String, String> formatted = new HashMap<>();
         Iterator<String> itr = errMap.keySet().iterator();
         
-        while(itr.hasNext()){
+        while (itr.hasNext()){
             String key = (String)itr.next();
             String camelKey = key;
             
-            if(CoConstDef.VALIDATION_USE_CAMELCASE) {
+            if (CoConstDef.VALIDATION_USE_CAMELCASE) {
             	camelKey = StringUtil.convertToCamelCase(camelKey);
             }
             
             formatted.put(camelKey, getFormattedMessage(key));
             
-            if(!StringUtil.isEmpty(getFormattedMessage(key))) {
+            if (!StringUtil.isEmpty(getFormattedMessage(key))) {
             	formatted.put(camelKey+"Style", "style=\"background:#FEF8F8;border:1px solid #FF0000;\"");
             }
         }
@@ -193,12 +193,12 @@ public class T2CoValidationResult {
     	Map<String, String> messageMap = new HashMap<>();
         Iterator<String> itr = errMap.keySet().iterator();
         
-        while(itr.hasNext()){
+        while (itr.hasNext()){
         	String key = (String)itr.next();
             String camelKey = key;
             
-            if(CoConstDef.VALIDATION_USE_CAMELCASE) {
-            	if(camelKey.indexOf(".") > -1) {
+            if (CoConstDef.VALIDATION_USE_CAMELCASE) {
+            	if (camelKey.indexOf(".") > -1) {
             		String _name = StringUtil.convertToCamelCase(camelKey.substring(0, camelKey.indexOf(".")));
             		String _rowId = camelKey.substring(camelKey.indexOf("."));
             		camelKey = _name + _rowId;
@@ -219,12 +219,12 @@ public class T2CoValidationResult {
     	Map<String, String> messageMap = new HashMap<>();
         Iterator<String> itr = diffMap.keySet().iterator();
         
-        while(itr.hasNext()){
+        while (itr.hasNext()){
         	String key = (String)itr.next();
             String camelKey = key;
             
-            if(CoConstDef.VALIDATION_USE_CAMELCASE) {
-            	if(camelKey.indexOf(".") > -1) {
+            if (CoConstDef.VALIDATION_USE_CAMELCASE) {
+            	if (camelKey.indexOf(".") > -1) {
             		String _name = StringUtil.convertToCamelCase(camelKey.substring(0, camelKey.indexOf(".")));
             		String _rowId = camelKey.substring(camelKey.indexOf("."));
             		camelKey = _name + _rowId;
@@ -241,7 +241,7 @@ public class T2CoValidationResult {
     }
     
     public boolean isDiff(){
-    	if(diffMap == null) {
+    	if (diffMap == null) {
     		throw new IllegalStateException("Not validated yet.");
     	}
     	
@@ -251,15 +251,15 @@ public class T2CoValidationResult {
     public String getDiffMessage(String key){
         boolean printErrCd = false;
         
-        if(diffMap == null || !diffMap.containsKey(key)){
+        if (diffMap == null || !diffMap.containsKey(key)){
             return "";
-        }else if(messageMap == null || !messageMap.containsKey(diffMap.get(key))){
+        }else if (messageMap == null || !messageMap.containsKey(diffMap.get(key))){
             return diffMap.get(key);
         }else{
             String errCd = diffMap.get(key);
             String msg;
             
-            if(errCd.endsWith(".LENGTH")){
+            if (errCd.endsWith(".LENGTH")){
                 Map<String,String> rule = ruleMap.get(key);
                 
                 // key에 해당ㅇ하는 rule이 없을 경우
@@ -268,7 +268,7 @@ public class T2CoValidationResult {
                     String rootKey = key.replaceFirst("\\.\\d+", "");
                     rule = ruleMap.get(rootKey);
                     
-                    if(rule == null && key.indexOf(".") > -1) {
+                    if (rule == null && key.indexOf(".") > -1) {
                     	rootKey = key.substring(0, key.indexOf("."));
                     	rule = ruleMap.get(rootKey);
                     }
@@ -287,11 +287,11 @@ public class T2CoValidationResult {
     	Map<String, String> messageMap = new HashMap<>();
         Iterator<String> itr = infoMap.keySet().iterator();
         
-        while(itr.hasNext()){
+        while (itr.hasNext()){
         	String key = (String)itr.next();
             String camelKey = key;
             
-            if(CoConstDef.VALIDATION_USE_CAMELCASE) {
+            if (CoConstDef.VALIDATION_USE_CAMELCASE) {
             	camelKey = StringUtil.convertToCamelCase(camelKey);
             }
             
@@ -304,7 +304,7 @@ public class T2CoValidationResult {
     }
     
     public boolean hasInfo(){
-    	if(infoMap == null) {
+    	if (infoMap == null) {
     		throw new IllegalStateException("Not validated yet.");
     	}
     	
@@ -314,15 +314,15 @@ public class T2CoValidationResult {
     public String getInfoMessage(String key){
         boolean printErrCd = false;
         
-        if(infoMap == null || !infoMap.containsKey(key)){
+        if (infoMap == null || !infoMap.containsKey(key)){
             return "";
-        }else if(messageMap == null || !messageMap.containsKey(infoMap.get(key))){
+        }else if (messageMap == null || !messageMap.containsKey(infoMap.get(key))){
             return infoMap.get(key);
         }else{
             String errCd = infoMap.get(key);
             String msg;
             
-            if(errCd.endsWith(".LENGTH")){
+            if (errCd.endsWith(".LENGTH")){
                 Map<String,String> rule = ruleMap.get(key);
                 
                 // key에 해당ㅇ하는 rule이 없을 경우
@@ -331,7 +331,7 @@ public class T2CoValidationResult {
                     String rootKey = key.replaceFirst("\\.\\d+", "");
                     rule = ruleMap.get(rootKey);
                     
-                    if(rule == null && key.indexOf(".") > -1) {
+                    if (rule == null && key.indexOf(".") > -1) {
                     	rootKey = key.substring(0, key.indexOf("."));
                     	rule = ruleMap.get(rootKey);
                     }
@@ -358,11 +358,11 @@ public class T2CoValidationResult {
     	Iterator<String> itr = errMap.keySet().iterator();
     	boolean result = true;
   
-		while(itr.hasNext()){
+		while (itr.hasNext()){
 			String key = (String)itr.next();
 			String componentId = key.split("\\.")[1];
 			
-			if(adminCheckList.indexOf(componentId) == -1) {
+			if (adminCheckList.indexOf(componentId) == -1) {
 				result = false;
 			}
 		}

--- a/src/main/java/oss/fosslight/validation/T2CoValidator.java
+++ b/src/main/java/oss/fosslight/validation/T2CoValidator.java
@@ -52,14 +52,14 @@ public abstract class T2CoValidator extends CoTopComponent {
     }
     
     public void setHint(String keys){
-        if(keys != null){
+        if (keys != null){
             hint = Arrays.asList(keys.split("\\s*,\\s*"));
             log.trace("HINT:" + hint);
         }
     }
     
     public void setIgnore(String keys){
-        if(keys != null){
+        if (keys != null){
             ignore = Arrays.asList(keys.split("\\s*,\\s*"));
             log.trace("IGNORE:" + ignore);
         }
@@ -79,14 +79,14 @@ public abstract class T2CoValidator extends CoTopComponent {
         int limitLength = getLimitLength(rule);
         String[] inputs = nvl(inputValue).split("\\t");
 
-        for(String input:inputs){
-            if(!ignoreRequired && isRequired(rule) && isEmpty(input) ){
+        for (String input:inputs){
+            if (!ignoreRequired && isRequired(rule) && isEmpty(input) ){
                 //필수체크
                 errCd = "REQUIRED";
-            }else if( limitLength < safeLength(input) ){
+            }else if ( limitLength < safeLength(input) ){
                 //길이체크
                 errCd = "LENGTH";
-            }else if(
+            }else if (
                 !isEmpty(input) &&
                 !input.matches(rule.get("FORMAT"))
             ){
@@ -94,7 +94,7 @@ public abstract class T2CoValidator extends CoTopComponent {
                 errCd = "FORMAT";
             }
 
-            if(errCd != null){
+            if (errCd != null){
                 break;
             }
         }
@@ -103,8 +103,8 @@ public abstract class T2CoValidator extends CoTopComponent {
     }
     
     private void printDebugLog(String inputValue, String errCd, String ruleKey, String ruleKeySeq){
-        if(ruleMap != null) {
-            if(errCd != null) {
+        if (ruleMap != null) {
+            if (errCd != null) {
                 Map<String, String> rule = getRule(ruleKey);
                 
                 log.trace("basic validation for [" + ruleKey + "] ----------------");
@@ -125,18 +125,18 @@ public abstract class T2CoValidator extends CoTopComponent {
         saveRequest(request, reqMap, keyPreMap);
         T2CoValidationResult vr = validate(reqMap);
         
-        if(map != null){
+        if (map != null){
             map.putAll(reqMap);
         }
         
         // key prefix 처리 추가
-        if(keyPreMap != null && !keyPreMap.isEmpty() && !vr.getErrorCodeMap().isEmpty()) {
+        if (keyPreMap != null && !keyPreMap.isEmpty() && !vr.getErrorCodeMap().isEmpty()) {
         	// Data Key 복원
         	Map<String, String> errMap = vr.getErrorCodeMap();
         	Map<String, String> replaceErrMap = new HashMap<>();
 
-        	for(String key : errMap.keySet()) {
-        		if(key.indexOf("@") > -1) {
+        	for (String key : errMap.keySet()) {
+        		if (key.indexOf("@") > -1) {
         			String paramName = key.substring(key.indexOf("@")+1);
         			String restoreKey = key.replaceAll(keyPreMap.get(paramName)+"@", "");
         			
@@ -166,7 +166,7 @@ public abstract class T2CoValidator extends CoTopComponent {
     	Map<String, String> reqMap = null;
     	List<String> gridKeys = null;
     	
-    	if(source instanceof List<?>) {
+    	if (source instanceof List<?>) {
     		reqMap = new HashMap<>();
     		gridKeys = new ArrayList<>();
         	int seqSuffix = 1;
@@ -175,7 +175,7 @@ public abstract class T2CoValidator extends CoTopComponent {
         	for (Object sourceVO : (List<Object>)source) {
         		_gridKey = avoidNull(((ComBean)sourceVO).getGridId(), ((ComBean)sourceVO).getNo());
         		
-        		if(!isEmpty(_gridKey)) {
+        		if (!isEmpty(_gridKey)) {
         			gridKeys.add(_gridKey); 
         		}
         		
@@ -185,13 +185,13 @@ public abstract class T2CoValidator extends CoTopComponent {
             reqMap = ConverObjectToMap(source, -1, keyPre);
     	}
     	
-    	if(map != null) {
+    	if (map != null) {
     		reqMap.putAll(map);
     	}
     	
         T2CoValidationResult vr = validate(reqMap);
         
-        if(!isEmpty(keyPre)) {
+        if (!isEmpty(keyPre)) {
 			//STEP. 
 		    //keyPre 변수가 있을시
 		    //validation_properties의 property 중 Prefix@ 형태를 제거한후
@@ -199,7 +199,7 @@ public abstract class T2CoValidator extends CoTopComponent {
         	Map<String, String> errMap = vr.getErrorCodeMap();
         	Map<String, String> replaceErrMap = new HashMap<>();
         	
-        	for(String key : errMap.keySet()) {
+        	for (String key : errMap.keySet()) {
         		replaceErrMap.put(key.replaceAll(keyPre+"@", ""), errMap.get(key));
         	}
         	
@@ -207,16 +207,16 @@ public abstract class T2CoValidator extends CoTopComponent {
         }
         
         // 시퀀스 번호를 grid key 값으로 치환한다.
-        if(gridKeys != null && !gridKeys.isEmpty() && !vr.getErrorCodeMap().isEmpty()) {
+        if (gridKeys != null && !gridKeys.isEmpty() && !vr.getErrorCodeMap().isEmpty()) {
         	Map<String, String> errMap = vr.getErrorCodeMap();
         	Map<String, String> addErrMap = new HashMap<>();
         	
-        	 for(String key : errMap.keySet()) {
-        		 if(key.indexOf(".") > -1) {
+        	 for (String key : errMap.keySet()) {
+        		 if (key.indexOf(".") > -1) {
         			 String seqStr = key.substring(key.indexOf(".") +1);
         			 int seq = StringUtil.string2integer(seqStr);
         			 
-        			 if(gridKeys.size() >= seq) {
+        			 if (gridKeys.size() >= seq) {
         				 addErrMap.put(key.replace("." + seqStr, "." + gridKeys.get(seq -1)), errMap.get(key));
         			 }
         		 }else{
@@ -225,7 +225,7 @@ public abstract class T2CoValidator extends CoTopComponent {
         	 }
         	 
         	 //Grid에 대한 에러맵이 존재할 경우 결과에 격납
-        	 if(!addErrMap.isEmpty()) {
+        	 if (!addErrMap.isEmpty()) {
         		 vr.setErrorCodeMap(addErrMap);
         	 }
         }
@@ -242,25 +242,25 @@ public abstract class T2CoValidator extends CoTopComponent {
 		Map<String, String> resultMap = new HashMap<>();
 		Method[] methods = obj.getClass().getMethods();
 		
-		for(Method method : methods){
+		for (Method method : methods){
 			// is getter check
 			if (!(!method.getName().startsWith("get") || method.getParameterTypes().length != 0
 					|| void.class.equals(method.getReturnType()) 
 					|| !(String.class.equals(method.getReturnType()) || String[].class.equals(method.getReturnType())))) {
 				Object valueObj = invokeGetter(method.getName(), obj);
 				
-				if(valueObj != null) {
+				if (valueObj != null) {
 					String key = StringUtil.convertToUnderScore(method.getName().substring(3)).toUpperCase();
 					
-					if(seq > 0) {
+					if (seq > 0) {
 						key += "." + Integer.toString(seq);
 					}
 					
-					if(valueObj instanceof String[]) {
+					if (valueObj instanceof String[]) {
 						String tempVal = "";
 						
-						for(String strVal : (String[]) valueObj) {
-							if(!isEmpty(tempVal)) {
+						for (String strVal : (String[]) valueObj) {
+							if (!isEmpty(tempVal)) {
 								tempVal += "\t";
 							}
 							
@@ -270,7 +270,7 @@ public abstract class T2CoValidator extends CoTopComponent {
 						valueObj = tempVal;
 					}
 					
-					if(!isEmpty(keyPre)) {
+					if (!isEmpty(keyPre)) {
 						key = keyPre + "@" + key;
 					}
 					
@@ -287,18 +287,18 @@ public abstract class T2CoValidator extends CoTopComponent {
 		Object variableValue = null;
 		
 		try {
-			if(name.startsWith("get")) {
+			if (name.startsWith("get")) {
 				objPropertyDescriptor = new PropertyDescriptor((String)name.substring(3), obj.getClass());
 				variableValue = objPropertyDescriptor.getReadMethod() != null ? objPropertyDescriptor.getReadMethod().invoke(obj) : null;
 			}
 		} catch (IntrospectionException e) {
-			//if(log.isDebugEnabled()) {e.printStackTrace();}
+			//if (log.isDebugEnabled()) {e.printStackTrace();}
 		} catch (IllegalAccessException e) {
-			//if(log.isDebugEnabled()) {e.printStackTrace();}
+			//if (log.isDebugEnabled()) {e.printStackTrace();}
 		} catch (IllegalArgumentException e) {
-			//if(log.isDebugEnabled()) {e.printStackTrace();}
+			//if (log.isDebugEnabled()) {e.printStackTrace();}
 		} catch (InvocationTargetException e) {
-			//if(log.isDebugEnabled()) {e.printStackTrace();}
+			//if (log.isDebugEnabled()) {e.printStackTrace();}
 		}
 		return variableValue;
 	}
@@ -310,10 +310,10 @@ public abstract class T2CoValidator extends CoTopComponent {
         {
             Iterator<String> itr = hint.iterator();
             
-            while(itr.hasNext()){
+            while (itr.hasNext()){
                 String mustHave = (String)itr.next();
                 
-                if(!map.containsKey(mustHave)){
+                if (!map.containsKey(mustHave)){
                     map.put(mustHave, "");
                 }
             }
@@ -333,14 +333,14 @@ public abstract class T2CoValidator extends CoTopComponent {
         try{
             Iterator<String> itr = ruleMap.keySet().iterator();
             
-            while(itr.hasNext()){
+            while (itr.hasNext()){
                 String ruleKey = (String)itr.next();
                 boolean doValidate = false;
                 Map<String, String> rule = getRule(ruleKey);
                 List<String> seqSuffix = new ArrayList<String>();
                 
-                if("TRUE".equalsIgnoreCase(rule.get("USE_SEQUENCE"))) {
-                    for(int i = 1; map.containsKey(ruleKey + "." + i); i++) {
+                if ("TRUE".equalsIgnoreCase(rule.get("USE_SEQUENCE"))) {
+                    for (int i = 1; map.containsKey(ruleKey + "." + i); i++) {
                         seqSuffix.add("." + i);
                     }
                 } else {
@@ -349,22 +349,22 @@ public abstract class T2CoValidator extends CoTopComponent {
 
                 Iterator<String> itr2 = seqSuffix.iterator();
                 
-                while(itr2.hasNext()){
+                while (itr2.hasNext()){
                     String ruleKeySeq = ruleKey + (String)itr2.next(); // 연번 이없는 경우는 ruleKey 와 같음
                     
-                    if(map.containsKey(ruleKeySeq)) {
+                    if (map.containsKey(ruleKeySeq)) {
                         doValidate = true;
-                    } else if(rule.containsKey("COMPOSITE")) {
+                    } else if (rule.containsKey("COMPOSITE")) {
                         StringBuffer buf = new StringBuffer();
                         String[] comp = parseExp(rule.get("COMPOSITE"));
                         boolean hasInputKey = false;
                         boolean hasInputValue = false;
                         
-                        for(int i = 0; i < comp.length; i++){
-                            if(comp[i].matches("'.*'")){
+                        for (int i = 0; i < comp.length; i++){
+                            if (comp[i].matches("'.*'")){
                                 buf.append(comp[i].substring(1,comp[i].length() - 1));
                             }else{
-                                if(map.containsKey(comp[i])){
+                                if (map.containsKey(comp[i])){
                                     doValidate = true;
                                     hasInputKey = true;
                                     String s = map.get(comp[i]);
@@ -375,21 +375,21 @@ public abstract class T2CoValidator extends CoTopComponent {
                             }
                         }
                         
-                        if(hasInputKey){
+                        if (hasInputKey){
                             map.put(ruleKeySeq, hasInputValue ? buf.toString() : "");// COMPSITE로 설정한 값을 추가
                         }
                     }
 
                     doValidate = (doValidate || this.hint.contains(ruleKey)) && !this.ignore.contains(ruleKey);
 
-                    if(doValidate){
+                    if (doValidate){
                         String errCd = basicValidation(map.get(ruleKeySeq), rule);
 
-                        if(log.isDebugEnabled()){
+                        if (log.isDebugEnabled()){
                             printDebugLog(map.get(ruleKeySeq), errCd, ruleKey, ruleKeySeq);
                         }
 
-                        if(errCd != null){
+                        if (errCd != null){
                             errCd = ruleKey + "." + errCd;
                             errMap.put(ruleKeySeq, errCd);
                         }else{
@@ -417,7 +417,7 @@ public abstract class T2CoValidator extends CoTopComponent {
         try {
             maxLength = Integer.parseInt((String)rule.get("LENGTH"));
             
-            if(maxLength < 0) {
+            if (maxLength < 0) {
             	throw new Exception();
             }
         } catch(Exception e) {
@@ -434,27 +434,27 @@ public abstract class T2CoValidator extends CoTopComponent {
     public void saveRequest(ServletRequest request, Map<String, String> map, Map<String, String> keyPreMap){
         Enumeration<?> names = request.getParameterNames();
         
-        while( names.hasMoreElements() ){
+        while ( names.hasMoreElements() ){
         	boolean ignore = false;
             String name = (String) names.nextElement();
             String value = "";
             
-            if(request.getParameterValues(name).length > 1){
+            if (request.getParameterValues(name).length > 1){
                 String[] vals = request.getParameterValues(name);
                 Map<String,String> rule = getRule(CoConstDef.VALIDATION_USE_CAMELCASE ? StringUtil.convertToUnderScore(name).toUpperCase() : name);
                 
-                if(rule != null && "TRUE".equalsIgnoreCase(rule.get("USE_SEQUENCE"))) {
-                    for(int i = 0; i < vals.length; i++){
+                if (rule != null && "TRUE".equalsIgnoreCase(rule.get("USE_SEQUENCE"))) {
+                    for (int i = 0; i < vals.length; i++){
                         value = vals[i];
                         
-                    	if(i == 0) {
-                    		if(CoConstDef.VALIDATION_USE_CAMELCASE) {
+                    	if (i == 0) {
+                    		if (CoConstDef.VALIDATION_USE_CAMELCASE) {
                     			name = StringUtil.convertToUnderScore(name).toUpperCase();
                     		}
                     		
                     		String _val = "";
                     		
-                    		for(int subIdx = 0; subIdx < vals.length; subIdx++){
+                    		for (int subIdx = 0; subIdx < vals.length; subIdx++){
                     			_val = (subIdx == 0 ? "" : value + "\t") + vals[subIdx];
                     		}
                     		
@@ -466,7 +466,7 @@ public abstract class T2CoValidator extends CoTopComponent {
                     
                     ignore = true;
                 } else {
-                    for(int i = 0; i < vals.length; i++){
+                    for (int i = 0; i < vals.length; i++){
                         value = (i == 0 ? "" : value + "\t") + vals[i];
                     }                	
                 }
@@ -474,8 +474,8 @@ public abstract class T2CoValidator extends CoTopComponent {
                 value = request.getParameter(name);
             }
             
-            if(!ignore) {
-            	if(CoConstDef.VALIDATION_USE_CAMELCASE) {
+            if (!ignore) {
+            	if (CoConstDef.VALIDATION_USE_CAMELCASE) {
             		name = StringUtil.convertToUnderScore(name).toUpperCase();
             	}
             	
@@ -487,7 +487,7 @@ public abstract class T2CoValidator extends CoTopComponent {
     }
 
     private String convertPrefixKey(String name, Map<String, String> keyPreMap) {
-    	if(keyPreMap != null && keyPreMap.containsKey(name)) {
+    	if (keyPreMap != null && keyPreMap.containsKey(name)) {
     		return keyPreMap.get(name) + "@" + name;
     	}
     	
@@ -497,7 +497,7 @@ public abstract class T2CoValidator extends CoTopComponent {
     public boolean isRequired(String key){
         checkStatus();
         
-        if(key == null) {
+        if (key == null) {
         	throw new NullPointerException("key name is null.");
         }
         
@@ -514,7 +514,7 @@ public abstract class T2CoValidator extends CoTopComponent {
     }
     
     public String getCustomMessage(String key){
-    	if(messageConfigMap.containsKey(key)) {
+    	if (messageConfigMap.containsKey(key)) {
     		return messageConfigMap.get(key);
     	}
     	
@@ -523,7 +523,7 @@ public abstract class T2CoValidator extends CoTopComponent {
     }
     
     private void checkStatus(){
-        if(this.ruleMap == null){
+        if (this.ruleMap == null){
             throw new IllegalStateException("No Validation Rule.");
         }
         
@@ -543,7 +543,7 @@ public abstract class T2CoValidator extends CoTopComponent {
         Map<String, String> map = new HashMap<String, String>();
         Iterator<String> itr = ruleMap.keySet().iterator();
         
-        while(itr.hasNext()){
+        while (itr.hasNext()){
             String key = (String) itr.next();
             map.put(key, isRequired(key) ? marker : "");
         }
@@ -556,7 +556,7 @@ public abstract class T2CoValidator extends CoTopComponent {
         Map<String, String> map = new HashMap<String, String>();
         Iterator<String> itr = ruleMap.keySet().iterator();
         
-        while(itr.hasNext()){
+        while (itr.hasNext()){
             String key = (String) itr.next();
             map.put(key, getLimitString(key));
         }
@@ -578,14 +578,14 @@ public abstract class T2CoValidator extends CoTopComponent {
             Iterator<String> itr = map.keySet().iterator();
             Map<String,String> addition = new HashMap<String, String>();
             
-            while(itr.hasNext()){
+            while (itr.hasNext()){
                 String key = (String)itr.next();
                 Map<String,String> rule = getRule(key);
 
-                if(ruleMap.containsKey(key) && rule.get("COPY_WHEN_INIT") != null){
+                if (ruleMap.containsKey(key) && rule.get("COPY_WHEN_INIT") != null){
                     String copyTo = rule.get("COPY_WHEN_INIT");
                     
-                    if(!map.containsKey(copyTo)){
+                    if (!map.containsKey(copyTo)){
                         addition.put(copyTo, map.get(key));
                     }
                 }
@@ -598,38 +598,38 @@ public abstract class T2CoValidator extends CoTopComponent {
             Iterator<String> itr = map.keySet().iterator();
             Map<String,String> addition = new HashMap<String, String>();
             
-            while(itr.hasNext()){
+            while (itr.hasNext()){
                 String key = (String)itr.next();
                 Map<String,String> rule = getRule(key);
 
-                if(rule.containsKey("COMPOSITE")){
+                if (rule.containsKey("COMPOSITE")){
                     String val = map.get(key);
                     String[] comp = parseExp(rule.get("COMPOSITE"));
                     String[] split = null;
                     
-                    if(rule.containsKey("SPLIT_WHEN_INIT")){
+                    if (rule.containsKey("SPLIT_WHEN_INIT")){
                         split = parseExp(rule.get("SPLIT_WHEN_INIT"));
                         
-                        if(comp.length != split.length){
+                        if (comp.length != split.length){
                             throw new IllegalArgumentException("inconsistency of COMPOSITE and SPLIT_WHEN_INIT of rule map.");
                         }
                     }
-                    for(int i = 0; i < comp.length; i++){
-                        if(isEmpty(val)) {
-                            if(!comp[i].matches("'.*'")){
+                    for (int i = 0; i < comp.length; i++){
+                        if (isEmpty(val)) {
+                            if (!comp[i].matches("'.*'")){
                                 addition.put(comp[i], "");
                             }
                         } else {
-                            if(comp.length - 1 <= i) {
+                            if (comp.length - 1 <= i) {
                                 //last element
-                                if(!comp[i].matches("'.*'")) {
+                                if (!comp[i].matches("'.*'")) {
                                     addition.put(comp[i], val);
                                 }
                             } else {
                                 //has next
-                                if(!comp[i].matches("'.*'")) {
+                                if (!comp[i].matches("'.*'")) {
 
-                                    if(comp[i + 1].matches("'.*'")) {
+                                    if (comp[i + 1].matches("'.*'")) {
                                         // 다음 COMPOSITE 요소 가 리터럴 이라면, 그 리터럴 직전까지 ( 없으면 끝까지 ) 를 취득
                                         String literal = comp[i + 1].substring(1, comp[i + 1].length() - 1);
                                         int p = val.indexOf(literal) < 0 ? val.length() : val.indexOf(literal);
@@ -639,7 +639,7 @@ public abstract class T2CoValidator extends CoTopComponent {
                                         // 다음 COMPOSITE 요소 가 변수 라면 지정 이 있으면 그 길이 없으면 끝까지 취득
                                         int limit = val.length();//값의 최대치를 초기화
                                         
-                                        if(split != null){
+                                        if (split != null){
                                             try{
                                                 limit = Integer.parseInt(split[i].replaceFirst(".+\\{(\\d+)\\}$", "$1"));
                                             }catch(Exception e){
@@ -671,7 +671,7 @@ public abstract class T2CoValidator extends CoTopComponent {
     }
     
     private String baseTreatment(String s){
-        if(s == null){
+        if (s == null){
             return null;
         }
         
@@ -702,10 +702,10 @@ public abstract class T2CoValidator extends CoTopComponent {
 		String errCd = "";
 		Map<String, String> ruleMap = getRule(basicKey);
 		
-		if(ruleMap != null && !ruleMap.isEmpty()) {
+		if (ruleMap != null && !ruleMap.isEmpty()) {
 			errCd = basicValidation(val, ruleMap, ignoreRequired);
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errCd = basicKey + "." + errCd;
 			}
 		}

--- a/src/main/java/oss/fosslight/validation/custom/DistributionValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/DistributionValidator.java
@@ -20,7 +20,7 @@ public class DistributionValidator extends T2CoValidator {
 	
 	@Override
 	protected void customValidation(Map<String, String> map, Map<String, String> errMap, Map<String, String> diffMap, Map<String, String> infoMap) {
-		if(dataBean != null) {
+		if (dataBean != null) {
 			// basic validation
 			String basicKey = "";
 			boolean isMod = !isEmpty(dataBean.getDistributeDeployTime());
@@ -30,7 +30,7 @@ public class DistributionValidator extends T2CoValidator {
 				basicKey = "DISTRIBUTE_NAME";
 				String errCd = checkBasicError(basicKey, dataBean.getDistributeName(), isMod);
 				
-				if(!isEmpty(errCd)) {
+				if (!isEmpty(errCd)) {
 					errMap.put(basicKey, errCd);
 				}
 			}
@@ -40,48 +40,48 @@ public class DistributionValidator extends T2CoValidator {
 				basicKey = "DISTRIBUTE_MASTER_CATEGORY";
 				String errCd = checkBasicError(basicKey, dataBean.getDistributeMasterCategory(), isMod);
 				
-				if(!isEmpty(errCd)) {
+				if (!isEmpty(errCd)) {
 					errMap.put(basicKey, errCd);
 				}
 			}
 			
 			// model info
-			if(dataBean.getModelList() != null && !dataBean.getModelList().isEmpty()) {
+			if (dataBean.getModelList() != null && !dataBean.getModelList().isEmpty()) {
 				// 중복체크
 				List<String> modelDuplCheckList = new ArrayList<>();
 				List<String> dupKeyList = new ArrayList<>();
 				
-				for(Project bean : dataBean.getModelList()) {
+				for (Project bean : dataBean.getModelList()) {
 					String key = avoidNull(bean.getCategory()) + "|" + avoidNull(bean.getModelName()).trim().toUpperCase();
 					
-					if(dupKeyList.contains(key)) {
+					if (dupKeyList.contains(key)) {
 						modelDuplCheckList.add(key);
 					} else {
 						dupKeyList.add(key);
 					}
 				}
 				
-				for(Project bean : dataBean.getModelList()) {
+				for (Project bean : dataBean.getModelList()) {
 					// model name
 					basicKey = "MODEL_NAME";
 					
 					String errCd = checkBasicError(basicKey, bean.getModelName());
-					if(!isEmpty(errCd)) {
+					if (!isEmpty(errCd)) {
 						errMap.put(basicKey + "." + bean.getGridId(), errCd);
-					} else if(modelDuplCheckList.contains(avoidNull(bean.getCategory()) + "|" + avoidNull(bean.getModelName()).trim().toUpperCase())){
+					} else if (modelDuplCheckList.contains(avoidNull(bean.getCategory()) + "|" + avoidNull(bean.getModelName()).trim().toUpperCase())){
 						errMap.put(basicKey + "." + bean.getGridId(), basicKey + ".DUPLICATED");
-					} else if(avoidNull(bean.getModelName()).trim().length() < 2) {
+					} else if (avoidNull(bean.getModelName()).trim().length() < 2) {
 						errMap.put(basicKey + "." + bean.getGridId(), basicKey + ".MINLENGTH");
 					}
 					
 					basicKey = "RELEASE_DATE";
 					errCd = checkBasicError(basicKey, bean.getReleaseDate());
 					
-					if(!isEmpty(errCd)) {
+					if (!isEmpty(errCd)) {
 						errMap.put(basicKey + "." + bean.getGridId(), errCd);
 					}
 				}
-			} else if("Distribution".equalsIgnoreCase(validType)) {
+			} else if ("Distribution".equalsIgnoreCase(validType)) {
 				errMap.put("VALID_MSG_MODEL_LIST", "MODEL_NAME.REQUIRED_INFO");
 			}
 			
@@ -95,7 +95,7 @@ public class DistributionValidator extends T2CoValidator {
 
 	@Override
 	public void setAppendix(String key, Object obj) {
-		if("project".equals(key)) {
+		if ("project".equals(key)) {
 			this.dataBean = (Project) obj;
 		}
  	}

--- a/src/main/java/oss/fosslight/validation/custom/T2CoAdminValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoAdminValidator.java
@@ -32,12 +32,12 @@ public class T2CoAdminValidator extends T2BasicValidator {
         String targetKey2 = "";
         
         // 코드 관리
-        if(CoConstDef.GRID_OPERATION_ADD.equals(map.get("OPER")) && map.containsKey(targetKey) && !errMap.containsKey(targetKey)) {
+        if (CoConstDef.GRID_OPERATION_ADD.equals(map.get("OPER")) && map.containsKey(targetKey) && !errMap.containsKey(targetKey)) {
         	// 중목체크
         	T2Code vo = new T2Code();
         	vo.setCdNo(map.get(targetKey));
         	
-        	if(codeService.isExists(vo)) {
+        	if (codeService.isExists(vo)) {
         		errMap.put(targetKey, targetKey + ".DUPLICATED");
         	}
         }
@@ -45,16 +45,16 @@ public class T2CoAdminValidator extends T2BasicValidator {
         // 코드 상세 등록 /수정
         targetKey = "CD_DTL_NO";
         
-        if(map.containsKey("CD_DTL_NO.1")) {
+        if (map.containsKey("CD_DTL_NO.1")) {
         	// 중목체크
         	List<String> cdDtlList = new ArrayList<>();
-        	for(int i = 1; map.containsKey(targetKey + "." + i); i++){
+        	for (int i = 1; map.containsKey(targetKey + "." + i); i++){
         		String _seqkey = targetKey + "." + i;
         		
-        		if(!errMap.containsKey(_seqkey)) {
+        		if (!errMap.containsKey(_seqkey)) {
             		String val = map.get(_seqkey);
             		
-            		if(cdDtlList.contains(val)) {
+            		if (cdDtlList.contains(val)) {
             			// 중목
             			errMap.put(_seqkey, targetKey + ".DUPLICATED");
             		} else {
@@ -68,22 +68,22 @@ public class T2CoAdminValidator extends T2BasicValidator {
         targetKey = "USER_ID";
         targetKey2 = "USER_PW";
         
-        if(map.containsKey(targetKey) && map.containsKey(targetKey2) && !errMap.containsKey(targetKey) && !errMap.containsKey(targetKey2)) {
+        if (map.containsKey(targetKey) && map.containsKey(targetKey2) && !errMap.containsKey(targetKey) && !errMap.containsKey(targetKey2)) {
         	// 기 등록 여부 체크
         	T2Users _param = new T2Users();
         	_param.setUserId(map.get(targetKey));
         	
-        	if(!isEmpty(_param.getUserId()) && userService.checkDuplicateId(_param)) {
+        	if (!isEmpty(_param.getUserId()) && userService.checkDuplicateId(_param)) {
         		errMap.put(targetKey, targetKey+".DUPLICATED");
         	}
         	
         	String ldapFlag = CoCodeManager.getCodeExpString(CoConstDef.CD_SYSTEM_SETTING, CoConstDef.CD_LDAP_USED_FLAG);
         	 
-        	if(CoConstDef.FLAG_YES.equals(ldapFlag)) { // configuration에서 LDAP을 선택시만 check함.
-	        	if(!isEmpty(map.get(targetKey2))) {
-	        		if(!userService.checkAdAccounts(map, targetKey, targetKey2, null)) {
-	        			if(map.containsKey("EMAIL") && !errMap.containsKey("EMAIL")) {
-	        				if(!userService.checkAdAccounts(map, "EMAIL", targetKey2, null)) {
+        	if (CoConstDef.FLAG_YES.equals(ldapFlag)) { // configuration에서 LDAP을 선택시만 check함.
+	        	if (!isEmpty(map.get(targetKey2))) {
+	        		if (!userService.checkAdAccounts(map, targetKey, targetKey2, null)) {
+	        			if (map.containsKey("EMAIL") && !errMap.containsKey("EMAIL")) {
+	        				if (!userService.checkAdAccounts(map, "EMAIL", targetKey2, null)) {
 	        					errMap.put(targetKey2, targetKey2+".AUTH");
 	        				}
 	        			} else {
@@ -96,13 +96,13 @@ public class T2CoAdminValidator extends T2BasicValidator {
         
         targetKey = "EMAIL";
         
-        if(map.containsKey(targetKey) && !errMap.containsKey(targetKey)) {
+        if (map.containsKey(targetKey) && !errMap.containsKey(targetKey)) {
         	// email 등록 여부 체크
         	String email = (String) map.get(targetKey);
         	
-        	if(!isEmpty(email)) {
+        	if (!isEmpty(email)) {
         		List<T2Users> duplicateEmailList = userService.checkEmail(email);
-        		if(duplicateEmailList.size() > 0) {
+        		if (duplicateEmailList.size() > 0) {
         			errMap.put(targetKey, targetKey+".DUPLICATED");
         		}
         	}

--- a/src/main/java/oss/fosslight/validation/custom/T2CoLicenseValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoLicenseValidator.java
@@ -26,15 +26,15 @@ public class T2CoLicenseValidator extends T2CoValidator {
 	
 	@Override
 	protected void customValidation(Map<String, String> map, Map<String, String> errMap, Map<String, String> diffMap, Map<String, String> infoMap) {
-		if(PROC_TYPE_DELETE.equals(PROC_TYPE)) {
+		if (PROC_TYPE_DELETE.equals(PROC_TYPE)) {
 			List<OssMaster> result = licenseService.checkExistsUsedOss(licenseId);
 			
-			if(result != null && !result.isEmpty()) {
+			if (result != null && !result.isEmpty()) {
 				String errMsg = MessageFormat.format(getCustomMessage("LICENSE_NAME.OSSUSED"), result.size());
 				int ossCnt = 1;
 				
-				for(OssMaster bean : result) {
-					if(ossCnt > 40) {
+				for (OssMaster bean : result) {
+					if (ossCnt > 40) {
 						errMsg += "<br>...";
 						
 						break;
@@ -53,8 +53,8 @@ public class T2CoLicenseValidator extends T2CoValidator {
 			// 1. license name 
 			targetName = "LICENSE_NAME";
 			
-			if(!errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
-				if(map.get(targetName).contains(CoConstDef.CD_COMMA_CHAR)) {
+			if (!errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
+				if (map.get(targetName).contains(CoConstDef.CD_COMMA_CHAR)) {
 					errMap.put(targetName, targetName + ".NOTALLOWED_CHAR");
 				}else {
 					// DB체크만
@@ -62,7 +62,7 @@ public class T2CoLicenseValidator extends T2CoValidator {
 					param.setLicenseName(map.get(targetName));
 					LicenseMaster result = licenseService.checkExistsLicense(param);
 					
-					if(result != null) {
+					if (result != null) {
 						errMap.put(targetName, MessageFormat.format(getCustomMessage(targetName + ".DUPLICATED"), map.get(targetName), result.getLicenseId(), result.getLicenseId(), result.getLicenseName()));
 					}
 				}
@@ -71,11 +71,11 @@ public class T2CoLicenseValidator extends T2CoValidator {
 			// 2. SHORT_IDENTIFIER
 			targetName = "SHORT_IDENTIFIER";
 			
-			if(!errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
+			if (!errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
 				// 2-1 license name 과 같은 경우
-				if(map.get(targetName).contains(CoConstDef.CD_COMMA_CHAR)) {
+				if (map.get(targetName).contains(CoConstDef.CD_COMMA_CHAR)) {
 					errMap.put(targetName, targetName + ".NOTALLOWED_CHAR");
-				} else if(map.get(targetName).equalsIgnoreCase(avoidNull(map.get("LICENSE_NAME")))) {
+				} else if (map.get(targetName).equalsIgnoreCase(avoidNull(map.get("LICENSE_NAME")))) {
 					errMap.put(targetName, targetName + ".SAME");
 				} else {
 					// 2-2 db 에 존재하는 경우
@@ -83,7 +83,7 @@ public class T2CoLicenseValidator extends T2CoValidator {
 					param.setLicenseName(map.get(targetName));
 					LicenseMaster result = licenseService.checkExistsLicense(param);
 					
-					if(result != null) {
+					if (result != null) {
 						errMap.put(targetName, MessageFormat.format(getCustomMessage(targetName + ".DUPLICATED"), map.get(targetName), result.getLicenseId(), result.getLicenseId(), result.getLicenseName()));
 					}
 				}
@@ -92,13 +92,13 @@ public class T2CoLicenseValidator extends T2CoValidator {
 			// 3. NICK NAME
 			targetName = "LICENSE_NICKNAMES";
 			
-			if(!errMap.containsKey(targetName) && (map.containsKey(targetName + ".1") || map.containsKey(targetName) )) {
+			if (!errMap.containsKey(targetName) && (map.containsKey(targetName + ".1") || map.containsKey(targetName) )) {
 	        	List<String> nickNameKeyList = new ArrayList<>();
 	        	
-	        	if(!map.containsKey(targetName + ".1")) {
+	        	if (!map.containsKey(targetName + ".1")) {
 	        		checkLicenseNickName(errMap, map, nickNameKeyList, targetName, licenseId);
 	        	} else {
-	            	for(int i = 1; map.containsKey(targetName + "." + i); i++){
+	            	for (int i = 1; map.containsKey(targetName + "." + i); i++){
 	            		String _seqkey = targetName + "." + i;
 	            		checkLicenseNickName(errMap, map, nickNameKeyList, _seqkey, licenseId);
 	            	}
@@ -110,20 +110,20 @@ public class T2CoLicenseValidator extends T2CoValidator {
 	private void checkLicenseNickName(Map<String, String> errMap, Map<String, String> map, List<String> nickNameKeyList, String _seqkey, String licenseId) {
 		String targetName = "LICENSE_NICKNAMES";
 		
-		if(isEmpty(map.get(_seqkey))) {
+		if (isEmpty(map.get(_seqkey))) {
 			return;
 		}
-		if(!errMap.containsKey(_seqkey)) {
+		if (!errMap.containsKey(_seqkey)) {
 			// 3-1 동일한 닉네임을 입력한 경우
-			if(nickNameKeyList.contains(map.get(_seqkey).toUpperCase())) {
+			if (nickNameKeyList.contains(map.get(_seqkey).toUpperCase())) {
 				errMap.put(_seqkey, targetName + ".SAME");
 			} else {
 				String nickName = map.get(_seqkey).toUpperCase(); 
 				nickNameKeyList.add(nickName);
 				
-				if(nickName.contains(CoConstDef.CD_COMMA_CHAR)) {
+				if (nickName.contains(CoConstDef.CD_COMMA_CHAR)) {
 					errMap.put(_seqkey, targetName + ".NOTALLOWED_CHAR");
-				} else if(map.get(_seqkey).equalsIgnoreCase(avoidNull(map.get("LICENSE_NAME")))
+				} else if (map.get(_seqkey).equalsIgnoreCase(avoidNull(map.get("LICENSE_NAME")))
 						|| map.get(_seqkey).equalsIgnoreCase(avoidNull(map.get("SHORT_IDENTIFIER")))) { // 3-2 license name 또는 SHORT_IDENTIFIER 과 같은 경우
 					errMap.put(_seqkey, targetName + ".SAME");
 				} else {
@@ -132,7 +132,7 @@ public class T2CoLicenseValidator extends T2CoValidator {
 					param.setLicenseName(map.get(_seqkey));
 					LicenseMaster result = licenseService.checkExistsLicense(param);
 					
-					if(result != null) {
+					if (result != null) {
 						errMap.put(_seqkey, MessageFormat.format(getCustomMessage(targetName + ".DUPLICATED"), map.get(_seqkey), result.getLicenseId(), result.getLicenseId(), result.getLicenseName()));
 					}
 				}
@@ -146,7 +146,7 @@ public class T2CoLicenseValidator extends T2CoValidator {
 
 	@Override
 	public void setAppendix(String key, Object obj) {
-		if("licenseId".equals(key)) {
+		if ("licenseId".equals(key)) {
 			this.licenseId = (String) obj;
 		}
 	}

--- a/src/main/java/oss/fosslight/validation/custom/T2CoOssValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoOssValidator.java
@@ -44,44 +44,44 @@ public class T2CoOssValidator extends T2CoValidator {
 		String ossId = avoidNull(map.get("OSS_ID"));
 		// oss 일괄등록 validator
 
-		if(VALID_TYPE == VALID_OSSLIST_BULK) {
-			if(ossList != null) {
-				for(OssMaster bean : ossList) {
+		if (VALID_TYPE == VALID_OSSLIST_BULK) {
+			if (ossList != null) {
+				for (OssMaster bean : ossList) {
 					ossBulkValidate(bean, map, errMap, diffMap, infoMap, true);
 				}
 			}
-		} else if(VALID_TYPE == VALID_OSS_BULK) {
+		} else if (VALID_TYPE == VALID_OSS_BULK) {
 			ossValidate(ossMaster, map, errMap, diffMap, infoMap, false);
-		} else if(VALID_TYPE == VALID_OSSANALYSIS) {
+		} else if (VALID_TYPE == VALID_OSSANALYSIS) {
 			ossAnalysisValidate(ossAnalysis, map, errMap, diffMap, infoMap, false);
-		} else if(VALID_TYPE == VALID_OSSANALYSIS_LIST) {
-			if(analysisList != null) {
-				for(OssAnalysis bean : analysisList) {
+		} else if (VALID_TYPE == VALID_OSSANALYSIS_LIST) {
+			if (analysisList != null) {
+				for (OssAnalysis bean : analysisList) {
 					ossAnalysisValidate(bean, map, errMap, diffMap, infoMap, true);
 				}
 			}
-		} else if(VALID_TYPE == VALID_DOWNLOADLOCATION){ // DOWNLOAD LOCATION URL을 중복으로 작성한 경우
+		} else if (VALID_TYPE == VALID_DOWNLOADLOCATION){ // DOWNLOAD LOCATION URL을 중복으로 작성한 경우
 			targetName = "DOWNLOAD_LOCATION";
 			
-			if(isEmpty(ossId) && !errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
+			if (isEmpty(ossId) && !errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
 				OssMaster param = new OssMaster();
 				param.setDownloadLocation(map.get(targetName));
 				param.setOssName((String) map.get("OSS_NAME"));
 				Map<String, Object> paramMap = ossService.checkExistsOssDownloadLocation(param);
 				List<OssMaster> downLoadLocationList = (List<OssMaster>) paramMap.get("downloadLocation");
 				
-				if(!downLoadLocationList.isEmpty()) {
+				if (!downLoadLocationList.isEmpty()) {
 					String sortOrder = downLoadLocationList.get(0).getSOrder();
 					String msg = "";
 					
-					if("1".equals(sortOrder)) {
+					if ("1".equals(sortOrder)) {
 						msg = MessageFormat.format(getCustomMessage(targetName + ".DUPLICATED"), "");
 					} else {
 						msg = MessageFormat.format(getCustomMessage(targetName + ".PARTIAL_DUPLICATED"), "");
 					}
 					
-					for(int i = 0 ; i < downLoadLocationList.size() ; i++) {
-						if("1".equals(sortOrder) && !"1".equals(downLoadLocationList.get(i).getSOrder())) {
+					for (int i = 0 ; i < downLoadLocationList.size() ; i++) {
+						if ("1".equals(sortOrder) && !"1".equals(downLoadLocationList.get(i).getSOrder())) {
 							msg += "<br>" + MessageFormat.format(getCustomMessage(targetName + ".PARTIAL_DUPLICATED"), "");
 							msg += MessageFormat.format(getCustomMessage(targetName + ".LIST_LINK"), downLoadLocationList.get(i).getOssName(), downLoadLocationList.get(i).getOssName());
 						} else {
@@ -93,33 +93,33 @@ public class T2CoOssValidator extends T2CoValidator {
 					diffMap.put(targetName, msg);
 				}
 			}
-		} else if(VALID_TYPE == VALID_DOWNLOADLOCATIONS){
+		} else if (VALID_TYPE == VALID_DOWNLOADLOCATIONS){
 			targetName = "DOWNLOAD_LOCATIONS";
 			
-			if(isEmpty(ossId) && !errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
+			if (isEmpty(ossId) && !errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
 				String[] downloadLocations = map.get(targetName).split("\t");
 				targetName = "DOWNLOAD_LOCATION";
 				List<String> result = new ArrayList<String>();
 				
-				for(String downloadLocation : downloadLocations){
+				for (String downloadLocation : downloadLocations){
 					OssMaster param = new OssMaster();
 					param.setDownloadLocation(downloadLocation);
 					param.setOssName((String) map.get("OSS_NAME"));
 					Map<String, Object> paramMap = ossService.checkExistsOssDownloadLocation(param);
 					List<OssMaster> downLoadLocationList = (List<OssMaster>) paramMap.get("downloadLocation");
 					
-					if(!downLoadLocationList.isEmpty()) {
+					if (!downLoadLocationList.isEmpty()) {
 						String sortOrder = downLoadLocationList.get(0).getSOrder();
 						String msg = "";
 						
-						if("1".equals(sortOrder)) {
+						if ("1".equals(sortOrder)) {
 							msg = MessageFormat.format(getCustomMessage(targetName + ".DUPLICATED"), "");
 						} else {
 							msg = MessageFormat.format(getCustomMessage(targetName + ".PARTIAL_DUPLICATED"), "");
 						}
 						
-						for(int i = 0 ; i < downLoadLocationList.size() ; i++) {
-							if("1".equals(sortOrder) && !"1".equals(downLoadLocationList.get(i).getSOrder())) {
+						for (int i = 0 ; i < downLoadLocationList.size() ; i++) {
+							if ("1".equals(sortOrder) && !"1".equals(downLoadLocationList.get(i).getSOrder())) {
 								msg += "<br>" + MessageFormat.format(getCustomMessage(targetName + ".PARTIAL_DUPLICATED"), "");
 								msg += MessageFormat.format(getCustomMessage(targetName + ".LIST_LINK"), downLoadLocationList.get(i).getOssName(), downLoadLocationList.get(i).getOssName());
 							} else {
@@ -132,31 +132,31 @@ public class T2CoOssValidator extends T2CoValidator {
 					}
 				}
 				
-				if(result.size() > 0){
+				if (result.size() > 0){
 					diffMap.put("DOWNLOAD_LOCATIONS", StringUtils.join(result, "||"));
 				}
 			}
-		} else if(VALID_TYPE == VALID_HOMEPAGE){ // HOMEPAGE URL을 중복으로 작성한 경우
+		} else if (VALID_TYPE == VALID_HOMEPAGE){ // HOMEPAGE URL을 중복으로 작성한 경우
 			targetName = "HOMEPAGE";
-			if(isEmpty(ossId) && !errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
+			if (isEmpty(ossId) && !errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
 				OssMaster param = new OssMaster();
 				param.setHomepage(map.get(targetName));
 				param.setOssName((String) map.get("OSS_NAME"));
 				Map<String, Object> paramMap = ossService.checkExistsOssHomepage(param);
 				List<OssMaster> homepageList = (List<OssMaster>) paramMap.get("homepage");
 				
-				if(!homepageList.isEmpty()) {
+				if (!homepageList.isEmpty()) {
 					String sortOrder = homepageList.get(0).getSOrder();
 					String msg = "";
 					
-					if("1".equals(sortOrder)) {
+					if ("1".equals(sortOrder)) {
 						msg = MessageFormat.format(getCustomMessage(targetName + ".DUPLICATED"), "");
 					} else {
 						msg = MessageFormat.format(getCustomMessage(targetName + ".PARTIAL_DUPLICATED"), "");
 					}
 					
-					for(int i = 0 ; i < homepageList.size() ; i++) {
-						if("1".equals(sortOrder) && !"1".equals(homepageList.get(i).getSOrder())) {
+					for (int i = 0 ; i < homepageList.size() ; i++) {
+						if ("1".equals(sortOrder) && !"1".equals(homepageList.get(i).getSOrder())) {
 							msg += "<br>" + MessageFormat.format(getCustomMessage(targetName + ".PARTIAL_DUPLICATED"), "");
 							msg += MessageFormat.format(getCustomMessage(targetName + ".LIST_LINK"), homepageList.get(i).getOssName(), homepageList.get(i).getOssName());
 						} else {
@@ -172,14 +172,14 @@ public class T2CoOssValidator extends T2CoValidator {
 			// 1. version
 			targetName = "OSS_VERSION";
 			
-			if(!errMap.containsKey(targetName) && map.containsKey(targetName)) {
+			if (!errMap.containsKey(targetName) && map.containsKey(targetName)) {
 				// DB체크만
 				OssMaster param = new OssMaster(ossId);
 				param.setOssVersion(map.get(targetName));
 				param.setOssName(map.get("OSS_NAME"));
 				OssMaster result = ossService.checkExistsOss(param);
 				
-				if(result != null) {
+				if (result != null) {
 					errMap.put(targetName, MessageFormat.format(getCustomMessage(targetName + ".DUPLICATED"), map.get(targetName), result.getOssId(), result.getOssId(), result.getOssName()));
 				}
 			}
@@ -187,65 +187,65 @@ public class T2CoOssValidator extends T2CoValidator {
 			// 2. NICK NAME
 			targetName = "OSS_NICKNAMES";
 			
-			if(!errMap.containsKey(targetName) && (map.containsKey(targetName + ".1") || map.containsKey(targetName)) ) {
+			if (!errMap.containsKey(targetName) && (map.containsKey(targetName + ".1") || map.containsKey(targetName)) ) {
 	        	List<String> nickNameKeyList = new ArrayList<>();
 	        	
-	        	if(!map.containsKey(targetName + ".1") && map.containsKey(targetName)) {
+	        	if (!map.containsKey(targetName + ".1") && map.containsKey(targetName)) {
 	        		String _seqkey = targetName;
 	        		
-	        		if(!errMap.containsKey(_seqkey) && !StringUtil.isEmpty(map.get(_seqkey))) {
+	        		if (!errMap.containsKey(_seqkey) && !StringUtil.isEmpty(map.get(_seqkey))) {
 	        			// 3-1 동일한 닉네임을 입력한 경우
-	        			if(nickNameKeyList.contains(map.get(_seqkey).trim().toUpperCase())) {
+	        			if (nickNameKeyList.contains(map.get(_seqkey).trim().toUpperCase())) {
 	        				errMap.put(_seqkey, targetName + ".SAME");
 	        			} else {
 	        				nickNameKeyList.add(map.get(_seqkey).trim().toUpperCase());
 	        				
 	        				// 3-2 oss name 과 같은 경우
-	        				if(map.get(_seqkey).trim().equalsIgnoreCase(avoidNull(map.get("OSS_NAME")).trim())) {
+	        				if (map.get(_seqkey).trim().equalsIgnoreCase(avoidNull(map.get("OSS_NAME")).trim())) {
 	        					errMap.put(_seqkey, targetName + ".SAME");
 	        				// 3-3 db 에 존재하는 경우
 	        				} else {
 	        					OssMaster param = new OssMaster(ossId);
 	        					param.setOssName(map.get(_seqkey).trim());
 	        					
-	        					if(!isEmpty(map.get("OSS_NAME"))) {
+	        					if (!isEmpty(map.get("OSS_NAME"))) {
 	        						param.setOssNameTemp(map.get("OSS_NAME"));
 	        					}
 	        					
 	        					OssMaster result = ossService.checkExistsOssNickname(param);
 	        					
-	        					if(result != null) {
+	        					if (result != null) {
 	        						errMap.put(_seqkey, MessageFormat.format(getCustomMessage(targetName + ".DUPLICATED"), map.get(_seqkey), result.getOssId(), result.getOssId(), result.getOssName()));
 	        					}
 	        				}
 	        			}
 	        		}
 	        	}else{
-		        	for(int i = 1; map.containsKey(targetName + "." + i); i++){
+		        	for (int i = 1; map.containsKey(targetName + "." + i); i++){
 		        		String _seqkey = targetName + "." + i;
 		        		
-		        		if(!errMap.containsKey(_seqkey) && !StringUtil.isEmpty(map.get(_seqkey))) {
+		        		if (!errMap.containsKey(_seqkey) && !StringUtil.isEmpty(map.get(_seqkey))) {
 		        			// 3-1 동일한 닉네임을 입력한 경우
-		        			if(nickNameKeyList.contains(map.get(_seqkey).trim().toUpperCase())) {
+		        			if (nickNameKeyList.contains(map.get(_seqkey).trim().toUpperCase())) {
 		        				errMap.put(_seqkey, targetName + ".SAME");
 		        			} else {
 		        				nickNameKeyList.add(map.get(_seqkey).trim().toUpperCase());
 		        				
 		        				// 3-2 oss name 과 같은 경우
-		        				if(map.get(_seqkey).trim().equalsIgnoreCase(avoidNull(map.get("OSS_NAME")).trim())) {
+		        				if (map.get(_seqkey).trim().equalsIgnoreCase(avoidNull(map.get("OSS_NAME")).trim())) {
 		        					errMap.put(_seqkey, targetName + ".SAME");
 		        				// 3-3 db 에 존재하는 경우
 		        				} else {
 		        					OssMaster param = new OssMaster(ossId);
 		        					param.setOssName(map.get(_seqkey).trim());
 		        					
-		        					if(!isEmpty(map.get("OSS_NAME"))) {
+		        					if (!isEmpty(map.get("OSS_NAME"))) {
 		        						param.setOssNameTemp(map.get("OSS_NAME"));
 		        					}
 		        					
 		        					OssMaster result = ossService.checkExistsOssNickname(param);
 		        					
-		        					if(result != null) {
+		        					if (result != null) {
 		        						errMap.put(_seqkey, MessageFormat.format(getCustomMessage(targetName + ".DUPLICATED"), map.get(_seqkey), result.getOssId(), result.getOssId(), result.getOssName()));
 		        					}
 		        				}
@@ -259,12 +259,12 @@ public class T2CoOssValidator extends T2CoValidator {
 			// OSS NAME이 이미 등록되어 있는 경우 체크 추가
 			targetName = "OSS_NAME";
 			
-			if(!errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
+			if (!errMap.containsKey(targetName) && map.containsKey(targetName) && !isEmpty(map.get(targetName))) {
 				OssMaster param = new OssMaster(ossId);
 				param.setOssName(map.get(targetName));
 				OssMaster result = ossService.checkExistsOssNickname2(param);
 				
-				if(result != null) {
+				if (result != null) {
 					errMap.put(targetName, MessageFormat.format(getCustomMessage(targetName + ".DUPLICATEDNICK"), map.get(targetName), result.getOssId(), result.getOssId(), result.getOssName()));
 				}
 			}
@@ -274,19 +274,19 @@ public class T2CoOssValidator extends T2CoValidator {
 	@SuppressWarnings("unchecked")
 	private void ossValidate(OssMaster ossBean, Map<String, String> map, Map<String, String> errMap,
 			Map<String, String> diffMap, Map<String, String> infoMap, boolean useGridSeq) {
-		if(ossBean != null) {
+		if (ossBean != null) {
 			// OSS Name
 			// 이미등록된 경우 체크
 			String basicKey = "OSS_NAME";
 			String gridKey = StringUtil.convertToCamelCase(basicKey);
 			String errCd = checkBasicError(basicKey, gridKey, ossBean.getOssName(), false);
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), errCd);
 			} else {
 				// 초기표시인 경우, Identification과 동일
-				if(useGridSeq) {
-					if(!CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().toUpperCase())) {
+				if (useGridSeq) {
+					if (!CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().toUpperCase())) {
 						errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".UNCONFIRMED");
 					}
 				} else {
@@ -294,7 +294,7 @@ public class T2CoOssValidator extends T2CoValidator {
 					param.setOssName(ossBean.getOssName());
 					OssMaster result = ossService.checkExistsOssNickname2(param);
 					
-					if(result != null) {
+					if (result != null) {
 						errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".DUPLICATEDNICK2");
 					}
 				}
@@ -306,13 +306,13 @@ public class T2CoOssValidator extends T2CoValidator {
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			errCd = checkBasicError(basicKey, gridKey, ossBean.getOssVersion(), true);
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), errCd);
 			} else {
 				// OSS Name에 에러가 있는 경우 version의 유효성 체크할 필요 없음
-				if(!hasError(errMap, "OSS_NAME", ossBean.getGridId(), useGridSeq)) {
-					if(useGridSeq) {
-						if(!CoCodeManager.OSS_INFO_UPPER.containsKey( (ossBean.getOssName() + "_" + ossBean.getOssVersion()).toUpperCase() )) {
+				if (!hasError(errMap, "OSS_NAME", ossBean.getGridId(), useGridSeq)) {
+					if (useGridSeq) {
+						if (!CoCodeManager.OSS_INFO_UPPER.containsKey( (ossBean.getOssName() + "_" + ossBean.getOssVersion()).toUpperCase() )) {
 							errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".UNCONFIRMED");
 						}
 					} else {
@@ -323,7 +323,7 @@ public class T2CoOssValidator extends T2CoValidator {
 						param.setOssName(ossBean.getOssName());
 						OssMaster result = ossService.checkExistsOss(param);
 						
-						if(result != null) {
+						if (result != null) {
 							errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".DUPLICATED2");
 						}
 					}
@@ -335,34 +335,34 @@ public class T2CoOssValidator extends T2CoValidator {
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			errCd = checkBasicError(basicKey, gridKey, ossBean.getLicenseName(), false);
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), errCd);
 			} else {
 				boolean breakPoint = false;
 				String chkStr = ossBean.getLicenseName().replaceAll("\\(", " ").replaceAll("\\)", " ").toUpperCase();
 				
-				for(String s1 : chkStr.split(" OR ")) {
-					for(String s2 : s1.split(" AND ")) {
-						if(!CoCodeManager.LICENSE_INFO_UPPER.containsKey(s2.trim().toUpperCase())) {
+				for (String s1 : chkStr.split(" OR ")) {
+					for (String s2 : s1.split(" AND ")) {
+						if (!CoCodeManager.LICENSE_INFO_UPPER.containsKey(s2.trim().toUpperCase())) {
 							errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".UNCONFIRMED");
 							breakPoint = true;
 							
 							break;
 						}
 					}
-					if(breakPoint) {
+					if (breakPoint) {
 						break;
 					}
 				}
 				
 				// error가 없다면, 괄호안에 OR 조건이 포함되어 있는지 체크
 				// 괄호 안에는 OR Operator가 존재할 수 없음 (AND만)
-				if(!breakPoint) {
+				if (!breakPoint) {
 					Pattern p = Pattern.compile("\\(([^()]*)\\)");
 					Matcher m = p.matcher(ossBean.getLicenseName());
 					
 					while (m.find()) {
-						if(m.group().toUpperCase().indexOf(" OR ") > -1) {
+						if (m.group().toUpperCase().indexOf(" OR ") > -1) {
 							errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".ORCONDITIONS");
 							
 							break;
@@ -375,22 +375,22 @@ public class T2CoOssValidator extends T2CoValidator {
 			basicKey = "OSS_NICKNAME";
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			
-			if(!isEmpty(ossBean.getOssNickname())) {
+			if (!isEmpty(ossBean.getOssNickname())) {
 				List<String> nickList = Arrays.asList(ossBean.getOssNickname().split(","));
 				String upperOssName = ossBean.getOssName().trim().toUpperCase();
 				List<String> dupCheckList = new ArrayList<>();
 				
-				for(String s : nickList) {
-					if(isEmpty(s)) {
+				for (String s : nickList) {
+					if (isEmpty(s)) {
 						continue;
 					}
 					
 					String upperNick = s.trim().toUpperCase();
 					
 					// oss name과 동일한 경우
-					if(upperNick.equalsIgnoreCase(upperOssName)) {
+					if (upperNick.equalsIgnoreCase(upperOssName)) {
 						errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".DUPLICATED");
-					} else if(dupCheckList.contains(upperNick)) {
+					} else if (dupCheckList.contains(upperNick)) {
 						// 동일한 nick name을 두번이상 설정한 경우
 						errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".DUPLICATED");
 					} else {
@@ -400,7 +400,7 @@ public class T2CoOssValidator extends T2CoValidator {
 						param.setOssNameTemp(upperOssName);
 						OssMaster result = ossService.checkExistsOssNickname(param);
 						
-						if(result != null) {
+						if (result != null) {
 							errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".SAME");
 						}
 					}
@@ -414,22 +414,22 @@ public class T2CoOssValidator extends T2CoValidator {
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			String[] downloadLocation = ossBean.getDownloadLocation().split(",");
 			
-			for(String location : downloadLocation){
+			for (String location : downloadLocation){
 				errCd = checkBasicError(basicKey, gridKey, location.trim(), true);
 				
-				if(!isEmpty(errCd)){
+				if (!isEmpty(errCd)){
 					break;
 				}
 			}
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), errCd);
-			} else if(!isEmpty(ossBean.getDownloadLocation())){
-				for(String location : downloadLocation){
+			} else if (!isEmpty(ossBean.getDownloadLocation())){
+				for (String location : downloadLocation){
 					OssMaster param = new OssMaster();
 					
 					// version up 인 경우, 해당 oss name을 제외하고 검증
-					if(!isEmpty(ossBean.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().trim().toUpperCase())) {
+					if (!isEmpty(ossBean.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().trim().toUpperCase())) {
 						param.setOssName(CoCodeManager.OSS_INFO_UPPER_NAMES.get(ossBean.getOssName().trim().toUpperCase()));
 					}
 					
@@ -437,9 +437,9 @@ public class T2CoOssValidator extends T2CoValidator {
 					Map<String, Object> paramMap = ossService.checkExistsOssDownloadLocation(param);
 					List<OssMaster> list = (List<OssMaster>) paramMap.get("downloadLocation");
 					
-					if(list != null && !list.isEmpty()) {
+					if (list != null && !list.isEmpty()) {
 						String sortOrder = list.get(0).getSOrder();
-						if("1".equals(sortOrder)) {
+						if ("1".equals(sortOrder)) {
 							diffMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".DUPLICATED");
 						} else {
 							diffMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".PARTIAL_DUPLICATED");
@@ -454,13 +454,13 @@ public class T2CoOssValidator extends T2CoValidator {
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			errCd = checkBasicError(basicKey, gridKey, ossBean.getHomepage().trim(), true);
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), errCd);
-			} else if(!isEmpty(ossBean.getHomepage())) {
+			} else if (!isEmpty(ossBean.getHomepage())) {
 				OssMaster param = new OssMaster();
 				
 				// version up 인 경우, 해당 oss name을 제외하고 검증
-				if(!isEmpty(ossBean.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().trim().toUpperCase())) {
+				if (!isEmpty(ossBean.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(ossBean.getOssName().trim().toUpperCase())) {
 					param.setOssName(CoCodeManager.OSS_INFO_UPPER_NAMES.get(ossBean.getOssName().trim().toUpperCase()));
 				}
 				
@@ -468,10 +468,10 @@ public class T2CoOssValidator extends T2CoValidator {
 				Map<String, Object> paramMap = ossService.checkExistsOssHomepage(param);
 				List<OssMaster> list = (List<OssMaster>) paramMap.get("homepage");
 				
-				if(list != null && !list.isEmpty()) {
+				if (list != null && !list.isEmpty()) {
 					String sortOrder = list.get(0).getSOrder();
 					
-					if("1".equals(sortOrder)) {
+					if ("1".equals(sortOrder)) {
 						diffMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".DUPLICATED");
 					} else {
 						diffMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), basicKey+".PARTIAL_DUPLICATED");
@@ -494,10 +494,10 @@ public class T2CoOssValidator extends T2CoValidator {
 
 		if (!isEmpty(errCd)) {
 			errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""), errCd);
-		} else if(ossService.checkExistsOssNickname2(ossBean) != null) {
+		} else if (ossService.checkExistsOssNickname2(ossBean) != null) {
 			errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""),
 					"OSS_NAME.DUPLICATEDNICK_SHORT");
-		} else if(ossService.checkExistsOssByname(ossBean) == 0) {
+		} else if (ossService.checkExistsOssByname(ossBean) == 0) {
 			errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""), "OSS_NAME.UNCONFIRMED");
 		}
 
@@ -506,10 +506,10 @@ public class T2CoOssValidator extends T2CoValidator {
 		OssMaster nicknameCheckBean = new OssMaster();
 		nicknameCheckBean.setOssNameTemp(ossBean.getOssName());
 
-		if(!Objects.isNull(ossBean.getOssNicknames())) {
+		if (!Objects.isNull(ossBean.getOssNicknames())) {
 			for (String ossNickname : ossBean.getOssNicknames()) {
 				nicknameCheckBean.setOssName(ossNickname);
-				if(!Objects.isNull(ossService.checkExistsOssNickname(nicknameCheckBean))) {
+				if (!Objects.isNull(ossService.checkExistsOssNickname(nicknameCheckBean))) {
 					errMap.put(basicKey + (useGridSeq ? "."+ossBean.getGridId() : ""), "OSS_NICKNAMES.SAME_SHORT");
 					break;
 				}
@@ -523,10 +523,10 @@ public class T2CoOssValidator extends T2CoValidator {
 		if (Objects.isNull(ossBean.getDeclaredLicenses()) || ossBean.getDeclaredLicenses().isEmpty()) {
 			errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""), "LICENSE_NAME.REQUIRED");
 		} else {
-			for(String license : ossBean.getDeclaredLicenses()) {
+			for (String license : ossBean.getDeclaredLicenses()) {
 				errCd = checkBasicError(basicKey, gridKey, license, false);
 
-				if(!isEmpty(errCd)) {
+				if (!isEmpty(errCd)) {
 					errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""), errCd);
 					break;
 				}
@@ -542,11 +542,11 @@ public class T2CoOssValidator extends T2CoValidator {
 		basicKey = "DETECTED_LICENSES";
 		gridKey = StringUtil.convertToCamelCase(basicKey);
 
-		if(!Objects.isNull(ossBean.getDetectedLicenses())) {
-			for(String license : ossBean.getDetectedLicenses()) {
+		if (!Objects.isNull(ossBean.getDetectedLicenses())) {
+			for (String license : ossBean.getDetectedLicenses()) {
 				errCd = checkBasicError(basicKey, gridKey, license, false);
 
-				if(!isEmpty(errCd)) {
+				if (!isEmpty(errCd)) {
 					errMap.put(basicKey + (useGridSeq ? "." + ossBean.getGridId() : ""), errCd);
 					break;
 				}
@@ -562,19 +562,19 @@ public class T2CoOssValidator extends T2CoValidator {
 	@SuppressWarnings("unchecked")
 	private void ossAnalysisValidate(OssAnalysis analysisBean, Map<String, String> map, Map<String, String> errMap,
 			Map<String, String> diffMap, Map<String, String> infoMap, boolean useGridSeq) {
-		if(analysisBean != null) {
+		if (analysisBean != null) {
 			// OSS Name
 			// 이미등록된 경우 체크
 			String basicKey = "OSS_NAME";
 			String gridKey = StringUtil.convertToCamelCase(basicKey);
 			String errCd = checkBasicError(basicKey, gridKey, analysisBean.getOssName(), false);
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), errCd);
 			} else {
 				// 초기표시인 경우, Identification과 동일
-				if(useGridSeq) {
-					if(!CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(analysisBean.getOssName().toUpperCase())) {
+				if (useGridSeq) {
+					if (!CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(analysisBean.getOssName().toUpperCase())) {
 						errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".UNCONFIRMED");
 					}
 				} else {
@@ -582,7 +582,7 @@ public class T2CoOssValidator extends T2CoValidator {
 					param.setOssName(analysisBean.getOssName());
 					OssMaster result = ossService.checkExistsOssNickname2(param);
 					
-					if(result != null) {
+					if (result != null) {
 						errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".DUPLICATEDNICK2");
 					}
 				}
@@ -593,13 +593,13 @@ public class T2CoOssValidator extends T2CoValidator {
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			errCd = checkBasicError(basicKey, gridKey, analysisBean.getOssVersion(), true);
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), errCd);
 			} else {
 				// OSS Name에 에러가 있는 경우 version의 유효성 체크할 필요 없음
-				if(!hasError(errMap, "OSS_NAME", analysisBean.getGridId(), useGridSeq)) {
-					if(useGridSeq) {
-						if(!CoCodeManager.OSS_INFO_UPPER.containsKey( (analysisBean.getOssName() + "_" + avoidNull(analysisBean.getOssVersion())).toUpperCase() )) {
+				if (!hasError(errMap, "OSS_NAME", analysisBean.getGridId(), useGridSeq)) {
+					if (useGridSeq) {
+						if (!CoCodeManager.OSS_INFO_UPPER.containsKey( (analysisBean.getOssName() + "_" + avoidNull(analysisBean.getOssVersion())).toUpperCase() )) {
 							errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".UNCONFIRMED");
 						}
 					} else {
@@ -610,7 +610,7 @@ public class T2CoOssValidator extends T2CoValidator {
 						param.setOssName(analysisBean.getOssName());
 						OssMaster result = ossService.checkExistsOss(param);
 						
-						if(result != null) {
+						if (result != null) {
 							errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".DUPLICATED2");
 						}
 					}
@@ -622,13 +622,13 @@ public class T2CoOssValidator extends T2CoValidator {
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			errCd = checkBasicError(basicKey, gridKey, analysisBean.getLicenseName(), false);
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), errCd);
 			} else {
 				boolean breakPoint = false;
 				
-				for(String s2 : analysisBean.getLicenseName().split(",")) {
-					if(!CoCodeManager.LICENSE_INFO_UPPER.containsKey(s2.trim().toUpperCase())) {
+				for (String s2 : analysisBean.getLicenseName().split(",")) {
+					if (!CoCodeManager.LICENSE_INFO_UPPER.containsKey(s2.trim().toUpperCase())) {
 						errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".UNCONFIRMED");
 						breakPoint = true;
 						
@@ -638,12 +638,12 @@ public class T2CoOssValidator extends T2CoValidator {
 								
 				// error가 없다면, 괄호안에 OR 조건이 포함되어 있는지 체크
 				// 괄호 안에는 OR Operator가 존재할 수 없음 (AND만)
-				if(!breakPoint) {
+				if (!breakPoint) {
 					Pattern p = Pattern.compile("\\(([^()]*)\\)");
 					Matcher m = p.matcher(analysisBean.getLicenseName());
 					
 					while (m.find()) {
-						if(m.group().toUpperCase().indexOf(" OR ") > -1) {
+						if (m.group().toUpperCase().indexOf(" OR ") > -1) {
 							errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".ORCONDITIONS");
 							
 							break;
@@ -656,7 +656,7 @@ public class T2CoOssValidator extends T2CoValidator {
 			basicKey = "OSS_NICKNAME";
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			
-			if(!isEmpty(analysisBean.getOssNickname())) {
+			if (!isEmpty(analysisBean.getOssNickname())) {
 				List<String> nickList = Arrays.asList(analysisBean.getOssNickname().split(","));
 				
 				String upperOssName = analysisBean.getOssName().trim().toUpperCase();
@@ -664,17 +664,17 @@ public class T2CoOssValidator extends T2CoValidator {
 				
 				String sameMsg = "The same OSS ";
 				
-				for(String s : nickList) {
-					if(isEmpty(s)) {
+				for (String s : nickList) {
+					if (isEmpty(s)) {
 						continue;
 					}
 					
 					String upperNick = s.trim().toUpperCase();
 					
 					// oss name과 동일한 경우
-					if(upperNick.equalsIgnoreCase(upperOssName)) {
+					if (upperNick.equalsIgnoreCase(upperOssName)) {
 						errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".DUPLICATED");
-					} else if(dupCheckList.contains(upperNick)) {
+					} else if (dupCheckList.contains(upperNick)) {
 						// 동일한 nick name을 두번이상 설정한 경우
 						errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".DUPLICATED");
 					} else {
@@ -684,8 +684,8 @@ public class T2CoOssValidator extends T2CoValidator {
 						param.setOssNameTemp(upperOssName);
 						OssMaster result = ossService.checkExistsOssNickname(param);
 						
-						if(result != null) {
-							if(sameMsg.contains(") exists.")) {
+						if (result != null) {
+							if (sameMsg.contains(") exists.")) {
 								sameMsg = sameMsg.substring(0, sameMsg.indexOf(") exists.")).trim() + ",";
 								sameMsg += s.trim() + ") exists.";
 							} else {
@@ -705,22 +705,22 @@ public class T2CoOssValidator extends T2CoValidator {
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			String[] downloadLocation = analysisBean.getDownloadLocation().split(",");
 			
-			for(String location : downloadLocation){
+			for (String location : downloadLocation){
 				errCd = checkBasicError(basicKey, gridKey, location.trim(), true);
 				
-				if(!isEmpty(errCd)){
+				if (!isEmpty(errCd)){
 					break;
 				}
 			}
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), errCd);
-			} else if(!isEmpty(analysisBean.getDownloadLocation())){
-				for(String location : downloadLocation){
+			} else if (!isEmpty(analysisBean.getDownloadLocation())){
+				for (String location : downloadLocation){
 					OssMaster param = new OssMaster();
 					
 					// version up 인 경우, 해당 oss name을 제외하고 검증
-					if(!isEmpty(analysisBean.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(analysisBean.getOssName().trim().toUpperCase())) {
+					if (!isEmpty(analysisBean.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(analysisBean.getOssName().trim().toUpperCase())) {
 						param.setOssName(CoCodeManager.OSS_INFO_UPPER_NAMES.get(analysisBean.getOssName().trim().toUpperCase()));
 					}
 					
@@ -728,10 +728,10 @@ public class T2CoOssValidator extends T2CoValidator {
 					Map<String, Object> paramMap = ossService.checkExistsOssDownloadLocation(param);
 					List<OssMaster> list = (List<OssMaster>) paramMap.get("downloadLocation");
 					
-					if(list != null && !list.isEmpty()) {
+					if (list != null && !list.isEmpty()) {
 						String sortOrder = list.get(0).getSOrder();
 						
-						if("1".equals(sortOrder)) {
+						if ("1".equals(sortOrder)) {
 							diffMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".DUPLICATED");
 						} else {
 							diffMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".PARTIAL_DUPLICATED");
@@ -747,13 +747,13 @@ public class T2CoOssValidator extends T2CoValidator {
 			gridKey = StringUtil.convertToCamelCase(basicKey);
 			errCd = checkBasicError(basicKey, gridKey, analysisBean.getHomepage().trim(), true);
 			
-			if(!isEmpty(errCd)) {
+			if (!isEmpty(errCd)) {
 				errMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), errCd);
-			} else if(!isEmpty(analysisBean.getHomepage())) {
+			} else if (!isEmpty(analysisBean.getHomepage())) {
 				OssMaster param = new OssMaster();
 				
 				// version up 인 경우, 해당 oss name을 제외하고 검증
-				if(!isEmpty(analysisBean.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(analysisBean.getOssName().trim().toUpperCase())) {
+				if (!isEmpty(analysisBean.getOssName()) && CoCodeManager.OSS_INFO_UPPER_NAMES.containsKey(analysisBean.getOssName().trim().toUpperCase())) {
 					param.setOssName(CoCodeManager.OSS_INFO_UPPER_NAMES.get(analysisBean.getOssName().trim().toUpperCase()));
 				}
 				
@@ -761,10 +761,10 @@ public class T2CoOssValidator extends T2CoValidator {
 				Map<String, Object> paramMap = ossService.checkExistsOssHomepage(param);
 				List<OssMaster> list = (List<OssMaster>) paramMap.get("homepage");
 				
-				if(list != null && !list.isEmpty()) {
+				if (list != null && !list.isEmpty()) {
 					String sortOrder = list.get(0).getSOrder();
 					
-					if("1".equals(sortOrder)) {
+					if ("1".equals(sortOrder)) {
 						diffMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".DUPLICATED");
 					} else {
 						diffMap.put(basicKey + (useGridSeq ? "."+analysisBean.getGridId() : ""), basicKey+".PARTIAL_DUPLICATED");
@@ -783,7 +783,7 @@ public class T2CoOssValidator extends T2CoValidator {
 	@SuppressWarnings("unchecked")
 	@Override
 	public void setAppendix(String key, Object obj) {
-		if("ossMaster".equals(key)) {
+		if ("ossMaster".equals(key)) {
 			this.ossMaster = (OssMaster) obj;
 		} else if ("ossList".equals(key)) {
 			this.ossList = (List<OssMaster>) obj;

--- a/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
@@ -79,7 +79,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 			}
 		} else if (VALID_LEVEL_REQUEST == LEVEL) {
 			if (!isEmpty(PROC_TYPE)) {
-				if(PROC_TYPE_IDENTIFICATION_PARTNER.equals(PROC_TYPE)) {
+				if (PROC_TYPE_IDENTIFICATION_PARTNER.equals(PROC_TYPE)) {
 					validatePartnerRequest(map, errMap, diffMap);
 				} else {
 					validateIdentificationRequest(map, errMap, diffMap);
@@ -134,12 +134,12 @@ public class T2CoProjectValidator extends T2CoValidator {
 	
 	private void validatePartnerRequest(Map<String, String> map, Map<String, String> errMap, Map<String, String> diffMap) {
 		//ossComponetList==> grid 데이터(사용자 등록 데이터)
-		if(ossComponetList != null) {
+		if (ossComponetList != null) {
 			// validation case에 따라 필요한 정보를 추출한다.
 			List<String> ossNameList = new ArrayList<>();
 			
-			for(ProjectIdentification bean : ossComponetList) {
-				if(!isEmpty(bean.getOssName()) && !ossNameList.contains(avoidNull(bean.getOssName()))) {
+			for (ProjectIdentification bean : ossComponetList) {
+				if (!isEmpty(bean.getOssName()) && !ossNameList.contains(avoidNull(bean.getOssName()))) {
 					ossNameList.add(avoidNull(bean.getOssName()));
 				}
 			}
@@ -147,15 +147,15 @@ public class T2CoProjectValidator extends T2CoValidator {
 			Map<String, OssMaster> ossInfoByName = null;
 			ossInfoByName = CoCodeManager.OSS_INFO_UPPER;
 
-			for(ProjectIdentification bean : ossComponetList) {
-				if(CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
+			for (ProjectIdentification bean : ossComponetList) {
+				if (CoConstDef.FLAG_YES.equals(bean.getExcludeYn())) {
 					continue;
 				}
 				
 				String basicKey = "";
 				String gridKey = "";
 				
-				if("-".equals(bean.getOssName())) {
+				if ("-".equals(bean.getOssName())) {
 					// license check
 					{
 						basicKey = "LICENSE_NAME";
@@ -163,11 +163,11 @@ public class T2CoProjectValidator extends T2CoValidator {
 						// 기본체크
 						String errCd = checkBasicError(basicKey, gridKey, bean.getLicenseName());
 						
-						if(!isEmpty(errCd)) {
+						if (!isEmpty(errCd)) {
 							errMap.put(basicKey + "." + bean.getComponentId(), errCd);
-						} else if(isEmpty(bean.getLicenseName())) {
+						} else if (isEmpty(bean.getLicenseName())) {
 							errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.REQUIRED");
-						} else if(!CoCodeManager.LICENSE_INFO_UPPER.containsKey(bean.getLicenseName().toUpperCase())) {
+						} else if (!CoCodeManager.LICENSE_INFO_UPPER.containsKey(bean.getLicenseName().toUpperCase())) {
 							diffMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
 						}
 					}
@@ -180,7 +180,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 						// basic validator의 체크 순서가 필수부터 체크하기 때문에, 필수체크를 무시하는 파라미터 플래그를 추가
 						String errCd = checkBasicError(basicKey, gridKey, bean.getFilePath(), true);
 						
-						if(!isEmpty(errCd)) {
+						if (!isEmpty(errCd)) {
 							errMap.put(basicKey + "." + bean.getComponentId(), errCd);
 						}
 					}
@@ -194,7 +194,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 
 				List<ProjectIdentification> licenseList = null;
 				
-				if(ossComponentLicenseListMap != null
+				if (ossComponentLicenseListMap != null
 						&& ossComponentLicenseListMap.containsKey(bean.getGridId())) {
 					licenseList = ossComponentLicenseListMap.get(bean.getGridId());
 				}
@@ -203,24 +203,24 @@ public class T2CoProjectValidator extends T2CoValidator {
 				gridKey = StringUtil.convertToCamelCase(basicKey);
 				String errCd = checkBasicError(basicKey, gridKey, bean.getOssName(), true);
 				
-				if(!isEmpty(errCd)) {
+				if (!isEmpty(errCd)) {
 					errMap.put(basicKey + "." + bean.getComponentId(), errCd);
 				}
 				
-				if(isEmpty(bean.getOssName()) && !checkNonPermissiveLicense(licenseList)) {
+				if (isEmpty(bean.getOssName()) && !checkNonPermissiveLicense(licenseList)) {
 					errMap.put("OSS_NAME."+bean.getComponentId(), "OSS_NAME.REQUIRED");
 				}
 				
 				// oss 등록 여부 체크
-				if(!isEmpty(bean.getOssName()) && !diffMap.containsKey("OSS_NAME." + bean.getComponentId())) {
+				if (!isEmpty(bean.getOssName()) && !diffMap.containsKey("OSS_NAME." + bean.getComponentId())) {
 					String licenseText = "";
 					
-					if(ossBean != null) {
+					if (ossBean != null) {
 						licenseText = CommonFunction.makeLicenseExpressionMsgType(ossBean.getOssLicenses(), true); // msgType return
 					}
 					
-					if(!ossInfoByName.containsKey(checkKey)) {
-						if(checkNonVersionOss(ossInfoByName, bean.getOssName())) {
+					if (!ossInfoByName.containsKey(checkKey)) {
+						if (checkNonVersionOss(ossInfoByName, bean.getOssName())) {
 							// oss는 등록되어 있지만, 해당 version은 없는 경우
 							diffMap.put("OSS_VERSION." + bean.getComponentId(), "OSS_VERSION.UNCONFIRMED");
 						} else {
@@ -228,36 +228,36 @@ public class T2CoProjectValidator extends T2CoValidator {
 						}
 					}
 					// license 등록 여부 (등록되어 있는 오픈소스이나 사용자가 입력한 라이선스는 포함하고 있지 않은 경우 & Detected License도 미 포함인 경우)
-					else if(!hasOssLicense2(ossBean, licenseList)) {
+					else if (!hasOssLicense2(ossBean, licenseList)) {
 						diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 					}
 					// Declared License가 미포함인 경우
-					else if(!hasOssLicense2(ossBean, licenseList, false)) {
+					else if (!hasOssLicense2(ossBean, licenseList, false)) {
 						diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 					}
 					//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-					else if(hasOssLicenseTypeProject(ossBean, licenseList)) {
+					else if (hasOssLicenseTypeProject(ossBean, licenseList)) {
 						diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 					}
 				}
 				
 				// 관리되지 않은 라이선스가 포함되어 있는 경우
-				if(licenseList != null) {
-					for(ProjectIdentification license : licenseList) {
-						if(CoConstDef.FLAG_YES.equals(license.getExcludeYn())) {
+				if (licenseList != null) {
+					for (ProjectIdentification license : licenseList) {
+						if (CoConstDef.FLAG_YES.equals(license.getExcludeYn())) {
 							continue;
 						}
 						
-						if(isEmpty(license.getLicenseName())) {
+						if (isEmpty(license.getLicenseName())) {
 							errMap.put("LICENSE_NAME." + bean.getComponentId(), "LICENSE_NAME.REQUIRED");
 							break;
 						}
 						
-						if(!CoCodeManager.LICENSE_INFO_UPPER.containsKey(license.getLicenseName().toUpperCase())
+						if (!CoCodeManager.LICENSE_INFO_UPPER.containsKey(license.getLicenseName().toUpperCase())
 								&& !ossInfoByName.containsKey(checkKey)) {
-							if(CommonFunction.isAdmin() && !errMap.containsKey("LICENSE_NAME." + bean.getComponentId())) {
+							if (CommonFunction.isAdmin() && !errMap.containsKey("LICENSE_NAME." + bean.getComponentId())) {
 								errMap.put("LICENSE_NAME." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
-							} else if(!diffMap.containsKey("LICENSE_NAME." + bean.getComponentId())) {
+							} else if (!diffMap.containsKey("LICENSE_NAME." + bean.getComponentId())) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "LICENSE_NAME.UNCONFIRMED");
 							}
 							break;
@@ -265,26 +265,26 @@ public class T2CoProjectValidator extends T2CoValidator {
 					}
 				}
 				
-				if(!errMap.containsKey("LICENSE_NAME." + bean.getComponentId()) && licenseList != null) {
+				if (!errMap.containsKey("LICENSE_NAME." + bean.getComponentId()) && licenseList != null) {
 					boolean hasSelected = false;
 					
-					for(ProjectIdentification license : licenseList) {
-						if(!CoConstDef.FLAG_YES.equals(license.getExcludeYn())) {
+					for (ProjectIdentification license : licenseList) {
+						if (!CoConstDef.FLAG_YES.equals(license.getExcludeYn())) {
 							hasSelected = true;
 							
 							break;
 						}
 					}
 					
-					if(!hasSelected) {
+					if (!hasSelected) {
 						errMap.put("LICENSE_NAME." + bean.getComponentId(), "LICENSE_NAME.NOLICENSE");
 					}
-					else if(licenseList != null // bom merge licese 정보를 이용해서 dual license 중복 여부를 확인한다. // oss list에 등록되어 있고, dual license를 가지는 oss에 대해서만 체크
+					else if (licenseList != null // bom merge licese 정보를 이용해서 dual license 중복 여부를 확인한다. // oss list에 등록되어 있고, dual license를 가지는 oss에 대해서만 체크
 							&& !CoConstDef.FLAG_YES.equals(bean.getExcludeYn())
 							&& ossInfoByName.containsKey(checkKey) 
 							&& CoConstDef.LICENSE_DIV_MULTI.equals(ossBean.getLicenseDiv()) 
 							&& CoConstDef.FLAG_YES.equals(ossBean.getDualLicenseFlag()) ) {
-						if(checkOROperation(licenseList, ossBean)) {
+						if (checkOROperation(licenseList, ossBean)) {
 							errMap.put("LICENSE_NAME."  + bean.getComponentId(), "LICENSE_NAME.INCLUDE_DUAL_OPERATE");
 						}
 					}
@@ -294,7 +294,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 	}
 
 	private boolean checkNonPermissiveLicense(List<ProjectIdentification> licenseList) {
-		if(licenseList != null) {
+		if (licenseList != null) {
 			for (ProjectIdentification license : licenseList) {
 				if (CoConstDef.FLAG_YES.equals(license.getExcludeYn())) {
 					continue;
@@ -411,7 +411,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 							&& !errMap.containsKey("LICENSE_NAME." + bean.getComponentId())) {
 						String licenseText = "";
 						
-						if(ossBean != null) {
+						if (ossBean != null) {
 							licenseText = CommonFunction.makeLicenseExpressionMsgType(ossBean.getOssLicenses(), true); // msgType return
 						}
 						
@@ -426,11 +426,11 @@ public class T2CoProjectValidator extends T2CoValidator {
 								}
 							}
 							// Declared License를 사용하지 않는 case
-							else if(!hasOssLicense(ossBean, bean.getOssComponentsLicenseList(), false)) {
+							else if (!hasOssLicense(ossBean, bean.getOssComponentsLicenseList(), false)) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeComponents(ossBean, bean.getOssComponentsLicenseList())) {
+							else if (hasOssLicenseTypeComponents(ossBean, bean.getOssComponentsLicenseList())) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						} else if (ossComponentLicenseListMap != null
@@ -450,7 +450,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeProject(ossBean, licenseList)) {
+							else if (hasOssLicenseTypeProject(ossBean, licenseList)) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						}
@@ -474,7 +474,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 							) {
 						String licenseText = "";
 						
-						if(ossBean != null) {
+						if (ossBean != null) {
 							licenseText = CommonFunction.makeLicenseExpressionMsgType(ossBean.getOssLicenses(), true); // msgType return
 						}
 						
@@ -489,11 +489,11 @@ public class T2CoProjectValidator extends T2CoValidator {
 								}
 							} 
 							// Declared License를 사용하지 않는 case
-							else if(!hasOssLicense(ossBean, bean.getOssComponentsLicenseList(), false)) {
+							else if (!hasOssLicense(ossBean, bean.getOssComponentsLicenseList(), false)) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeComponents(ossBean, bean.getOssComponentsLicenseList())) {
+							else if (hasOssLicenseTypeComponents(ossBean, bean.getOssComponentsLicenseList())) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						} else if (ossComponentLicenseListMap != null
@@ -513,7 +513,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeProject(ossBean, licenseList)) {
+							else if (hasOssLicenseTypeProject(ossBean, licenseList)) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						}
@@ -678,7 +678,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 					gridKey = StringUtil.convertToCamelCase(basicKey);
 					
 					try {
-						if(!isEmpty(bean.getCopyrightText())) {
+						if (!isEmpty(bean.getCopyrightText())) {
 							String copyrightText = new String(bean.getCopyrightText().getBytes("UTF-8"), "UTF-8");
 							Pattern pattern = Pattern.compile("[\uD83C-\uDBFF\uDC00-\uDFFF]+");
 							Matcher matcher = pattern.matcher(copyrightText);
@@ -687,12 +687,12 @@ public class T2CoProjectValidator extends T2CoValidator {
 							while (matcher.find()) {
 								String group = matcher.group().replaceAll("-", "");
 								
-								if(!isEmpty(matcher.group()) && group.length() > 0) {
+								if (!isEmpty(matcher.group()) && group.length() > 0) {
 									matchList.add(group);
 								}
 							}
 							
-							if(matchList.size() > 0) {
+							if (matchList.size() > 0) {
 								String key = isEmpty(bean.getBinaryName()) ? bean.getFilePath() : bean.getBinaryName();
 								key += " | " + bean.getOssName() + " | " + bean.getOssVersion( )+ " | " + bean.getLicenseName();
 								
@@ -740,7 +740,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 					{
 						basicKey = "LICENSE_NAME";
 						gridKey = StringUtil.convertToCamelCase(basicKey);
-						if(bean.getLicenseName().split(",").length > 1) {
+						if (bean.getLicenseName().split(",").length > 1) {
 							errMap.put(basicKey + "." + bean.getComponentId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
 						} else {
 							// 기본체크
@@ -823,7 +823,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 							&& !errMap.containsKey("LICENSE_NAME." + bean.getComponentId())) {
 						String licenseText = "";
 						
-						if(checkOSSMaster != null) {
+						if (checkOSSMaster != null) {
 							licenseText = CommonFunction.makeLicenseExpressionMsgType(checkOSSMaster.getOssLicenses(), true); // msgType return
 						}
 						
@@ -840,12 +840,12 @@ public class T2CoProjectValidator extends T2CoValidator {
 								}
 							} 
 							// Declared License를 사용하지 않는 case
-							else if(!hasOssLicense(checkOSSMaster, bean.getOssComponentsLicenseList(), false)) {
+							else if (!hasOssLicense(checkOSSMaster, bean.getOssComponentsLicenseList(), false)) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 								diffMapLicense = true;
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeComponents(checkOSSMaster, bean.getOssComponentsLicenseList())) {
+							else if (hasOssLicenseTypeComponents(checkOSSMaster, bean.getOssComponentsLicenseList())) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						} else if (ossComponentLicenseListMap != null
@@ -862,12 +862,12 @@ public class T2CoProjectValidator extends T2CoValidator {
 								}
 							}
 							// Declared License를 사용하지 않는 case
-							else if(!hasOssLicense2(checkOSSMaster, licenseList, false)) {
+							else if (!hasOssLicense2(checkOSSMaster, licenseList, false)) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 								diffMapLicense = true;
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeProject(checkOSSMaster, licenseList)) {
+							else if (hasOssLicenseTypeProject(checkOSSMaster, licenseList)) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						}
@@ -891,7 +891,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 							) {
 						String licenseText = "";
 						
-						if(checkOSSMaster != null) {
+						if (checkOSSMaster != null) {
 							licenseText = CommonFunction.makeLicenseExpressionMsgType(checkOSSMaster.getOssLicenses(), true); // msgType return
 						}
 						
@@ -912,7 +912,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 								diffMapLicense = true;
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeComponents(checkOSSMaster, bean.getOssComponentsLicenseList())) {
+							else if (hasOssLicenseTypeComponents(checkOSSMaster, bean.getOssComponentsLicenseList())) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						} else if (ossComponentLicenseListMap != null
@@ -934,7 +934,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 								diffMapLicense = true;
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeProject(checkOSSMaster, licenseList)) {
+							else if (hasOssLicenseTypeProject(checkOSSMaster, licenseList)) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						}
@@ -998,7 +998,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 								&& checkOROperation((List<ProjectIdentification>) checkLicenseInfo.get("rows"), checkOSSMaster)) {
 							errMap.put("LICENSE_NAME." + bean.getComponentId(), "LICENSE_NAME.INCLUDE_DUAL_OPERATE");
 							
-							if(diffMapLicense) { // 일반사용자의 경우 error message 우선순위가 높은 대상들이 diff message로 출력하기 때문에 중복등록 방지를 해야함.
+							if (diffMapLicense) { // 일반사용자의 경우 error message 우선순위가 높은 대상들이 diff message로 출력하기 때문에 중복등록 방지를 해야함.
 								diffMap.remove("LICENSE_NAME." + bean.getComponentId());
 							}
 						}
@@ -1043,7 +1043,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 		case "DOWNLOAD":
 			getData = ossMaster.getDownloadLocation();
 			getData2 = ossMaster.getDownloadLocationGroup();
-			if(getData.contains(",") && isEmpty(getData2)) {
+			if (getData.contains(",") && isEmpty(getData2)) {
 				ossMaster.setDownloadLocationGroup(getData);
 				getData2 = getData;
 			}
@@ -1064,91 +1064,91 @@ public class T2CoProjectValidator extends T2CoValidator {
 		List<String> checkOssNameUrl = CoCodeManager.getCodeNames(CoConstDef.CD_CHECK_OSS_NAME_URL);
 		boolean splitFlag = false;
 		
-		for(String checkVal : splitCheckVal) {
+		for (String checkVal : splitCheckVal) {
 			checkVal = linkPatternCompile(checkOssNameUrl, checkVal);
 			splitFlag = checkVal.split("//").length == 2 ? true : false;
 			
 			if (!isEmpty(getData) && !kind.equals("DOWNLOAD")) {
-				if(kind.equals("HOMEPAGE")) {
-					if((checkVal.startsWith("http://") || checkVal.startsWith("https://")) && splitFlag) {
+				if (kind.equals("HOMEPAGE")) {
+					if ((checkVal.startsWith("http://") || checkVal.startsWith("https://")) && splitFlag) {
 						checkVal = checkVal.split("//")[1];
 					}
 					
-					if(checkVal.startsWith("www.")) {
+					if (checkVal.startsWith("www.")) {
 						checkVal = checkVal.substring(5, checkVal.length());
 					}
 					
-					if(getData.contains(";")) {
+					if (getData.contains(";")) {
 						getData = getData.split(";")[0];
 					}
 					
 					getData = linkPatternCompile(checkOssNameUrl, getData);
 					
-					if(getData.startsWith("http://") || getData.startsWith("https://")) {
+					if (getData.startsWith("http://") || getData.startsWith("https://")) {
 						getData = getData.split("//")[1];
 					}
 					
-					if(getData.startsWith("www.")) {
+					if (getData.startsWith("www.")) {
 						getData = getData.substring(5, getData.length());
 					}
 				}
 				
-				if(!getData.toUpperCase().equals(checkVal.toUpperCase())) {
+				if (!getData.toUpperCase().equals(checkVal.toUpperCase())) {
 					return true;
 				}
 			}
 			
-			if(kind.equals("DOWNLOAD") && !isEmpty(getData2)){
-				if((checkVal.startsWith("http://") || checkVal.startsWith("https://")) && splitFlag) {
+			if (kind.equals("DOWNLOAD") && !isEmpty(getData2)){
+				if ((checkVal.startsWith("http://") || checkVal.startsWith("https://")) && splitFlag) {
 					checkVal = checkVal.split("//")[1];
 				}
 				
-				if(checkVal.startsWith("www.")) {
+				if (checkVal.startsWith("www.")) {
 					checkVal = checkVal.substring(5, checkVal.length());
 				}
 				
 				boolean chkFlag = false;
 				
-				for(String downloadLocation : getData2.split(",")){
+				for (String downloadLocation : getData2.split(",")){
 					downloadLocation = linkPatternCompile(checkOssNameUrl, downloadLocation);
 					
-					if(downloadLocation.startsWith("http://") || downloadLocation.startsWith("https://")) {
+					if (downloadLocation.startsWith("http://") || downloadLocation.startsWith("https://")) {
 						downloadLocation = downloadLocation.split("//")[1];
 					}
 					
-					if(downloadLocation.startsWith("www.")) {
+					if (downloadLocation.startsWith("www.")) {
 						downloadLocation = downloadLocation.substring(5, downloadLocation.length());
 					}
 					
-					if(downloadLocation.toUpperCase().equals(checkVal.toUpperCase())) {
+					if (downloadLocation.toUpperCase().equals(checkVal.toUpperCase())) {
 						chkFlag = true;
 						break;
 					}
 				}
 				
-				if(!chkFlag) {
+				if (!chkFlag) {
 					return true;
 				}
-			}else if(kind.equals("DOWNLOAD") && !isEmpty(getData) && isEmpty(getData2)){
-				if((checkVal.startsWith("http://") || checkVal.startsWith("https://")) && splitFlag) {
+			}else if (kind.equals("DOWNLOAD") && !isEmpty(getData) && isEmpty(getData2)){
+				if ((checkVal.startsWith("http://") || checkVal.startsWith("https://")) && splitFlag) {
 					checkVal = checkVal.split("//")[1];
 				}
 				
-				if(checkVal.startsWith("www.")) {
+				if (checkVal.startsWith("www.")) {
 					checkVal = checkVal.substring(5, checkVal.length());
 				}
 				
 				getData = linkPatternCompile(checkOssNameUrl, getData);
 				
-				if(getData.startsWith("http://") || getData.startsWith("https://")) {
+				if (getData.startsWith("http://") || getData.startsWith("https://")) {
 					getData = getData.split("//")[1];
 				}
 				
-				if(getData.startsWith("www.")) {
+				if (getData.startsWith("www.")) {
 					getData = getData.substring(5, getData.length());
 				}
 				
-				if(!getData.toUpperCase().equals(checkVal.toUpperCase())) {
+				if (!getData.toUpperCase().equals(checkVal.toUpperCase())) {
 					return true;
 				}
 			}
@@ -1161,8 +1161,8 @@ public class T2CoProjectValidator extends T2CoValidator {
 		int urlSearchSeq = -1;
 		int seq = 0;
 		
-		for(String url : checkOssNameUrl) {
-			if(urlSearchSeq == -1 && checkVal.contains(url)) {
+		for (String url : checkOssNameUrl) {
+			if (urlSearchSeq == -1 && checkVal.contains(url)) {
 				urlSearchSeq = seq;
 				break;
 			}
@@ -1171,21 +1171,21 @@ public class T2CoProjectValidator extends T2CoValidator {
 		
 		Pattern p = null;
 		
-		if(checkVal.startsWith("git://")) {
+		if (checkVal.startsWith("git://")) {
 			checkVal = checkVal.replace("git://", "https://");
-		} else if(checkVal.startsWith("ftp://")) {
+		} else if (checkVal.startsWith("ftp://")) {
 			checkVal = checkVal.replace("ftp://", "https://");
-		} else if(checkVal.startsWith("svn://")) {
+		} else if (checkVal.startsWith("svn://")) {
 			checkVal = checkVal.replace("svn://", "https://");
-		} else if(checkVal.startsWith("git@")) {
+		} else if (checkVal.startsWith("git@")) {
 			checkVal = checkVal.replace("git@", "https://");
 		}
 		
-		if(checkVal.contains(".git")) {
-			if(checkVal.endsWith(".git")) {
+		if (checkVal.contains(".git")) {
+			if (checkVal.endsWith(".git")) {
 				checkVal = checkVal.substring(0, checkVal.length()-4);
 			} else {
-				if(checkVal.contains("#")) {
+				if (checkVal.contains("#")) {
 					checkVal = checkVal.substring(0, checkVal.indexOf("#"));
 					checkVal = checkVal.substring(0, checkVal.length()-4);
 				}
@@ -1193,14 +1193,14 @@ public class T2CoProjectValidator extends T2CoValidator {
 		}
 		
 		String[] downloadlocationUrlSplit = checkVal.split("/");
-		if(downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
+		if (downloadlocationUrlSplit[downloadlocationUrlSplit.length-1].indexOf("#") > -1) {
 			checkVal = checkVal.substring(0, checkVal.indexOf("#"));
 		}
 		
-		if( urlSearchSeq > -1 ) {
+		if ( urlSearchSeq > -1 ) {
 			switch(urlSearchSeq) {
 				case 0: // github
-					if(checkVal.contains("www.")) {
+					if (checkVal.contains("www.")) {
 						checkVal = checkVal.replace("www.", "");
 					}
 					p = Pattern.compile("((http|https)://github.com/([^/]+)/([^/]+))");
@@ -1208,7 +1208,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 					break;
 				case 1: // npm
 				case 6: // npm
-					if(checkVal.contains("/package/@")) {
+					if (checkVal.contains("/package/@")) {
 						p = Pattern.compile("((http|https)://www.npmjs.(org|com)/package/([^/]+)/([^/]+))");
 					}else {
 						p = Pattern.compile("((http|https)://www.npmjs.(org|com)/package/([^/]+))");
@@ -1237,7 +1237,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 		
 			Matcher m = p.matcher(checkVal);
 		
-			while(m.find()) {
+			while (m.find()) {
 				checkVal = m.group(0);
 			}
 		}
@@ -1258,7 +1258,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 		List<String> checkLicenseNameList = new ArrayList<>(); // declared License
 		List<String> detectedLicenseList = ossMaster.getDetectedLicenses(); // detected License
 		
-		if(detectedLicenseList == null) {
+		if (detectedLicenseList == null) {
 			detectedLicenseList = new ArrayList<>();
 		}
 		
@@ -1271,7 +1271,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 					checkLicenseNameList.add(_temp.getShortIdentifier().toUpperCase());
 				}
 				
-				if(!isEmpty(_temp.getLicenseNameTemp())) {
+				if (!isEmpty(_temp.getLicenseNameTemp())) {
 					checkLicenseNameList.add(_temp.getLicenseNameTemp().toUpperCase());
 				}
 				
@@ -1286,16 +1286,16 @@ public class T2CoProjectValidator extends T2CoValidator {
 			}
 		}
 		
-		if(detectedLicenseCheck) {
-			if(detectedLicenseList != null) {
-				for(String licenseName : detectedLicenseList) {
+		if (detectedLicenseCheck) {
+			if (detectedLicenseList != null) {
+				for (String licenseName : detectedLicenseList) {
 					if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
 						LicenseMaster _temp = CoCodeManager.LICENSE_INFO_UPPER.get(licenseName.toUpperCase());
 						checkLicenseNameList.add(_temp.getLicenseName().toUpperCase());
 						if (!isEmpty(_temp.getShortIdentifier())) {
 							checkLicenseNameList.add(_temp.getShortIdentifier().toUpperCase());
 						}
-						if(!isEmpty(_temp.getLicenseNameTemp())) {
+						if (!isEmpty(_temp.getLicenseNameTemp())) {
 							checkLicenseNameList.add(_temp.getLicenseNameTemp().toUpperCase());
 						}
 						// nick name이 등록되어 있다면 닉네임도 포함시킨다.
@@ -1319,7 +1319,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 			// 포함되어 있지 않은 라이선스가 하나라도 존재한다면 false
 			String licenseName = avoidNull(license.getLicenseName()).trim().toUpperCase();
 			
-			if(!detectedLicenseCheck && detectedLicenseList.contains(licenseName) && !checkLicenseNameList.contains(licenseName)) {
+			if (!detectedLicenseCheck && detectedLicenseList.contains(licenseName) && !checkLicenseNameList.contains(licenseName)) {
 				continue;
 			}
 			
@@ -1331,7 +1331,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 			}
 		}
 		
-		if(declaredLicenseEmptyCheck) {
+		if (declaredLicenseEmptyCheck) {
 			return false;
 		}
 		
@@ -1351,7 +1351,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 		List<String> detectedLicenseList = ossMaster.getDetectedLicenses();
 		String[] LicenseNames = LicenseName.split("AND|OR|\\,");
 		
-		if(detectedLicenseList == null) {
+		if (detectedLicenseList == null) {
 			detectedLicenseList = new ArrayList<>();
 		}
 		
@@ -1364,7 +1364,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 					checkLicenseNameList.add(_temp.getShortIdentifier().toUpperCase());
 				}
 				
-				if(!isEmpty(_temp.getLicenseNameTemp())) {
+				if (!isEmpty(_temp.getLicenseNameTemp())) {
 					checkLicenseNameList.add(_temp.getLicenseNameTemp().toUpperCase());
 				}
 				
@@ -1378,16 +1378,16 @@ public class T2CoProjectValidator extends T2CoValidator {
 				}
 			}
 		}
-		if(detectedLicenseCheck) {
-			if(detectedLicenseList != null) {
-				for(String licenseName : detectedLicenseList) {
+		if (detectedLicenseCheck) {
+			if (detectedLicenseList != null) {
+				for (String licenseName : detectedLicenseList) {
 					if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
 						LicenseMaster _temp = CoCodeManager.LICENSE_INFO_UPPER.get(licenseName.toUpperCase());
 						checkLicenseNameList.add(_temp.getLicenseName().toUpperCase());
 						if (!isEmpty(_temp.getShortIdentifier())) {
 							checkLicenseNameList.add(_temp.getShortIdentifier().toUpperCase());
 						}
-						if(!isEmpty(_temp.getLicenseNameTemp())) {
+						if (!isEmpty(_temp.getLicenseNameTemp())) {
 							checkLicenseNameList.add(_temp.getLicenseNameTemp().toUpperCase());
 						}
 						// nick name이 등록되어 있다면 닉네임도 포함시킨다.
@@ -1404,8 +1404,8 @@ public class T2CoProjectValidator extends T2CoValidator {
 		}
 		
 		// 포함되어 있지 않은 라이선스가 하나라도 존재한다면 false
-		for(String LicenseNm : LicenseNames){
-			if(!detectedLicenseCheck && detectedLicenseList.contains(LicenseNm)) {
+		for (String LicenseNm : LicenseNames){
+			if (!detectedLicenseCheck && detectedLicenseList.contains(LicenseNm)) {
 				continue;
 			}
 			
@@ -1427,7 +1427,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 		List<String> checkLicenseNameList = new ArrayList<>(); // declared License
 		List<String> detectedLicenseList = ossMaster.getDetectedLicenses(); // detected License
 		
-		if(detectedLicenseList == null) {
+		if (detectedLicenseList == null) {
 			detectedLicenseList = new ArrayList<>();
 		}
 		
@@ -1441,7 +1441,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 						checkLicenseNameList.add(_temp.getShortIdentifier().toUpperCase());
 					}
 					
-					if(!isEmpty(_temp.getLicenseNameTemp())) {
+					if (!isEmpty(_temp.getLicenseNameTemp())) {
 						checkLicenseNameList.add(_temp.getLicenseNameTemp().toUpperCase());
 					}
 					
@@ -1456,16 +1456,16 @@ public class T2CoProjectValidator extends T2CoValidator {
 				}
 			}
 			
-			if(detectedLicenseCheck) {
-				if(detectedLicenseList != null) {
-					for(String licenseName : detectedLicenseList) {
+			if (detectedLicenseCheck) {
+				if (detectedLicenseList != null) {
+					for (String licenseName : detectedLicenseList) {
 						if (CoCodeManager.LICENSE_INFO_UPPER.containsKey(licenseName.toUpperCase())) {
 							LicenseMaster _temp = CoCodeManager.LICENSE_INFO_UPPER.get(licenseName.toUpperCase());
 							checkLicenseNameList.add(_temp.getLicenseName().toUpperCase());
 							if (!isEmpty(_temp.getShortIdentifier())) {
 								checkLicenseNameList.add(_temp.getShortIdentifier().toUpperCase());
 							}
-							if(!isEmpty(_temp.getLicenseNameTemp())) {
+							if (!isEmpty(_temp.getLicenseNameTemp())) {
 								checkLicenseNameList.add(_temp.getLicenseNameTemp().toUpperCase());
 							}
 							// nick name이 등록되어 있다면 닉네임도 포함시킨다.
@@ -1490,7 +1490,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 				// 포함되어 있지 않은 라이선스가 하나라도 존재한다면 false
 				String licenseName = avoidNull(license.getLicenseName()).trim().toUpperCase();
 				
-				if(!detectedLicenseCheck && detectedLicenseList.contains(licenseName) && !checkLicenseNameList.contains(licenseName)) {
+				if (!detectedLicenseCheck && detectedLicenseList.contains(licenseName) && !checkLicenseNameList.contains(licenseName)) {
 					continue;
 				}
 				
@@ -1502,7 +1502,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 				}
 			}
 			
-			if(declaredLicenseEmptyCheck) {
+			if (declaredLicenseEmptyCheck) {
 				return false;
 			}
 		}
@@ -1517,9 +1517,9 @@ public class T2CoProjectValidator extends T2CoValidator {
 	private void validateProjectVerify(Map<String, String> map, Map<String, String> errMap) {
 		// Check, if you apply for exceptional notice file 체크인 경우 basic
 		// validator 결과를 무시한다.
-		for(String str : map.keySet()){
-			if(str.contains("PACKAGING@")){
-				if(!errMap.containsKey(str) && isEmpty(map.get(str))) {
+		for (String str : map.keySet()){
+			if (str.contains("PACKAGING@")){
+				if (!errMap.containsKey(str) && isEmpty(map.get(str))) {
 					errMap.put(str, str+".REQUIRED");
 				}
 			}
@@ -1725,7 +1725,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 					{
 						basicKey = "LICENSE_NAME";
 						gridKey = StringUtil.convertToCamelCase(basicKey);
-						if(bean.getLicenseName().split(",").length > 1) {
+						if (bean.getLicenseName().split(",").length > 1) {
 							errMap.put(basicKey + "." + bean.getGridId(), "LICENSE_NAME.INCLUDE_MULTI_OPERATE");
 						} else {
 							// 기본체크
@@ -1835,8 +1835,8 @@ public class T2CoProjectValidator extends T2CoValidator {
 						// OSS NAME에 대해서 추가적으로 해야할 것이 있다면
 					}
 					
-					if((isEmpty(bean.getOssName()) || "-".equals(bean.getOssName())) && bean.getComponentLicenseList() != null) {
-						if(bean.getComponentLicenseList().size() > 1) {
+					if ((isEmpty(bean.getOssName()) || "-".equals(bean.getOssName())) && bean.getComponentLicenseList() != null) {
+						if (bean.getComponentLicenseList().size() > 1) {
 							basicKey = "LICENSE_NAME";
 							gridKey = StringUtil.convertToCamelCase(basicKey);
 							
@@ -1844,8 +1844,8 @@ public class T2CoProjectValidator extends T2CoValidator {
 						}
 					}
 					
-					if(ossmaster != null) {
-						if(CoConstDef.FLAG_YES.equals(ossmaster.getDeactivateFlag())){
+					if (ossmaster != null) {
+						if (CoConstDef.FLAG_YES.equals(ossmaster.getDeactivateFlag())){
 							if (CommonFunction.isAdmin()) {
 								errMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
 							} else {
@@ -1855,12 +1855,12 @@ public class T2CoProjectValidator extends T2CoValidator {
 					} else {
 						boolean deactivateFlag = false;
 						
-						if(!isEmpty(bean.getOssName())) {
-							if(deactivateOssList.contains(bean.getOssName().toUpperCase())) {
+						if (!isEmpty(bean.getOssName())) {
+							if (deactivateOssList.contains(bean.getOssName().toUpperCase())) {
 								deactivateFlag = true;
 							}
 							
-							if(deactivateFlag) {
+							if (deactivateFlag) {
 								if (CommonFunction.isAdmin()) {
 									errMap.put(basicKey + "." + bean.getGridId(), "OSS_NAME.DEACTIVATED");
 								} else {
@@ -2059,7 +2059,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 								if (CommonFunction.isAdmin()) {
 									errMap.put(LICENSE_KEY, "LICENSE_NAME.UNCONFIRMED");
 								} else {
-									if(!errMap.containsKey(LICENSE_KEY)) {
+									if (!errMap.containsKey(LICENSE_KEY)) {
 										diffMap.put(LICENSE_KEY, "LICENSE_NAME.UNCONFIRMED");
 									}
 								}
@@ -2080,7 +2080,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 								if (CommonFunction.isAdmin()) {
 									errMap.put(LICENSE_KEY, "LICENSE_NAME.UNCONFIRMED");
 								} else {
-									if(!errMap.containsKey(LICENSE_KEY)) {
+									if (!errMap.containsKey(LICENSE_KEY)) {
 										diffMap.put(LICENSE_KEY, "LICENSE_NAME.UNCONFIRMED");
 									}
 								}
@@ -2118,7 +2118,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 							&& !errMap.containsKey("LICENSE_NAME." + bean.getGridId())) {
 						String licenseText = "";
 						
-						if(ossmaster != null) {
+						if (ossmaster != null) {
 							licenseText = CommonFunction.makeLicenseExpressionMsgType(ossmaster.getOssLicenses(), true); // msgType return
 						}
 						
@@ -2131,19 +2131,19 @@ public class T2CoProjectValidator extends T2CoValidator {
 								if (CommonFunction.isAdmin()) {
 									errMap.put(LICENSE_KEY, "Declared : " + licenseText);
 								} else {
-									if(!errMap.containsKey(LICENSE_KEY)) {
+									if (!errMap.containsKey(LICENSE_KEY)) {
 										diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 									}
 								}
 							}
 							// Declared License를 사용하지 않는 case
 							else if (!hasOssLicense(ossmaster, bean.getOssComponentsLicenseList(), false)) {
-								if(!errMap.containsKey(LICENSE_KEY)) {
+								if (!errMap.containsKey(LICENSE_KEY)) {
 									diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 								}
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeComponents(ossmaster, bean.getOssComponentsLicenseList())) {
+							else if (hasOssLicenseTypeComponents(ossmaster, bean.getOssComponentsLicenseList())) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						} else if (ossComponentLicenseListMap != null
@@ -2156,23 +2156,23 @@ public class T2CoProjectValidator extends T2CoValidator {
 								if (CommonFunction.isAdmin()) {
 									errMap.put(LICENSE_KEY, "Declared : " + licenseText);
 								} else {
-									if(!errMap.containsKey(LICENSE_KEY)) {
+									if (!errMap.containsKey(LICENSE_KEY)) {
 										diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 									}
 								}
 							}
 							// Declared License를 사용하지 않는 case
 							else if (!hasOssLicense2(ossmaster, useLicenseList, false)) {
-								if(!errMap.containsKey(LICENSE_KEY)) {
+								if (!errMap.containsKey(LICENSE_KEY)) {
 									diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 								}
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeProject(ossmaster, useLicenseList)) {
+							else if (hasOssLicenseTypeProject(ossmaster, useLicenseList)) {
 								diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 							}
 						} else if (ossComponentLicenseListMap == null) {
-							if(PROC_TYPE_IDENTIFICATION_PARTNER.equals(PROC_TYPE)) {
+							if (PROC_TYPE_IDENTIFICATION_PARTNER.equals(PROC_TYPE)) {
 								// Declared & Detected License를 전부 사용하지 않는 case
 								if (!hasOssLicense(ossmaster, bean.getLicenseName(), bean.getExcludeYn())) {
 									String LICENSE_KEY = "LICENSE_NAME." + bean.getGridId();
@@ -2180,7 +2180,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 									if (CommonFunction.isAdmin()) {
 										errMap.put(LICENSE_KEY, "Declared : " + licenseText);
 									} else {
-										if(!errMap.containsKey(LICENSE_KEY)) {
+										if (!errMap.containsKey(LICENSE_KEY)) {
 											diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 										}
 									}
@@ -2189,12 +2189,12 @@ public class T2CoProjectValidator extends T2CoValidator {
 								else if (!hasOssLicense(ossmaster, bean.getLicenseName(), bean.getExcludeYn(), false)) {
 									String LICENSE_KEY = "LICENSE_NAME." + bean.getGridId();
 									
-									if(!errMap.containsKey(LICENSE_KEY)) {
+									if (!errMap.containsKey(LICENSE_KEY)) {
 										diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 									}
 								}
 								//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-								else if(hasOssLicenseTypeSingle(ossmaster, bean.getLicenseName())) {
+								else if (hasOssLicenseTypeSingle(ossmaster, bean.getLicenseName())) {
 									diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 								}
 							}
@@ -2219,7 +2219,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 							) {
 						String licenseText = "";
 						
-						if(ossmaster != null) {
+						if (ossmaster != null) {
 							licenseText = CommonFunction.makeLicenseExpressionMsgType(ossmaster.getOssLicenses(), true); // msgType return
 						}
 						
@@ -2232,7 +2232,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 								if (CommonFunction.isAdmin()) {
 									errMap.put(LICENSE_KEY, "Declared : " + licenseText);
 								} else {
-									if(!errMap.containsKey(LICENSE_KEY)) {
+									if (!errMap.containsKey(LICENSE_KEY)) {
 										diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 									}
 								}
@@ -2241,12 +2241,12 @@ public class T2CoProjectValidator extends T2CoValidator {
 							else if (!hasOssLicense(ossmaster, bean.getOssComponentsLicenseList(), false)) {
 								String LICENSE_KEY = "LICENSE_NAME." + bean.getGridId();
 								
-								if(!errMap.containsKey(LICENSE_KEY)) {
+								if (!errMap.containsKey(LICENSE_KEY)) {
 									diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 								}
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeComponents(ossmaster, bean.getOssComponentsLicenseList())) {
+							else if (hasOssLicenseTypeComponents(ossmaster, bean.getOssComponentsLicenseList())) {
 								diffMap.put("LICENSE_NAME." + bean.getComponentId(), "Declared : " + licenseText);
 							}
 						} else if (ossComponentLicenseListMap != null
@@ -2259,19 +2259,19 @@ public class T2CoProjectValidator extends T2CoValidator {
 								if (CommonFunction.isAdmin()) {
 									errMap.put(LICENSE_KEY, "Declared : " + licenseText);
 								} else {
-									if(!errMap.containsKey(LICENSE_KEY)) {
+									if (!errMap.containsKey(LICENSE_KEY)) {
 										diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 									}
 								}
 							} 
 							// Declared License를 사용하지 않는 case
 							else if (!hasOssLicense2(ossmaster, useLicenseList, false)) {								
-								if(!errMap.containsKey(LICENSE_KEY)) {
+								if (!errMap.containsKey(LICENSE_KEY)) {
 									diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 								}
 							}
 							//Declared License 중 Permissive가 아닌 type(Copyleft, weak copyleft, Proprietary, Proprietary Free)의 License가 누락된 경우
-							else if(hasOssLicenseTypeProject(ossmaster, useLicenseList)) {
+							else if (hasOssLicenseTypeProject(ossmaster, useLicenseList)) {
 								diffMap.put(LICENSE_KEY, "Declared : " + licenseText);
 							}
 						}
@@ -2297,32 +2297,32 @@ public class T2CoProjectValidator extends T2CoValidator {
 				
 				// exception 처리
 				// LICENSE_NAME.UNCONFIRMED 의 경우, notice warning message 미표시
-				if(PROC_TYPE_IDENTIFICATION_ANDROID.equals(PROC_TYPE)) {
+				if (PROC_TYPE_IDENTIFICATION_ANDROID.equals(PROC_TYPE)) {
 					String chkKey1 = "LICENSE_NAME." + bean.getGridId();
 					String chkKey2 = "BINARY_NOTICE." + bean.getGridId();
 					
-					if(errMap.containsKey(chkKey1) && (errMap.containsKey(chkKey2) || diffMap.containsKey(chkKey2))) {
+					if (errMap.containsKey(chkKey1) && (errMap.containsKey(chkKey2) || diffMap.containsKey(chkKey2))) {
 						String _diffCode1 = errMap.get(chkKey1);
 						
-						if("LICENSE_NAME.UNCONFIRMED".equals(_diffCode1)) {
-							if(errMap.containsKey(chkKey2)) {
+						if ("LICENSE_NAME.UNCONFIRMED".equals(_diffCode1)) {
+							if (errMap.containsKey(chkKey2)) {
 								errMap.remove(chkKey2);
 							}
 							
-							if(diffMap.containsKey(chkKey2)) {
+							if (diffMap.containsKey(chkKey2)) {
 								diffMap.remove(chkKey2);
 							}
 						}
 					}
-					if(diffMap.containsKey(chkKey1) && (errMap.containsKey(chkKey2) || diffMap.containsKey(chkKey2))) {
+					if (diffMap.containsKey(chkKey1) && (errMap.containsKey(chkKey2) || diffMap.containsKey(chkKey2))) {
 						String _diffCode1 = diffMap.get(chkKey1);
 						
-						if("LICENSE_NAME.UNCONFIRMED".equals(_diffCode1)) {
-							if(errMap.containsKey(chkKey2)) {
+						if ("LICENSE_NAME.UNCONFIRMED".equals(_diffCode1)) {
+							if (errMap.containsKey(chkKey2)) {
 								errMap.remove(chkKey2);
 							}
 							
-							if(diffMap.containsKey(chkKey2)) {
+							if (diffMap.containsKey(chkKey2)) {
 								diffMap.remove(chkKey2);
 							}
 						}
@@ -2336,7 +2336,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 	private String makeBinaryOssName(String ossName, String ossVersion) {
 		String rtn = avoidNull(ossName, "-");
 		
-		if(!isEmpty(ossVersion)) {
+		if (!isEmpty(ossVersion)) {
 			rtn += " " + ossVersion;
 		}
 		
@@ -2455,13 +2455,13 @@ public class T2CoProjectValidator extends T2CoValidator {
 	}
 	
 	private boolean checkOROperation(List<ProjectIdentification> licenseList, OssMaster ossInfo) {
-		if(ossInfo != null) {
+		if (ossInfo != null) {
 			String licenseGroup = CommonFunction.makeLicenseExpression(ossInfo.getOssLicenses());
 //			String[] licenseGroupSplit = licenseGroup.split("OR");
 			
 			List<String> andCombLicenseList = new ArrayList<>();
-			for(OssLicense bean : ossInfo.getOssLicenses()) {
-				if(andCombLicenseList.isEmpty() || "OR".equals(bean.getOssLicenseComb())) {
+			for (OssLicense bean : ossInfo.getOssLicenses()) {
+				if (andCombLicenseList.isEmpty() || "OR".equals(bean.getOssLicenseComb())) {
 					andCombLicenseList.add(bean.getLicenseName());
 					
 					continue;
@@ -2476,20 +2476,20 @@ public class T2CoProjectValidator extends T2CoValidator {
 			Map<String, Object> result = new HashMap<String, Object>();
 			boolean returnFlag = false;
 			
-			for(ProjectIdentification iden : licenseList) {
-				if(!licenseGroup.contains(iden.getLicenseName())) {
+			for (ProjectIdentification iden : licenseList) {
+				if (!licenseGroup.contains(iden.getLicenseName())) {
 					returnFlag = true;
 					break;
 				}
 			}
 			
-			if(returnFlag || licenseList.size() == 1) { // OSS에 등록된 license를 사용하지 않았거나, license가 1개만 들록된 경우 dual check를 하지 않음.
+			if (returnFlag || licenseList.size() == 1) { // OSS에 등록된 license를 사용하지 않았거나, license가 1개만 들록된 경우 dual check를 하지 않음.
 				return false;
 			}
 			
-			for(String licenseName : andCombLicenseList) {
-				for(ProjectIdentification iden : licenseList) {
-					if(!licenseName.trim().contains(iden.getLicenseName().trim()) && CoConstDef.FLAG_NO.equals(iden.getExcludeYn())) {
+			for (String licenseName : andCombLicenseList) {
+				for (ProjectIdentification iden : licenseList) {
+					if (!licenseName.trim().contains(iden.getLicenseName().trim()) && CoConstDef.FLAG_NO.equals(iden.getExcludeYn())) {
 						result.put(licenseName, false);
 						break;
 					}
@@ -2535,7 +2535,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 	}
 	
 	private boolean hasOssLicenseType(OssMaster ossInfo, List<String> licenseNameList) {
-		if(ossInfo != null) {
+		if (ossInfo != null) {
 			// License가 permissive로만 구성되어 있는지 check 함.
 			List<OssLicense> permissiveCheck = ossInfo.getOssLicenses()
 														.stream()
@@ -2543,7 +2543,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 														.collect(Collectors.toList());
 			
 			// 전체가 permissive로 이루어져 있으므로 message를 출력하지 않음.
-			if(permissiveCheck.size() == 0) { 
+			if (permissiveCheck.size() == 0) { 
 				return false;
 			}
 			
@@ -2551,7 +2551,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 			List<OssLicense> ossLicenses = ossInfo.getOssLicenses().stream().filter(ol -> "OR".equals(ol.getOssLicenseComb())).collect(Collectors.toList());
 			
 			// Single License이거나 AND로만 구성된 Multi License -> Group을 나눌 필요가 없음.
-			if(ossLicenses.size() == 0) {				
+			if (ossLicenses.size() == 0) {				
 				// permissive가 아닌 licenseType이면서 사용자가 입력한 License Name중에 없는 License가 존재할 경우 message를 출력함.
 				ossLicenses = ossInfo.getOssLicenses()
 											.stream()
@@ -2559,7 +2559,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 															&& !licenseNameList.contains(ol.getLicenseName()))
 											.collect(Collectors.toList());
 			
-				if(ossLicenses.size() > 0) {
+				if (ossLicenses.size() > 0) {
 					return true;
 				}
 			} 
@@ -2569,8 +2569,8 @@ public class T2CoProjectValidator extends T2CoValidator {
 				List<OssLicense> olList = new ArrayList<>();
 				
 				// OR Group별로 분리
-				for(OssLicense bean : ossInfo.getOssLicenses()) {
-					if(olList.isEmpty() || "OR".equals(bean.getOssLicenseComb())) {
+				for (OssLicense bean : ossInfo.getOssLicenses()) {
+					if (olList.isEmpty() || "OR".equals(bean.getOssLicenseComb())) {
 						olList = new ArrayList<>();
 						olList.add(bean);
 						
@@ -2586,10 +2586,10 @@ public class T2CoProjectValidator extends T2CoValidator {
 					groupList.set(seq, olList);
 				}
 				boolean errorFlag = true;
-				for(List<OssLicense> list : groupList) {
+				for (List<OssLicense> list : groupList) {
 					List<OssLicense> checkList = list.stream().filter(c -> licenseNameList.contains(c.getLicenseName())).collect(Collectors.toList());
 					// 현재 그룹 내에 사용된 license name이 존재하는지 check함.
-					if(checkList.size() == 0) {
+					if (checkList.size() == 0) {
 						continue; // 그룹내에 사용한 license name이 없을 경우 continue
 					}
 					
@@ -2598,13 +2598,13 @@ public class T2CoProjectValidator extends T2CoValidator {
 									   			&& !licenseNameList.contains(ol.getLicenseName()))
 							   .collect(Collectors.toList());
 					
-					if(list.size() == 0) {
+					if (list.size() == 0) {
 						errorFlag = false;
 						break;
 					}
 				}
 				
-				if(errorFlag) {
+				if (errorFlag) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>
#793 

## Description

Added 1 space between the `(` after the `if` and `for`, `while` statements using command below:

```bash
KEYWORDS="(if|for|while)"
find . -name '*.java' | ag "$KEYWORDS\(" -l | xargs sed -i ''  -E "s/$KEYWORDS\(/\1 (/"
```

## References

- [새로 입사한 개발자가 프로젝트에 기여하는 방법 한 가지 - 컬리 기술 블로그](https://helloworld.kurly.com/blog/fix-style-with-command/)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
