### PR TITLE
Change string concatenation method

### DIFF
--- a/src/main/java/oss/fosslight/util/StringUtil.java
+++ b/src/main/java/oss/fosslight/util/StringUtil.java
@@ -506,21 +506,21 @@ public final class StringUtil {
 	 * @return underscore 형태로 변환된 문자열
 	 */
 	public static String convertToUnderScore(String camelCase) {
-		String result = "";
-		
+		StringBuilder result = new StringBuilder();
+
 		for (int i = 0; i < camelCase.length(); i++) {
 			char currentChar = camelCase.charAt(i);
 			// This is starting at 1 so the result does not end up with an
 			// underscore at the begin of the value
-			
+
 			if (i > 0 && Character.isUpperCase(currentChar)) {
-				result = result.concat("_");
+				result.append('_');
 			}
-			
-			result = result.concat(Character.toString(currentChar).toLowerCase());
+
+			result.append(Character.toLowerCase(currentChar));
 		}
-		
-		return result;
+
+		return result.toString();
 	}
 
 	/**


### PR DESCRIPTION
String.concat() to StringBuilder append() in StringUtil.java

## Description
<!-- 
Please describe what this PR do.
 -->
Hi, I've found a single usage of `String.concat()` in `StringUtil.java`, which is widely known to be bad in performance in Java's string concatenation. So I've changed it to StringBuilder based like the other utility methods.


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
