### PR TITLE
Modify @Transactional and @CacheEvict applied to private methods

### DIFF
--- a/src/main/java/oss/fosslight/service/BinaryDataService.java
+++ b/src/main/java/oss/fosslight/service/BinaryDataService.java
@@ -195,7 +195,8 @@ public class BinaryDataService  extends CoTopComponent {
 		
 		insertBatConfirmBinOssWithChecksum(null, prjName, platformName, platformVer, binaryTextFile, list);
 	}
-	
+
+	@Transactional
 	public void insertBatConfirmBinOssWithChecksum(String gubn, String prjName, String platformName, String platformVer, T2File binaryTextFile, List<ProjectIdentification> list) {
 		
 		//bin binary.txt 파일 정보를 추출한다.
@@ -342,8 +343,7 @@ public class BinaryDataService  extends CoTopComponent {
 		}
 	}
 	
-	
-	@Transactional
+
 	private void mergeBinaryOssInfo(Map<String, BinaryAnalysisResult> batInfoMap) {
 
 		List<BinaryData> historyList = new ArrayList<>();
@@ -459,6 +459,7 @@ public class BinaryDataService  extends CoTopComponent {
 			
 	}
 
+	@Transactional
 	public void insertBatConfirmAndroidBinOssWithChecksum(String prjName, String platformName, String platformVer,
 			String fileId, List<ProjectIdentification> list) {
 		if(!isEmpty(fileId) && list != null && !list.isEmpty()) {
@@ -732,7 +733,7 @@ public class BinaryDataService  extends CoTopComponent {
 		return loadData;
 	}
 	
-	@Transactional
+
 	private void addOssComponentByBinaryInfo(List<OssComponents> componentList,
 			Map<String, List<BinaryData>> binaryRegInfoMap) {
 
@@ -878,7 +879,6 @@ public class BinaryDataService  extends CoTopComponent {
 
 	
 
-	@Transactional
 	private void addOssComponentByBinaryInfoPartner(List<OssComponents> componentList,
 			Map<String, List<BinaryData>> binaryRegInfoMap) {
 
@@ -1100,7 +1100,7 @@ public class BinaryDataService  extends CoTopComponent {
 		}
 	}
 	
-	@Transactional
+	
 	private void addOssComponentByBinaryInfoAndroid(List<OssComponents> componentList,
 			Map<String, List<BinaryData>> binaryRegInfoMap) {
 
@@ -1238,6 +1238,7 @@ public class BinaryDataService  extends CoTopComponent {
 		}
 	}
 
+	@Transactional
 	public void autoIdentificationWithBinryTextFilePartner(PartnerMaster partner) {
 
 		// oss name과 license가 설정되지 않은 oss coponent를 찾는다.

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -2104,7 +2104,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		updateOssComponentList(new Project(), refDiv, refId, ossComponent, ossComponentLicense);
 	}
 	
-	@Transactional
+
 	private void updateOssComponentList(Project project, String refDiv, String refId, List<ProjectIdentification> ossComponent,
 			List<List<ProjectIdentification>> ossComponentLicense) {
 		// 컴포넌트 마스터 라이센스 지우기
@@ -2354,7 +2354,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		projectMapper.deleteOssComponentsWithIds(param);
 	}
 	
-	@Transactional
+
 	private void addOssComponentByBinaryInfo(List<OssComponents> componentList, Map<String, List<Map<String, Object>>> binaryRegInfoMap) {
 		for (OssComponents bean : componentList) {
 			String binaryName = avoidNull(bean.getBinaryName());
@@ -2513,7 +2513,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 	}
 	
-	@Transactional
+
 	private void addOssComponentByBinaryInfoAndroid(List<OssComponents> componentList, Map<String, List<Map<String, Object>>> binaryRegInfoMap) {
 		for (OssComponents bean : componentList) {
 			String binaryName = avoidNull(bean.getBinaryName());

--- a/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
@@ -1254,7 +1254,6 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	}
 	
 
-	@CacheEvict(value="autocompleteProjectCache", allEntries=true)
 	private void updateProjectStatus(Project project) {
 		//다운로드 허용 플래그
 		project.setAllowDownloadBitFlag(allowDownloadMultiFlagToBitFlag(project));
@@ -1265,6 +1264,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 	
 	@Override
 	@Transactional
+	@CacheEvict(value="autocompleteProjectCache", allEntries=true)
 	public void updateStatusWithConfirm(Project project, OssNotice ossNotice, boolean copyConfirmFlag) throws Exception {
 		if (copyConfirmFlag) {
 			projectMapper.updateConfirmCopyVerificationDestributionStatus(project);

--- a/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/VerificationServiceImpl.java
@@ -1253,7 +1253,7 @@ public class VerificationServiceImpl extends CoTopComponent implements Verificat
 		return ossComponentList == null || ossComponentList.isEmpty();
 	}
 	
-	@Transactional
+
 	@CacheEvict(value="autocompleteProjectCache", allEntries=true)
 	private void updateProjectStatus(Project project) {
 		//다운로드 허용 플래그


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->
Fixed `@Transactional`and `@CacheEvict` applied to private methods.

### 1. Modify `@Transactional`
The private methods with `@Transactional` applied is as follows :
- BinaryDataService > mergeBinaryOssInfo
- BinaryDataService > addOssComponentByBinaryInfo
- BinaryDataService > addOssComponentByBinaryInfoPartner
- BinaryDataService > addOssComponentByBinaryInfoAndroid
- ProjectServiceImpl > updateOssComponentList
- ProjectServiceImpl > addOssComponentByBinaryInfo
- ProjectServiceImpl > addOssComponentByBinaryInfoAndroid
- VerificationServiceImpl > updateProjectStatus
- NvdDataService > nvdCveDataApiJob
- NvdDataService > nvdMetaDataApiJob
- NvdDataService > nvdCveDataSyncJob
- NvdDataService > initNvdDataFeed

Modified above methods as follows, except the methods in NvdDataService :
- BinaryDataService > mergeBinaryOssInfo
  - Applied `@Transactional` to parent public methods :
    - insertBatConfirmBinOssWithChecksum
    - insertBatConfirmAndroidBinOssWithChecksum
- BinaryDataService > addOssComponentByBinaryInfo
  - Removed `@Transactional` (because the parent method already has `@Transactional` applied)
- BinaryDataService > addOssComponentByBinaryInfoPartner
  - Applied `@Transactional` to parent public methods :
    - autoIdentificationWithBinryTextFilePartner
- BinaryDataService > addOssComponentByBinaryInfoAndroid
  - Removed `@Transactional` (because it is never used)
- ProjectServiceImpl > updateOssComponentList
  - Removed `@Transactional` (because the parent method already has `@Transactional` applied)
- ProjectServiceImpl > addOssComponentByBinaryInfo
  - Removed `@Transactional` (because it is never used)
- ProjectServiceImpl > addOssComponentByBinaryInfoAndroid
  - Removed `@Transactional` (because it is never used)
- VerificationServiceImpl > updateProjectStatus
  - Removed `@Transactional` (because the parent method already has `@Transactional` applied)

### 2. Modify `@CacheEvict`
The private methods with `@CacheEvict` applied is as follows :
- VerificationServiceImpl > updateProjectStatus

And modified it as follows :
- Removed `@CacheEvict` from updateProjectStatus 
  and applied `@CacheEvict` to parent public method updateStatusWithConfirm

<br>

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
