### PR TITLE
Remove unused Slack notification step

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -2,7 +2,6 @@
 # 2. Build the exe file and upload it in the release assets
 # 3. Deploy the latest release to demo.fosslight.org
 # 4. Deploy Image to Docker Hub
-# 5. Notify the results to the Slack channel
 
 name: Release FOSSLight
 
@@ -133,22 +132,3 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/fosslight:${{ github.event.release.tag_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  notify:
-    if: always()
-    needs:
-      - update-changelog
-      - build
-      - deploy-demo
-      - deploy-image
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Slack Workflow Notification
-        uses: Gamesight/slack-workflow-status@master
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          channel: '#release'
-          name: 'FOSSLight Bot'
-          icon_url: https://github.com/fosslight.png


### PR DESCRIPTION
## Description
I found deprecated code in /github/workflows/release-publish.yml.

We've been informed that we're not using Slack this year. We decided it would be more efficient for the program to remove unused features.

AS-IS:
Slack Workflow Notification feature still exists in program code even though it's disabled

TO-BE:
Remove unused Slack Workflow Notification features

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
