### PR TITLE
OSS List > Make license name clickable like OSS Name

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/oss/list-js.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/list-js.jsp
@@ -223,7 +223,12 @@
 					, {name: 'ossName', index: 'ossName', width: 200, align: 'left', formatter: fn.ossNameLinkFormat}
 					</c:if>
 					, {name: 'ossVersion', index: 'ossVersion', width: 70, align: 'left'}
-					, {name: 'licenseName', index: 'licenseName', width: 200, align: 'left'}
+                    <c:if test="${searchBean.linkFlag != 'Y'}">
+                    , {name: 'licenseName', index: 'licenseName', width: 200, align: 'left', formatter: 'linkOssName'}
+                    </c:if>
+                    <c:if test="${searchBean.linkFlag == 'Y'}">
+                    , {name: 'licenseName', index: 'licenseName', width: 200, align: 'left', formatter:fn.ossNameLinkFormat}
+                    </c:if>
 					, {name: 'licenseType', index: 'licenseType', width: 70, align: 'center'}
 					, {name: 'obligation', index: 'obligation', width: 70, align: 'left'}
 					, {name: 'downloadLocation', index: 'downloadLocation', width: 150, align: 'left', formatter: 'link', formatoptions: {target:'_blank'}}


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->

Like the OSS Name, make the License name clickable, and when clicked, bring up the Details tab for that License.

### Issue

closes #877 

AS-IS


![]()

<img width="700" alt="스크린샷" src="https://user-images.githubusercontent.com/4284712/253440665-224aa388-a547-46a3-b1fd-cca56489c1a0.png">


TO-BE
<img width="700" alt="스크린샷 2023-07-30 오후 3 53 56" src="https://github.com/fosslight/fosslight/assets/91937954/8d8b1b8a-3032-4298-b58b-c6d9e6e0b23c">




## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
