### PR TITLE
Bug fix - Fail to remove the compressed notice file in BIN(Android)

### DIFF
--- a/src/main/java/oss/fosslight/domain/Project.java
+++ b/src/main/java/oss/fosslight/domain/Project.java
@@ -338,6 +338,8 @@ public class Project extends ComBean implements Serializable {
 	private String srcAndroidCsvFileFlag = "N";
 	
 	private String srcAndroidNoticeFileFlag = "N";
+
+	private String srcAndroidNoticeXmlFileFlag = "N";
 	
 	private String identificationStatusConfFlag = "N";
 	
@@ -4176,6 +4178,14 @@ public class Project extends ComBean implements Serializable {
 
 	public void setSrcAndroidNoticeFileFlag(String srcAndroidNoticeFileFlag) {
 		this.srcAndroidNoticeFileFlag = srcAndroidNoticeFileFlag;
+	}
+
+	public String getSrcAndroidNoticeXmlFileFlag() {
+		return srcAndroidNoticeXmlFileFlag;
+	}
+
+	public void setSrcAndroidNoticeXmlFileFlag(String srcAndroidNoticeXmlFileFlag) {
+		this.srcAndroidNoticeXmlFileFlag = srcAndroidNoticeXmlFileFlag;
 	}
 
 	public String getIdentificationStatusConfFlag() {

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -1848,6 +1848,10 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 				project.setSrcAndroidNoticeFileFlag(CoConstDef.FLAG_YES);
 				fileDeleteCheckFlag = true;
 			}
+			if(isEmpty(project.getSrcAndroidNoticeXmlId()) && !isEmpty(prjFileCheck.getSrcAndroidNoticeXmlId())) {
+				project.setSrcAndroidNoticeXmlFileFlag(CoConstDef.FLAG_YES);
+				fileDeleteCheckFlag = true;
+			}
 		}
 		
 		if (project.getCsvFile() != null && project.getCsvFile().size() > 0) {

--- a/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ProjectMapper.xml
@@ -1410,6 +1410,9 @@
 			<if test="@oss.fosslight.util.StringUtil@equals('Y', srcAndroidNoticeFileFlag)">
 			SRC_ANDROID_NOTICE_FILE_ID = null
 			</if>
+			<if test="@oss.fosslight.util.StringUtil@equals('Y', srcAndroidNoticeXmlFileFlag)">
+				SRC_ANDROID_NOTICE_XML_ID = null
+			</if>
 		</set>
 		WHERE 
 			PRJ_ID = #{prjId}


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
BIN(Android)
1. Upload the compressed notice file
2. Click "Save"
3. Click "x" to remove the compressed notice file
4. Click "Save"
5. Close project identify tab
6. Load project identify tab again

Before : 
Fail to remove auto generated notice.html file

After : 
Success to remove all files

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
