### PR TITLE
Remove Unused Parameter 'binaryName' in Function

### DIFF
--- a/src/main/java/oss/fosslight/service/AutoIdService.java
+++ b/src/main/java/oss/fosslight/service/AutoIdService.java
@@ -44,7 +44,7 @@ public class AutoIdService {
 			
 			List<BinaryData> list = new ArrayList<>();
 			// tlsh distance를 비교하여 근접값을 찾는다.
-			BinaryData binaryData = findCloseBatOssWithTlshDistance(binaryName, tlsh, dbDataList);
+			BinaryData binaryData = findCloseBatOssWithTlshDistance(tlsh, dbDataList);
 			if(binaryData != null) {
 				list.add(binaryData);
 				return list;
@@ -56,12 +56,11 @@ public class AutoIdService {
 	
 	/**
 	 * tlsh distance가 가장 가까운 binary 정보를 찾는다.
-	 * @param binaryName
 	 * @param tish
 	 * @param dbDataList
 	 * @return
 	 */
-	private BinaryData findCloseBatOssWithTlshDistance(String binaryName, String tlsh, List<BinaryData> dbDataList) {
+	private BinaryData findCloseBatOssWithTlshDistance(String tlsh, List<BinaryData> dbDataList) {
 		
 		int currentDistance = 999999;
 		BinaryData currentBinaryBean = null;


### PR DESCRIPTION
## Description
parameter binaryName unused in Function.
Personally, looking at the semantics of the function, the binaryName parameter doesn't seem necessary.

AS-IS
```
private BinaryData findCloseBatOssWithTlshDistance(String binaryName, String tlsh, List<BinaryData> dbDataList)
```

TO-BE
```
private BinaryData findCloseBatOssWithTlshDistance(String tlsh, List<BinaryData> dbDataList);
```

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
