### PR TITLE
Add stackoverflow pattern for check oss name

### DIFF
--- a/db/initdb.d/fosslight_create.sql
+++ b/db/initdb.d/fosslight_create.sql
@@ -2467,6 +2467,7 @@ INSERT INTO `T2_CODE_DTL` (`CD_NO`, `CD_DTL_NO`, `CD_DTL_NM`, `CD_SUB_NO`, `CD_D
 	('903', '007', 'www.npmjs.org/package/', '', 'npm url', 7, 'Y'),
 	('903', '008', 'android.googlesource.com/platform', '', 'android url', 8, 'Y'),
 	('903', '009', 'www.nuget.org/packages/', '', 'nuget url', 9, 'Y'),
+	('903', '010', 'stackoverflow.com/revisions/', '', 'stackoverflow url', 10, 'Y'),
 	('904', '100', 'server url', '', '180', 1, 'Y'),
 	('904', '200', 'download url', '', '180', 2, 'Y'),
 	('905', '100', 'idleTime', '', '180', 1, 'Y'),

--- a/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/OssServiceImpl.java
@@ -2038,6 +2038,9 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 				case 8:
 					checkName = "nuget:" + ossNameMatcher.group(3);
 					break;
+				case 9:
+					checkName = "stackoverflow-" + ossNameMatcher.group(3);
+					break;
 				default:
 					break;
 			}
@@ -2091,8 +2094,11 @@ public class OssServiceImpl extends CoTopComponent implements OssService {
 			case 7:
 				p = Pattern.compile("((http|https)://android.googlesource.com/platform/(.*))");
 				break;
-			case 8 :
+			case 8:
 				p = Pattern.compile("((http|https)://nuget.org/packages/([^/]+))");
+				break;
+			case 9:
+				p = Pattern.compile("((http|https)://stackoverflow.com/revisions/([^/]+)/([^/]+))");
 				break;
 			default:
 				p = Pattern.compile("(.*)");

--- a/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
@@ -1276,8 +1276,11 @@ public class T2CoProjectValidator extends T2CoValidator {
 				case 7:
 					p = Pattern.compile("((http|https)://android.googlesource.com/platform/(.*))");
 					break;
-				case 8 :
+				case 8:
 					p = Pattern.compile("((http|https)://www.nuget.org/packages/([^/]+))");
+					break;
+				case 9:
+					p = Pattern.compile("((http|https)://stackoverflow.com/revisions/([^/]+)/([^/]+))");
 					break;
 				default:
 					break;


### PR DESCRIPTION
## Description
closed #964

- AS-IS
  Download Location in 'stackoverflow' does not apply to 'check os name' function

- TO-BE
 Download Location in 'stackoverflow' apply to 'check os name' function

    example)
    [https://stackoverflow.com/revisions/{ID}/](https://stackoverflow.com/revisions/29867106/2) → stackoverflow-{ID}
    https://stackoverflow.com/revisions/29867106/2 → stackoverflow-29867106

<img width="1440" alt="image" src="https://github.com/fosslight/fosslight/assets/84485400/e080dc11-e89d-4c24-a687-b4867310e4ed">
<img width="1440" alt="image" src="https://github.com/fosslight/fosslight/assets/84485400/3f60484c-aadd-4708-942e-722669ff40a8">
<img width="1222" alt="image" src="https://github.com/fosslight/fosslight/assets/84485400/787ed682-0c4a-406f-be32-f61eaf2bfa2d">

> OSS name has been changed.





## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
