### PR TITLE
Fix a typo 'AUTOCOMPLETE_CRAETOR_AJAX'

### DIFF
--- a/src/main/java/oss/fosslight/common/Url.java
+++ b/src/main/java/oss/fosslight/common/Url.java
@@ -488,7 +488,7 @@ public final class Url {
 		
 		public static final String CHECK_EMAIL = PATH + "/checkEmail";
 		
-		public static final String AUTOCOMPLETE_CRAETOR_AJAX = PATH + "/autoCompleteCreatorAjax";
+		public static final String AUTOCOMPLETE_CREATOR_AJAX = PATH + "/autoCompleteCreatorAjax";
 		public static final String AUTOCOMPLETE_REVIEWER_AJAX = PATH + "/autoCompleteReviewerAjax";
 		public static final String AUTOCOMPLETE_CREATOR_DIVISION_AJAX = PATH + "/autoCompleteCreatorDivisionAjax";
 		

--- a/src/main/java/oss/fosslight/controller/UserController.java
+++ b/src/main/java/oss/fosslight/controller/UserController.java
@@ -162,7 +162,7 @@ public class UserController extends CoTopComponent {
 		return makeJsonResponseHeader(resMap);
 	}
 	
-	@GetMapping(value = USER.AUTOCOMPLETE_CRAETOR_AJAX)
+	@GetMapping(value = USER.AUTOCOMPLETE_CREATOR_AJAX)
 	public @ResponseBody ResponseEntity<Object> autoCompleteCreatorAjax(T2Users t2Users, HttpServletRequest req,
 			HttpServletResponse res, Model model) {
 		t2Users.setSortField("userName");


### PR DESCRIPTION
## Description
Fix a typo 'AUTOCOMPLETE_CRAETOR_AJAX' to 'AUTOCOMPLETE_CREATOR_AJAX' in Url.java
Fix a typo 'AUTOCOMPLETE_CRAETOR_AJAX' to 'AUTOCOMPLETE_CREATOR_AJAX' in UserController.java


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
