### PR TITLE
Fix a typo in the notice template

### DIFF
--- a/src/main/resources/template/notice/notice.txt
+++ b/src/main/resources/template/notice/notice.txt
@@ -21,7 +21,7 @@ $!{closeSource.copyrightText}
 #end
 
 #if($!{noticeObligationSize} != "0")
-Please be informed that #if($!{editCompanyYn} == "Y") $!{companyNameFull} #end #if($!{editCompanyYn} == "N") this #end product may contain open source software listed in to tables below.
+Please be informed that #if($!{editCompanyYn} == "Y") $!{companyNameFull} #end #if($!{editCompanyYn} == "N") this #end product may contain open source software listed in the tables below.
 
 #foreach( $!{openSource} in $!{noticeObligationList} ) 
 $!{openSource.ossName} #if($!{hideOssVersionYn} != "Y")$!{openSource.ossVersion}#end (#foreach( $!{licenseInfo} in $!{openSource.ossComponentsLicense})$!{licenseInfo.licenseName},#end)


### PR DESCRIPTION
## Description
There was a typo in text format of the notice template. 


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
