### PR TITLE
fetch base-check-commit-message.yml from .github

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,27 +9,10 @@ on:
       - '*'
 jobs:
   check-commit-message:
-    name: Check Commit Message
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get PR Commits
-        id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check Subject Line Length
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.{0,50}(\n.*)*$'
-          error: 'Subject too long (max 50)'
-      - name: Check Body Line Length
-        if: ${{ success() || failure() }}
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.+(\n.{0,72})*$'
-          error: 'Body line too long (max 72)'
+    uses: fosslight/.github/.github/workflows/base-check-commit-message.yml@main
+    secrets:
+      envPAT: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Description
---
### Overall pull request
* The workflow for checking commit messages is being used across all repositories in Fosslight Hub.
* The base-check-commit-message.yml is already ready in .github repository
*  I want to fetch the base-check-commit-message.yml file from the .github repository

### Code
```yml
check-commit-message:
  uses: fosslight/.github/.github/workflows/base-check-commit-message.yml@main
```
* This code represents a Trigger.
* Due to this Trigger, the workflow can fetch other workflows.
```yml
secrets:
  envPAT: ${{ secrets.GITHUB_TOKEN }}
```
* This code represents a Secret.
* base-check-commit-message.yml requires secrets.GITHUB_TOKEN, So, the workflow shares secrets.GITHUB_TOKEN as envPAT

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
