### PR TITLE
Convert comment data created by Check Oss Name into table format

### DIFF
--- a/src/main/java/oss/fosslight/domain/ProjectIdentification.java
+++ b/src/main/java/oss/fosslight/domain/ProjectIdentification.java
@@ -310,6 +310,7 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	 */
 	private String obligationGrayFlag;
 	private String obligationMsg;
+	private String tableFlag;
 	
 	/** The oss copyright. */
 	private String copyright;
@@ -372,6 +373,8 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	public String getObligationGrayFlag() {
 		return obligationGrayFlag;
 	}
+
+	public String gettableFlag() { return tableFlag; }
 
 	public void setObligationGrayFlag(String obligationGrayFlag) {
 		this.obligationGrayFlag = obligationGrayFlag;

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2391,15 +2391,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				int urlSearchSeq;
 				int seq;
 
-				for (String downloadLocation : downloadLocations) {
+				for (int i = 0 ; i < downloadLocations.length ; i++) {
 					updateCnt = 0;
 					urlSearchSeq = -1;
 					seq = 0;
 
-					paramBean.setDownloadLocation(downloadLocation);
+					paramBean.setDownloadLocation(downloadLocations[i]);
 
 					for (String url : checkOssNameUrl) {
-						if (urlSearchSeq == -1 && downloadLocation.contains(url)) {
+						if (urlSearchSeq == -1 && downloadLocations[i].contains(url)) {
 							urlSearchSeq = seq;
 
 							break;
@@ -2409,8 +2409,8 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 					}
 
 					if ( urlSearchSeq > -1 ) {
-						Pattern p = generatePattern(urlSearchSeq, downloadLocation);
-						Matcher m = p.matcher(downloadLocation);
+						Pattern p = generatePattern(urlSearchSeq, downloadLocations[i]);
+						Matcher m = p.matcher(downloadLocations[i]);
 						while (m.find()) {
 							paramBean.setDownloadLocation(m.group(0));
 						}
@@ -2436,12 +2436,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 							if (updateCnt >= 1) {
 								String commentId = paramBean.getRefPrjId();
 								String checkOssNameComment = "";
-								String changeOssNameInfo = "<p>" + paramBean.getOssName() + " => " + paramBean.getCheckName() + "</p>";
+								String changeOssNameInfo = "<tr><td>" + paramBean.getOssName() + "</td><td>" + paramBean.getCheckName() + "</td></tr>";
 								CommentsHistory commentInfo = null;
 
 								if (isEmpty(commentId)) {
 									checkOssNameComment = messageSource.getMessage("msg.oss.changed.by.checkossname",null, LocaleContextHolder.getLocale());
 									checkOssNameComment += changeOssNameInfo;
+									if(paramBean.gettableFlag().equals("Y") && i == downloadLocations.length-1){
+										checkOssNameComment += "</table>";
+									}
 									CommentsHistory commHisBean = new CommentsHistory();
 									commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PARTNER_HIS);
 									commHisBean.setReferenceId(paramBean.getReferenceId());
@@ -2457,6 +2460,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 											if (!isEmpty(commentInfo.getContents())) {
 												checkOssNameComment  = commentInfo.getContents();
 												checkOssNameComment += changeOssNameInfo;
+												if(paramBean.gettableFlag().equals("Y") && i == downloadLocations.length-1){
+													checkOssNameComment += "</table>";
+												}
 												commentInfo.setContents(checkOssNameComment);
 
 												commentService.updateComment(commentInfo, false);
@@ -2479,12 +2485,15 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 							if (updateCnt >= 1) {
 								String commentId = paramBean.getReferenceId();
 								String checkOssNameComment = "";
-								String changeOssNameInfo = "<p>" + paramBean.getOssName() + " => " + paramBean.getCheckName() + "</p>";
+								String changeOssNameInfo = "<tr><td>" + paramBean.getOssName() + "</td><td>" + paramBean.getCheckName() + "</td></tr>";
 								CommentsHistory commentInfo = null;
 
 								if (isEmpty(commentId)) {
 									checkOssNameComment = messageSource.getMessage("msg.oss.changed.by.checkossname",null, LocaleContextHolder.getLocale());
 									checkOssNameComment += changeOssNameInfo;
+									if(paramBean.gettableFlag().equals("Y") && i == downloadLocations.length-1){
+										checkOssNameComment += "</table>";
+									}
 									CommentsHistory commHisBean = new CommentsHistory();
 									commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_IDENTIFICAITON_HIS);
 									commHisBean.setReferenceId(paramBean.getRefPrjId());
@@ -2497,6 +2506,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 										if (!isEmpty(commentInfo.getContents())) {
 											checkOssNameComment  = commentInfo.getContents();
 											checkOssNameComment += changeOssNameInfo;
+											if(paramBean.gettableFlag().equals("Y") && i == downloadLocations.length-1){
+												checkOssNameComment += "</table>";
+											}
 											commentInfo.setContents(checkOssNameComment);
 
 											commentService.updateComment(commentInfo, false);

--- a/src/main/resources/messages/message_en.properties
+++ b/src/main/resources/messages/message_en.properties
@@ -211,7 +211,7 @@ msg.oss.check.rename=It has already been registered with another OSS.
 msg.oss.name.nickname.sametime.notchange=Cannot change OSS Name and Nickname at the same time.
 msg.oss.change.success=Successfully add nickname or download location except for OSS not registered in OSS list
 msg.oss.changed.by.system=<b>The following open source and license names have been changed to names registered on the system for efficient management.</b><br><br>
-msg.oss.changed.by.checkossname=<p><b><span style="color:red;">* Check Point *</span></b></p><p><b>The following open source names have been changed based on download location by "Check OSS name".</b></p><p><b>Open Source Name</b></p>
+msg.oss.changed.by.checkossname=<p><b><span style="color:red;">* Check Point *</span></b></p><p><b>The following open source names have been changed based on download location by "Check OSS name".</b></p><p><b>Open Source Name</b></p><table><th>Before OssName</th><th>After OssName</th>
 
 # Partner
 msg.partner.notice=Binary analysis results are used only as reference data. Until the accuracy of the tool is improved, it is not included in the BOM and OSS Notice

--- a/src/main/resources/messages/message_ko.properties
+++ b/src/main/resources/messages/message_ko.properties
@@ -211,7 +211,7 @@ msg.oss.check.rename=다른 OSS로 등록된 사항이 있음.
 msg.oss.name.nickname.sametime.notchange=OSS Name과 Nickname을 동시에 변경할 수 없습니다.
 msg.oss.change.success=OSS 목록에 등록되지 않은 OSS를 제외하고 nickname 또는 download location을 추가했습니다.
 msg.oss.changed.by.system=<b>아래 open source와 license의 이름이 효율적인 관리를 위해서 시스템에 저장된 이름으로 변경되었습니다.</b><br><br>
-msg.oss.changed.by.checkossname=<p><b><span style="color:red;">* 확인 사항 *</span></b></p><p><b>아래 open source의 이름이 "Check OSS name"를 통해서 download location 기반으로 변경되었습니다.</b></p><p><b>Open Source 이름</b></p>
+msg.oss.changed.by.checkossname=<p><b><span style="color:red;">* 확인 사항 *</span></b></p><p><b>아래 open source의 이름이 "Check OSS name"를 통해서 download location 기반으로 변경되었습니다.</b></p><p><b>Open Source 이름</b></p><table><th>전 OssName</th><th>후 OssName</th>
 
 # Partner
 msg.partner.notice=Binary 분석 결과는 참조 데이터로만 사용됩니다. 정확도가 향상될 때까지 BOM 및 OSS 공지사항에 포함되지 않습니다.

--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
@@ -156,11 +156,21 @@
 								rowdata["refPrjId"] = rowdata["referenceId"];
 								rowdata["referenceId"] = commentId;
 								rowdata["referenceDiv"] = referenceDiv.split("-")[0];
+								if(i == idArry.length - 1){
+									rowdata["tableFlag"] = "Y";
+								}else{
+									rowdata["tableFlag"] = "N";
+								}
 								</c:if>
 								<c:if test="${projectInfo.targetName eq 'partner'}">
 								rowdata["referenceId"] = rowdata["referenceId"];
 								rowdata["refPrjId"] = commentId;
 								rowdata["referenceDiv"] = referenceDiv;
+								if(i == idArry.length - 1){
+									rowdata["tableFlag"] = "Y";
+								}else{
+									rowdata["tableFlag"] = "N";
+								}
 								</c:if>
 								
 								$.ajax({


### PR DESCRIPTION
# Description 
closes #944 
- #944
##  To Do 
Convert the comment data format created by the changed OSS Name to a table format

## Solution
1. Send the OSS NAME data changed in checkOssNamepop.jsp to ossService.saveOsscheckName one by one.
2. OSS NAME data changed in the saveOsscheckName function is saved in the content of comment_History Table in html format
3. A  "\<table>" tag is required to create a table, and a "\</table>" element must be added to the last element.
4. In the jsp, the last element should be sent to the saveOsscheckName function.
5. Send ProjectIdentification as RequestBody when sending data from Jsp
6. So, add tableFlag member to ProjectIdentification to check if it is the last element or not and send data
7. In the saveOsscheckName function, if tableFlag is "Y" (last element), add "\</table>" to the content

AS Is :
<img width="826" alt="image" src="https://github.com/fosslight/fosslight/assets/91003734/ddac652b-2f52-4036-9e3e-24398a0136ad">


To Be :
<img width="186" alt="image" src="https://github.com/fosslight/fosslight/assets/91003734/0a3702fa-92f0-4d1b-8cc5-6230691d4400">

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
