### PR TITLE
Combine comment into one when packaging confirm

### DIFF
--- a/src/main/java/oss/fosslight/controller/VerificationController.java
+++ b/src/main/java/oss/fosslight/controller/VerificationController.java
@@ -477,7 +477,7 @@ public class VerificationController extends CoTopComponent {
 				}
 				
 				verificationService.updateStatusWithConfirm(project, ossNotice, false);
-				
+
 				try {
 					History h = new History();
 					h = projectService.work(project);
@@ -489,7 +489,8 @@ public class VerificationController extends CoTopComponent {
 				} catch (Exception e) {
 					log.error(e.getMessage(), e);
 				}
-				
+
+				userComment += verificationService.changePackageFileNameCombine(ossNotice.getPrjId());
 				try {
 					CommentsHistory commHisBean = new CommentsHistory();
 					commHisBean.setReferenceDiv(CoConstDef.CD_DTL_COMMENT_PACKAGING_HIS);
@@ -527,8 +528,6 @@ public class VerificationController extends CoTopComponent {
 					}
 				}
 
-				// package file 이 존재하는 경우 파일명을 변경한다.
-				verificationService.changePackageFileNameDistributeFormat(ossNotice.getPrjId());
 			} else { // preview 인 경우
 				// 저장된 고지문구가 없을 경우
 				if (isEmpty(noticeFileId) || !CoConstDef.FLAG_YES.equals(useCustomNoticeYn)) {

--- a/src/main/java/oss/fosslight/service/VerificationService.java
+++ b/src/main/java/oss/fosslight/service/VerificationService.java
@@ -87,4 +87,6 @@ public interface VerificationService {
 	public void updateProjectAllowDownloadBitFlag(Project project);
 
 	void registOssNoticeConfirmStatus(OssNotice ossNotice);
+
+	String changePackageFileNameCombine(String prjId);
 }

--- a/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
@@ -1539,6 +1539,51 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 			}
 		}
 	}
+
+	@Override
+	public String changePackageFileNameCombine(String prjId) {
+
+		String contents = "";
+		// 프로젝트 기본정보 취득
+		Project prjBean = new Project();
+		prjBean.setPrjId(prjId);
+		prjBean = projectMapper.selectProjectMaster2(prjBean);
+		List<String> packageFileIds = new ArrayList<String>();
+
+		if (!isEmpty(prjBean.getPackageFileId())) {
+			packageFileIds.add(prjBean.getPackageFileId());
+		}
+
+		if (!isEmpty(prjBean.getPackageFileId2())) {
+			packageFileIds.add(prjBean.getPackageFileId2());
+		}
+
+		if (!isEmpty(prjBean.getPackageFileId3())) {
+			packageFileIds.add(prjBean.getPackageFileId3());
+		}
+
+		int fileSeq = 1;
+
+		for (String packageFileId : packageFileIds){
+			T2File packageFileInfo = new T2File();
+			packageFileInfo.setFileSeq(packageFileId);
+			packageFileInfo = fileMapper.getFileInfo(packageFileInfo);
+
+			if (packageFileInfo != null) {
+				String orgFileName = packageFileInfo.getOrigNm();
+				// Packaging > Confirm시 Packaging 파일명 변경 건
+				String paramSeq = (packageFileIds.size() > 1 ? Integer.toString(fileSeq++) : "");
+				String chgFileName = getPackageFileName(prjBean.getPrjName(), prjBean.getPrjVersion(), packageFileInfo.getOrigNm(), paramSeq);
+
+				packageFileInfo.setOrigNm(chgFileName);
+
+				fileMapper.upateOrgFileName(packageFileInfo);
+
+				contents += "<p>Changed File Name (\""+orgFileName+"\") to \""+chgFileName+"\" </p> ";
+			}
+		}
+		return contents;
+	}
 	
 	private String getPackageFileName(String prjName, String prjVersion, String orgFileName, String fileSeq) {
 		String fileName = prjName;


### PR DESCRIPTION
## Description

closes #907 
- #907

## AS IS

![image](https://github.com/fosslight/fosslight/assets/91003734/50d52093-e3bf-4b6c-a9a9-1fa823fce1d6)
Separate comments are left for each attached file. 

## TO BE

1. The comments generated for each attached file were combined
2. added to the comment's content generated when confrim.

![image](https://github.com/fosslight/fosslight/assets/91003734/d303e847-72e0-4d76-9ca6-dfdf68f552fc)



## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
