### PR TITLE
Remove v from OSS Version

### DIFF
--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -1910,7 +1910,14 @@ public class ProjectController extends CoTopComponent {
 			ossComponents = (List<ProjectIdentification>) fromJson(mainDataString, collectionType2);
 			
 			List<List<ProjectIdentification>> ossComponentsLicense = CommonFunction.setOssComponentLicense(ossComponents);
-			
+			for(ProjectIdentification idx : ossComponents){
+				String ossVersion = idx.getOssVersion();
+				if (ossVersion.matches("[vV]\\.(\\d+).*") || ossVersion.matches("[vV](\\d+).*")) {
+					ossVersion = ossVersion.replaceAll("[vV]\\.", "").replaceAll("[vV]", "");
+					idx.setOssVersion(ossVersion);
+				}
+			}
+
 			Type collectionType4 = new TypeToken<List<Project>>() {
 			}.getType();
 			List<Project> binAddList = new ArrayList<Project>();
@@ -2185,7 +2192,15 @@ public class ProjectController extends CoTopComponent {
 		ossComponents = (List<ProjectIdentification>) fromJson(mainDataString, collectionType2);
 		
 		List<List<ProjectIdentification>> ossComponentsLicense = CommonFunction.setOssComponentLicense(ossComponents);
-		
+
+		for(ProjectIdentification idx : ossComponents){
+			String ossVersion = idx.getOssVersion();
+			if (ossVersion.matches("[vV]\\.(\\d+).*") || ossVersion.matches("[vV](\\d+).*")) {
+				ossVersion = ossVersion.replaceAll("[vV]\\.", "").replaceAll("[vV]", "");
+				idx.setOssVersion(ossVersion);
+			}
+		}
+
 		Type collectionType4 = new TypeToken<List<Project>>() {}.getType();
 		List<Project> srcAddList = new ArrayList<Project>();
 		srcAddList = (List<Project>) fromJson(srcAddListDataString, collectionType4);


### PR DESCRIPTION
## Description
I created a function to remove the V from the OSS table in context.
Currently, v is being removed based on conditions, and we haven't developed the admin check feature yet,
OSS Table : Table that stores OSS information in Project > Identification tab (SRC, BIN, 3rd Party), 3rd Party, Self-check tab
When applied: When the user clicks Save
Application plan: If the following conditions are satisfied, remove v (regardless of case) or v.
v or v. Start with 2. If a number appears immediately after number 1 (However, if admin check is displayed, the user's input is left as it is)
ex) v.1.0 / V1.0 -> 1.0
V_1.0, version1.0 -> no change
closed: #966

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
