### PR TITLE
Fix bugs related to Vulnerability when searching OSS List

### DIFF
--- a/src/main/resources/oss/fosslight/repository/OssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/OssMapper.xml
@@ -864,6 +864,11 @@
         <if test="!@oss.fosslight.util.StringUtil@isEmpty(mEndDate)">
             AND DATE_FORMAT(T1.MODIFIED_DATE,'%Y%m%d') <![CDATA[<=]]> #{mEndDate}
         </if>
+		<if test="!@oss.fosslight.util.StringUtil@isEmpty(cvssScore)">
+			<![CDATA[
+			AND CAST(T1.CVSS_SCORE AS FLOAT ) >= CAST(#{cvssScore} AS FLOAT )
+			]]>
+		</if>
 		GROUP BY T1.OSS_ID
 		ORDER BY
 		T1.OSS_VERSION DESC


### PR DESCRIPTION
# Description

This PR add watcher feature to https://github.com/fosslight/fosslight/issues/992

# AS-IS
<img width="332" alt="스크린샷 2023-10-01 오후 8 43 55" src="https://github.com/fosslight/fosslight/assets/81344634/ae963a8c-0b3a-4554-8457-5fd12a2b2598">


https://github.com/fosslight/fosslight/assets/81344634/5d02e9df-b25d-4de4-9e50-a1ea4383babb

# To-Be


https://github.com/fosslight/fosslight/assets/81344634/0e4e7884-17f2-40e2-874b-11178e6d6c2e

# Explanation

from getOssMasterList in OssServiceImpl, we should check ⬇
After importing data that meets the search conditions, data that has the same Ossname as the data **must be grouped and imported again into the new List.** 
So I fixed that code in OssMapper.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Comments
Example data was used to compare before and after. You can check it in the video !