### PR TITLE
chore: Bump spring-security-core to 5.7.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-quartz'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.session:spring-session-core'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -66,7 +66,7 @@ dependencies {
 	implementation group: 'javax.cache', name: 'cache-api', version: '1.1.1'
 	implementation group: 'org.ehcache', name: 'ehcache', version: '3.9.2'
 	
-	implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.6.5'
+	implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.7.5'
 	implementation group: 'org.springframework.security', name: 'spring-security-taglibs', version: '5.6.5'
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-velocity', version: '1.4.7.RELEASE'
 	
@@ -108,11 +108,11 @@ dependencies {
 	implementation group: 'org.jsoup', name: 'jsoup', version: '1.13.1'
 	implementation group: 'com.googlecode.juniversalchardet', name: 'juniversalchardet', version: '1.0.3'
 	implementation group: 'com.googlecode.java-diff-utils', name: 'diffutils', version: '1.3.0'
-    
+
 	implementation group: 'com.monitorjbl', name: 'xlsx-streamer', version: '2.2.0'
 	
 	implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
-    implementation 'io.springfox:springfox-swagger-ui:2.10.5'
+	implementation 'io.springfox:springfox-swagger-ui:2.10.5'
 	
 	implementation group: 'net.sf.sociaal', name: 'xmlpull-xpp3', version: '3.0.0.20130526'
 	


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description


Bumped `spring-security-core` from 5.6.5 to 5.7.5 in order to fix [CVE-2022-31692](https://devhub.checkmarx.com/cve-details/CVE-2022-31692/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea&utm_term=maven).

> Spring Security, versions 5.7.x prior to 5.7.5, and 5.6.x prior to 5.6.9 could be susceptible to authorization rules bypass via forward or include dispatcher types. Specifically, an application is vulnerable when all of the following are true: The application expects that Spring Security applies security to forward and include dispatcher types. The application uses the AuthorizationFilter either manually or via the "authorizeHttpRequests()" method. The application configures the FilterChainProxy to apply to forward and/or include requests (e.g. spring.security.filter.dispatcher-types = request, error, async, forward, include). The application may forward or include the request to a higher privilege-secured endpoint. The application configures Spring Security to apply to every dispatcher type via "authorizeHttpRequests().shouldFilterAllDispatcherTypes(true)".

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
