### PR TITLE
Fix the bug that the Vulnerability popup is not searched if there is a space in the OSS Name

### DIFF
--- a/src/main/java/oss/fosslight/controller/VulnerabilityController.java
+++ b/src/main/java/oss/fosslight/controller/VulnerabilityController.java
@@ -101,9 +101,11 @@ public class VulnerabilityController extends CoTopComponent {
 		if (!isLogin()) {
 			return SESSION.LOGIN_JSP;
 		}
-		
+		if (bean.getOssName().contains(" ")) {
+			bean.setOssName(bean.getOssName().replaceAll(" ", "_"));
+		}
 		model.addAttribute("ossInfo", bean);
-		
+
 		return VULNERABILITY.VULN_POPUP_JSP;
 	}
 	


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Fix the bug that the Vulnerability popup is not searched if there is a space in the OSS Name.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
