### PR TITLE
Convert comment data created by Check Oss License into table format #945

### DIFF
--- a/src/main/java/oss/fosslight/domain/ProjectIdentification.java
+++ b/src/main/java/oss/fosslight/domain/ProjectIdentification.java
@@ -340,7 +340,17 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	private String checkOssList = "N";
 	private String publDate;
 	private String patchLink;
-	
+
+	private String tableFlag ="N";
+
+	public String getTableFlag() {
+		return tableFlag;
+	}
+
+	public void setTableFlag(String tableFlag) {
+		this.tableFlag = tableFlag;
+	}
+
 	public String getRedirectLocation() {
 		return redirectLocation;
 	}

--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -623,7 +623,6 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 	@Transactional
 	@Override
 	public Map<String, Object> saveOssCheckLicense(ProjectIdentification paramBean, String targetName) {
-		System.out.println("saveOssCheckLicense에 들어왔음.");
 		Map<String, Object> map = new HashMap<String, Object>();
 		try {
 			int updateCnt = 0;
@@ -675,24 +674,17 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				if (updateCnt >= 1) {
 					String commentId = CoConstDef.CD_CHECK_OSS_PARTNER.equals(targetName.toUpperCase()) ? paramBean.getRefPrjId() : paramBean.getReferenceId();
 					String checkOssLicenseComment = "";
-					CommentAutoHistory commentAutoHistory = new CommentAutoHistory();
 					String changeOssLicenseInfo = "<tr><td>" + paramBean.getOssName()+"</td>";
-					commentAutoHistory.setOssName(paramBean.getOssName());
 
 					if (!paramBean.getOssVersion().isEmpty()) {
 						changeOssLicenseInfo += "<td>" + paramBean.getOssVersion() + "</td>";
-						commentAutoHistory.setOssVersion(paramBean.getOssVersion());
 					} else {
 						changeOssLicenseInfo += "<td></td>";
-						commentAutoHistory.setOssVersion(" ");
 					}
 
 					changeOssLicenseInfo += "<td>"+paramBean.getDownloadLocation() + "</td> "
 							+ "<td>"+paramBean.getLicenseName()+"</td><td>"+paramBean.getCheckLicense()+"</td></tr>";
 					CommentsHistory commentInfo = null;
-					commentAutoHistory.setDownloadLocation(paramBean.getDownloadLocation());
-					commentAutoHistory.setBeforeLicense(paramBean.getLicenseName());
-					commentAutoHistory.setAfterLicense(paramBean.getCheckLicense());
 
 					if (isEmpty(commentId)) {
 						checkOssLicenseComment  = "<p><b>The following Licenses were modified by \"Check License\"</b></p>";
@@ -717,8 +709,7 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 						
 						commHisBean.setContents(checkOssLicenseComment);
 						commentInfo = commentService.registComment(commHisBean, false);
-						//만약 commentInfo에 잘 들어온다면, 이 값을 table로 표현해주기만 하면 된다.
-						System.out.println("commentInfo > "+ commentInfo);
+
 					} else {
 
 						commentInfo = (CommentsHistory) commentService.getCommnetInfo(commentId).get("info");

--- a/src/main/resources/static/js/basic.js
+++ b/src/main/resources/static/js/basic.js
@@ -1654,6 +1654,7 @@ function openNVD2(_ossName, _url){
 
 function openCommentHistory(_url) {	
 	if(_popupComment == null || _popupComment.closed){
+		console.log("openCommerntHistory / _url > "+ _url);
 		_popupComment = window.open(_url, "commentPopup", "width=900, height=600, toolbar=no, location=no, left=100, top=100, scrollbars=yes, resizeable=yes");
 		
 		if(!_popupComment || _popupComment.closed || typeof _popupComment.closed=='undefined') {

--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
@@ -21,23 +21,23 @@
 			var evt_fn = {
 				init : function(){
 					$("#btnChangeOss").on("click", function(){
-						Ctrl_fn.changeProc();				
+						Ctrl_fn.changeProc();
 					});
 				}
 			};
-			
+
 			var Ctrl_fn = {
 				loadGridData : function(){
 					$('#loading_wrap_popup').show();
-					
+
 					var params = {};
 					params["referenceId"] = referenceId;
 					params["referenceDiv"] = referenceDiv;
-					
+
 					if('identification' == targetName) {
 						params["referenceDiv"] = params["referenceDiv"].split("-")[0];
 					}
-					
+
 					$.ajax({
 						url : '/oss/getCheckOssLicenseAjax/${projectInfo.targetName}',
 						dataType : 'json',
@@ -50,7 +50,7 @@
 							ossErrorMsg = resultData.error;
 
 							grid_fn.displayErrorMsg(ossErrorMsg);
-							
+
 							$('#ossList').jqGrid({
 									datatype: 'local',
 									data : resultData.list,
@@ -82,54 +82,56 @@
 									loadComplete: function(data){
 										if(data.total > 0){
 											$("#btnChangeOss").show();
-											
+
 											var datas = data.rows, rows=this.rows, row, className, rowsCount=rows.length,rowIdx=0;
 											for(var _idx=0;_idx<rowsCount;_idx++) {
 												row = rows[_idx];
 												className = row.className;
-												
+
 												if (className.indexOf('jqgrow') !== -1) {
 													rowid = row.id;
 													rowData = data.rows[rowIdx++];
 													var dataObject = datas.filter(function(a){return a.componentId==rowid})[0];
-													
+
 													if(dataObject.checkLicense.indexOf("|") > -1) {
 														className= className + ' excludeRow';
 													}
-													
+
 													row.className = className;
 												} else if(className.indexOf('ui-subgrid') !== -1){
 													rowIdx++;
 												}
 											}
 										}
-										
+
 										$('#loading_wrap_popup').hide();
 
 										if(ossValidMsg) {
 											gridValidMsgNew(ossValidMsg, "ossList", "SELF");
 										}
-										
+
 										if(ossDiffMsg){
 											gridDiffMsg(ossDiffMsg, "ossList", "SELF");
 										}
-										
+
 									},
 									onSelectRow: function(rowid){},
 									gridComplete:function (){}
 							});
-							
+
 							$('#ossList').closest(".ui-jqgrid-bdiv").css({"height":"373px", "overflow-y" : "scroll"});
 						},
 						error : function(){
 							alertify.error('<spring:message code="msg.common.valid2" />', 0);
 						}
-					});	
+					});
 				},
 				changeProc : function(){
 					$('#loading_wrap_popup').show();
+					console.log("changoProc log ");
 
 					var target = $("#ossList");
+					console.log(target);
 					var result = [];
 					var failFlag = false;
 					var idArry = grid_fn.getCheckedRow("CHANGE");
@@ -143,16 +145,26 @@
 
 								var rowdata = target.getRowData(rowId);
 								rowdata["checkLicense"] = rowdata["checkLicense"].replace(/(<([^>]+)>)/ig,"");
-								rowdata["componentIdList"] = rowdata["componentIdList"].split(",");							
+								rowdata["componentIdList"] = rowdata["componentIdList"].split(",");
 								if("identification" == targetName) {
+									rowdata["tableFlag"] = "N";
 									rowdata["refPrjId"] = rowdata["referenceId"];
 									rowdata["referenceId"] = commentId;
 									rowdata["referenceDiv"] = referenceDiv.split("-")[0];
+									if( i == idArry.length -1 ){
+										rowdata["tableFlag"] = "Y";
+									}
 								} else if("partner" == targetName) {
+									rowdata["tableFlag"] = "N";
 									rowdata["referenceId"] = rowdata["referenceId"];
 									rowdata["refPrjId"] = commentId;
 									rowdata["referenceDiv"] = referenceDiv;
+									if( i == idArry.length -1 ){
+										rowdata["tableFlag"] = "Y";
+									}
 								}
+
+								console.log(rowdata);
 
 								$.ajax({
 									url : '/oss/saveOssCheckLicense/${projectInfo.targetName}',
@@ -163,6 +175,8 @@
 									async: false,
 									contentType : 'application/json',
 									success: function(resultData){
+
+										console.log("/oss/saveOssCheckLicense "+resultData);
 										if(resultData.isValid == true){
 											$("#ossList").jqGrid('setCell', idArry[i], 'changeFlag', 'Y'); // popup grid Data change => success
 											$("#ossList").jqGrid('setCell', idArry[i], 'result', 'Y');
@@ -214,7 +228,7 @@
 													 */
 													opener.location.href = `/project/identification/\${rowdata["refPrjId"]}/\${identificationTabOrder}`;
 												}
-												
+
 												alertify.success(successMsg, 5); // 5sec동안 message 출력
 											}
 


### PR DESCRIPTION
## Description
closes #945 
change comment history's content to table format when auto-creating comment history in check OSS license. 

## Solution
- Add html table Flag for meaning the last element in the comment list.
```
private String tableFlag ="N";
```
<br>

- Add html table tag in saveOssCheckLicense function of AutoFillOssInfoServiceImpl.java

<br>

- Add tableFlag data in the changeProc function in checkOssLicensepopup.jsp

```
rowdata["tableFlag"] = "N";
if( i == idArry.length -1 ){
    rowdata["tableFlag"] = "Y";
}
```
As Is :
![image](https://github.com/jiwon83/PS-Algorithm/assets/88698607/85ada130-1086-4dde-b70e-a55520a4bb8f)
<br>

To Be :
![image](https://github.com/jiwon83/PS-Algorithm/assets/88698607/a42f9f79-7f97-4db4-b73b-fca3bd86225f)
<br>

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
