### PR TITLE
Fix a typo at AutoIdService

### DIFF
--- a/src/main/java/oss/fosslight/service/AutoIdService.java
+++ b/src/main/java/oss/fosslight/service/AutoIdService.java
@@ -21,7 +21,7 @@ public class AutoIdService {
 	
 	@Autowired private BinaryDataMapper binaryDataMapper;
 	
-	@Cacheable(value="tlshFindOssInfoCache", key="{#root.methodName, #binaryName, #checkSum, #tish}")
+	@Cacheable(value="tlshFindOssInfoCache", key="{#root.methodName, #binaryName, #checkSum, #tlsh}")
 	public List<BinaryData> findOssInfoWithBinaryName(String binaryName, String checkSum, String tlsh) {
 		
 		List<BinaryData> dbDataList = binaryDataMapper.getBinaryListWithNameAndChecksum(binaryName, checkSum);


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Location: src/main/java/oss/fosslight/service/AutoIdService.java

A key in the Cacheable annotation applied to the `findOssInfoWithBinaryName` method of the AutoIdService class had a key that was not applicable for caching. (`#tish` -> `#tlsh`)

**AS-IS**
```java
@Cacheable(value="tlshFindOssInfoCache", key="{#root.methodName, #binaryName, #checkSum, #tish}")
public List<BinaryData> findOssInfoWithBinaryName(String binaryName, String checkSum, String tlsh) { ... }
```

**TO-BE**
```java
@Cacheable(value="tlshFindOssInfoCache", key="{#root.methodName, #binaryName, #checkSum, #tlsh}")
public List<BinaryData> findOssInfoWithBinaryName(String binaryName, String checkSum, String tlsh) { ... }
```


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
