### PR TITLE
Seperate Build and Deploy-demo from publish workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,60 @@
+name: Build and Deploy demo
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build --exclude-task test
+
+      - name: Rename package
+        run: mv build/libs/FOSSLight*.war FOSSLight.war
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./FOSSLight.war
+          asset_name: FOSSLight.war
+          asset_content_type: application/octet-stream
+
+  deploy-demo:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sleep for 30 seconds
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '30s'
+
+      - name: Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.REMOTE_IP }}
+          username: ${{ secrets.REMOTE_SSH_ID }}
+          key: ${{ secrets.REMOTE_SSH_KEY }}
+          port: ${{ secrets.REMOTE_SSH_PORT }}
+          script: |
+            cd /service/deploy/fosslight/
+            bash /service/deploy/fosslight/deploy.sh

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -41,63 +41,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ matrix.ref }}
 
-  build:
-    needs: update-changelog
-    runs-on: ubuntu-18.04
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          cache: 'gradle'
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Build with Gradle
-        run: ./gradlew build --exclude-task test
-
-      - name: Rename package
-        run: mv build/libs/FOSSLight*.war FOSSLight.war
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./FOSSLight.war
-          asset_name: FOSSLight.war
-          asset_content_type: application/octet-stream
-
-  deploy-demo:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Sleep for 30 seconds
-        uses: jakejarvis/wait-action@master
-        with:
-          time: '30s'
-
-      - name: Deploy
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.REMOTE_IP }}
-          username: ${{ secrets.REMOTE_SSH_ID }}
-          key: ${{ secrets.REMOTE_SSH_KEY }}
-          port: ${{ secrets.REMOTE_SSH_PORT }}
-          script: |
-            cd /service/deploy/fosslight/
-            bash /service/deploy/fosslight/deploy.sh
-
   deploy-image:
-    needs: deploy-demo
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Resolve #948 
Related Issue: fosslight/.github#1

Currently, the `release-publish.yml` file is performing all the logic for the published event, resulting in a long action time. Also, there is a high dependency between jobs in the `release-publish.yml` file, which is not good for maintainability.

Therefore, by separating the jobs in the `release-publish.yml` file into different yml files, we want to reduce the dependency between each job and change the workflow from a publish event-centric workflow to a purpose-centric workflow for each job.

***

### AS-IS
List of jobs performed by the `release-publish.yml` file
> 1. Update changelog
> 2. Build
> 3. Deploy demo
> 4. Deploy image

### TO-BE
List of jobs performed by the `release-publish.yml` file
> 1. Update changelog
> 2. Deploy image

List of jobs performed by the `deploy-demo.yml` file
> 1. Build
> 2. Deploy demo

***

The build job and deploy demo job perform the task of building the project and deploying the demo. 
We separated the build job and deploy demo job from the `release-publish.yml` file because the relationship between the update-changelog job and the deploy-image job was not clear, and we felt they could be done independently. 

***

## Test
I tested this with my personal repository. I created a project configured with the same SpringBoot and Gradle versions, and fired the Release published event through the same workflow script with only the environment variables modified. 

As a result, I could see that the two actions were executed normally and both were successful.

**Execute two action with same the release published event**
<img width="527" alt="image" src="https://github.com/fosslight/fosslight/assets/42243302/b0e9f1a9-9ee5-4f6b-bb3b-33d253b60b55">

**Result of `release-publish.yml`**
<img width="287" alt="image" src="https://github.com/fosslight/fosslight/assets/42243302/2054fde8-b0d9-4c72-b6a7-d57400f95de0">
[> Go to test action result](https://github.com/hseungho/separate-workflow-test/actions/runs/6001350000)

**Result of `deploy-demo.yml`**
<img width="487" alt="image" src="https://github.com/fosslight/fosslight/assets/42243302/668942e8-0280-495c-af8a-6a92c97f0970">
[> Go to test action result](https://github.com/hseungho/separate-workflow-test/actions/runs/6001350003)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
