### PR TITLE
Test LicenseController saveAjax method

### DIFF
--- a/src/test/java/oss/fosslight/controller/LicenseControllerTest.java
+++ b/src/test/java/oss/fosslight/controller/LicenseControllerTest.java
@@ -1,0 +1,37 @@
+package oss.fosslight.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc(addFilters = false)
+@SpringBootTest
+@Transactional
+class LicenseControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @DisplayName("saveAjax Test")
+    @Test
+    public void saveAjax() throws Exception {
+        String licenseMasterJson = "{ \"licenseId\": \"testId\", \"licenseName\": \"testName\" }";
+
+        mockMvc.perform(post("/license/saveAjax")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(licenseMasterJson))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("deleteComment Test")
+    @Test
+    void deleteComment() {
+
+    }
+}


### PR DESCRIPTION
## Description
Closes #954
I'm testing the saveAjax and deleteComment method of the license controller to make sure it responds properly to requests.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
