### PR TITLE
Check oss name - the oss matched with name and version is existed and download location has "Not the same as property" warning message

### DIFF
--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2232,10 +2232,6 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 								checkName = generateCheckOSSName(urlSearchSeq, downloadlocationUrl, p);
 							} else {
 								String redirectlocationUrl = "";
-								String key = avoidNull(bean.getOssName()) + "_" + avoidNull(bean.getOssVersion());
-								if (CoCodeManager.OSS_INFO_UPPER.containsKey(key.toUpperCase())) {
-									continue;
-								}
 								try {
 									URL checkUrl = new URL("https://" + downloadlocationUrl);
 									HttpURLConnection oc = (HttpURLConnection) checkUrl.openConnection();


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Bug fix
- Even if the oss matched with name and version is existed and the entered download location is different from database, generate oss name by using "check oss name" based on the entered download location.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
