### PR TITLE
Fix the RUN script format of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ COPY ./LICENSES /app/LICENSES
 
 ADD ./src/main/resources/template /app/template
 
-RUN chmod +x /app/wait-for /app/verify/verify  \
-    && apt-get update  \
-    && apt-get install -y --no-install-recommends netcat  \
-    && rm -rf /var/lib/apt/lists/*  \
-    && ln -s /bin/sh bash
+RUN chmod +x /app/wait-for /app/verify/verify && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends netcat && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /bin/sh bash
 
 WORKDIR /app
 CMD ["java" , "-jar", "FOSSLight.war", "--root.dir=/data/fosslight", "--server.port=8180"]


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Currently, our project uses double-ampersand(`&&`) for `RUN` scripts that run multiple commands in the Dockerfile.
Also, the `RUN` script in the Dockerfile is currently writing the double ampersand first, followed by the command.

I want to modify this so that the command is written first and the double-ampersand is written at the end of the line. 
I think this will make the script more readable, and it will also make it the same format as other fosslight projects' Dockerfiles.

**AS-IS**
```dockerfile
RUN chmod +x /app/wait-for /app/verify/verify  \
    && apt-get update  \
    && apt-get install -y --no-install-recommends netcat  \
    && rm -rf /var/lib/apt/lists/*  \
    && ln -s /bin/sh bash
```

**TO-BE**
```dockerfile
RUN chmod +x /app/wait-for /app/verify/verify && \
    apt-get update && \
    apt-get install -y --no-install-recommends netcat && \
    rm -rf /var/lib/apt/lists/* && \
    ln -s /bin/sh bash
```

### Test
To test, I built the Dockerfile in my local. As a result, I saw that it builds fine.


<img width="750" alt="image" src="https://github.com/fosslight/fosslight/assets/42243302/8faa05a0-0f61-4557-a5f6-6831b6b76a45">
<img width="750" alt="image" src="https://github.com/fosslight/fosslight/assets/42243302/afacb859-d19b-498d-909b-de04a2e2244f">


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
