### PR TITLE
Convert comment data created by Check Oss License into table format #945

### DIFF
--- a/src/main/java/oss/fosslight/domain/ProjectIdentification.java
+++ b/src/main/java/oss/fosslight/domain/ProjectIdentification.java
@@ -224,7 +224,16 @@ public class ProjectIdentification extends ComBean implements Serializable, Comp
 	/** The oss license comb. */
 	// OSS_LICENSE
 	private String ossLicenseComb;
-	
+
+	/** The oss license check flag. */
+	private String tableFlag ="N";
+	public String getTableFlag() {
+		return tableFlag;
+	}
+	public void setTableFlag(String tableFlag) {
+		this.tableFlag = tableFlag;
+	}
+
 	/** The oss copyright. */
 	private String ossCopyright;
 	

--- a/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/AutoFillOssInfoServiceImpl.java
@@ -681,21 +681,27 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 				if (updateCnt >= 1) {
 					String commentId = CoConstDef.CD_CHECK_OSS_PARTNER.equals(targetName.toUpperCase()) ? paramBean.getRefPrjId() : paramBean.getReferenceId();
 					String checkOssLicenseComment = "";
-					String changeOssLicenseInfo = "<p>" + paramBean.getOssName();
-
+					String changeOssLicenseInfo = "<tr><td>" + paramBean.getOssName()+"</td>";
 					if (!paramBean.getOssVersion().isEmpty()) {
-						changeOssLicenseInfo += " (" + paramBean.getOssVersion() + ") ";
+						changeOssLicenseInfo += "<td>" + paramBean.getOssVersion() + "</td>";
 					} else {
-						changeOssLicenseInfo += " ";
+						changeOssLicenseInfo += "<td></td>";
 					}
 
-					changeOssLicenseInfo += paramBean.getDownloadLocation() + " "
-							+ paramBean.getLicenseName() + " => " + paramBean.getCheckLicense() + "</p>";
+					changeOssLicenseInfo += "<td>"+paramBean.getDownloadLocation() + "</td> "
+							+ "<td>"+paramBean.getLicenseName()+"</td><td>"+paramBean.getCheckLicense()+"</td></tr>";
 					CommentsHistory commentInfo = null;
 
 					if (isEmpty(commentId)) {
 						checkOssLicenseComment  = "<p><b>The following Licenses were modified by \"Check License\"</b></p>";
+						checkOssLicenseComment += "<table>";
+						checkOssLicenseComment += "<tr><th>OSS Name</th><th>OSS Version</th><th>Download location</th><th>Before Change</th><th>After Change</th></tr>";
 						checkOssLicenseComment += changeOssLicenseInfo;
+
+						if(paramBean.getTableFlag().equals("Y")){
+							checkOssLicenseComment +="</table>";
+						}
+
 						CommentsHistory commHisBean = new CommentsHistory();
 						
 						if (CoConstDef.CD_CHECK_OSS_PARTNER.equals(targetName.toUpperCase())) {
@@ -715,6 +721,9 @@ public class AutoFillOssInfoServiceImpl extends CoTopComponent implements AutoFi
 							if (!isEmpty(commentInfo.getContents())) {
 								checkOssLicenseComment  = commentInfo.getContents();
 								checkOssLicenseComment += changeOssLicenseInfo;
+								if(paramBean.getTableFlag().equals("Y")){
+									checkOssLicenseComment +="</table>";
+								}
 								commentInfo.setContents(checkOssLicenseComment);
 
 								commentService.updateComment(commentInfo, false);

--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
@@ -148,10 +148,12 @@
 									rowdata["refPrjId"] = rowdata["referenceId"];
 									rowdata["referenceId"] = commentId;
 									rowdata["referenceDiv"] = referenceDiv.split("-")[0];
+									rowdata["tableFlag"] = ( i == idArry.length -1 )? "Y" : "N";
 								} else if("partner" == targetName) {
 									rowdata["referenceId"] = rowdata["referenceId"];
 									rowdata["refPrjId"] = commentId;
 									rowdata["referenceDiv"] = referenceDiv;
+									rowdata["tableFlag"] = ( i == idArry.length -1 )? "Y" : "N";
 								}
 
 								$.ajax({


### PR DESCRIPTION
## Description
closes #945 
Change comment history's content to table format when auto-creating comment history in check OSS license. 

## Solution
- Add html table Flag for meaning the last element in the comment list.
```
private String tableFlag ="N";
```
<br>

- Add html table tag in saveOssCheckLicense function of AutoFillOssInfoServiceImpl.java

<br>

- Add tableFlag data in the changeProc function in checkOssLicensepopup.jsp

```
rowdata["tableFlag"] = "N";
if( i == idArry.length -1 ){
    rowdata["tableFlag"] = "Y";
}
```
As Is :
![image](https://github.com/jiwon83/PS-Algorithm/assets/88698607/85ada130-1086-4dde-b70e-a55520a4bb8f)
<br>

To Be :
![image](https://github.com/jiwon83/PS-Algorithm/assets/88698607/a42f9f79-7f97-4db4-b73b-fca3bd86225f)
<br>

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
