### PR TITLE
Fix a typo of CoMail's getSndSeq comment

### DIFF
--- a/src/main/java/oss/fosslight/domain/CoMail.java
+++ b/src/main/java/oss/fosslight/domain/CoMail.java
@@ -152,11 +152,10 @@ public class CoMail extends ComBean {
 	private boolean toIdsCheckDivision = false;
 	
 	/**
-	 *  //.
+	 * Gets the snd seq.
 	 *
 	 * @return the snd seq
 	 */
-	
 	public String getSndSeq() {
 		return sndSeq;
 	}


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
src/java/main/oss/fosslight/domain/CoMail.java
Fix a typo of CoMail's getSndSeq comment

**AS-IS**
```java
	/**
	 *  //.
	 *
	 * @return the snd seq
	 */

	public String getSndSeq() {
		return sndSeq;
	}
```

**TO-BE**
```java
	/**
	 * Gets the snd seq.
	 *
	 * @return the snd seq
	 */
	public String getSndSeq() {
		return sndSeq;
	}
```


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
