### PR TITLE
Division N notification email sending

### DIFF
--- a/src/main/java/oss/fosslight/repository/T2UserMapper.java
+++ b/src/main/java/oss/fosslight/repository/T2UserMapper.java
@@ -49,6 +49,8 @@ public interface T2UserMapper {
 	public List<T2Users> selectAdminUser();
 	
 	public List<T2Users> selectAllUsersDivision();
+
+	public List<T2Users> selectAllUsersUpdatedDivision(String division);
 	
 	public List<T2Users> selectCheckEmail(String email);
 	

--- a/src/main/java/oss/fosslight/service/impl/CodeServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/CodeServiceImpl.java
@@ -137,25 +137,28 @@ public class CodeServiceImpl extends CoTopComponent implements CodeService {
 			}
 
 			// send email if useYn changed from "Y" to "N"
-			for (T2CodeDtl cdDtlBefore : beforeCodeDetailList){
-				for(T2CodeDtl cdDtlAfter : dtlList){
-					if( cdDtlBefore.getUseYn().equalsIgnoreCase("Y")
-							&& cdDtlAfter.getUseYn().equalsIgnoreCase("N")){
-						List<T2Users> t2UsersList = t2UserMapper.selectAllUsersUpdatedDivision(cdDtlAfter.getCdDtlNo());
+			for (T2CodeDtl before : beforeCodeDetailList) {
+				for (T2CodeDtl after : dtlList) {
+					if (before.getCdDtlNo().equals(after.getCdDtlNo()) &&
+							before.getUseYn().equalsIgnoreCase("Y") &&
+							after.getUseYn().equalsIgnoreCase("N")) {
+
+						List<T2Users> t2UsersList = t2UserMapper.selectAllUsersUpdatedDivision(after.getCdDtlNo());
 						List<String> toIds = new ArrayList<>();
-						for (T2Users users: t2UsersList){
-							toIds.add(users.getEmail());
+						for (T2Users user: t2UsersList){
+							System.out.println(user);
+							toIds.add(user.getEmail());
 						}
 						try {
 							CoMail mailBean = new CoMail(CoConstDef.CD_MAIL_TYPE_OSS_UPDATE);
 							mailBean.setEmlTitle("Division이 비활성화되었습니다. 로그인 후 왼쪽 메뉴바의 User name을 클릭하여 Division을 업데이트해주십시오.");
 							mailBean.setEmlMessage("Division이 비활성화되었습니다. 로그인 후 왼쪽 메뉴바의 User name을 클릭하여 Division을 업데이트해주십시오.");
 							mailBean.setToIds(toIds.toArray(new String[toIds.size()]));
-
 							CoMailManager.getInstance().sendMail(mailBean);
 						} catch (Exception e) {
 							log.error(e.getMessage(), e);
 						}
+
 					}
 				}
 			}

--- a/src/main/resources/oss/fosslight/repository/T2UserMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/T2UserMapper.xml
@@ -336,6 +336,14 @@
 		AND B.CD_NO = '200'
 	WHERE A.USE_YN = 'Y' ORDER BY DIVISION, A.USER_NAME
 	</select>
+
+    <select id="selectAllUsersUpdatedDivision" resultType="oss.fosslight.domain.T2Users" parameterType="String">
+        SELECT
+            A.USER_ID, A.USER_NAME, A.EMAIL, A.DIVISION AS DIVISION
+        FROM
+            T2_USERS A
+        WHERE A.DIVISION = #{division} ORDER BY DIVISION, A.USER_NAME
+    </select>
 	
 	<select id="selectCheckEmail" parameterType="String" resultType="oss.fosslight.domain.T2Users"> 
     /*email check*/


### PR DESCRIPTION
## Description
closes #908 
Division N notification email sending. If the division changes, an email is sent to users classified into this division to notify them.

## Solution
-  Add a query to retrieve user bean whose code has changed.
```
if (before.getCdDtlNo().equals(after.getCdDtlNo()) && before.getUseYn().equalsIgnoreCase("Y")  && after.getUseYn().equalsIgnoreCase("N"))
```

<br>

- Add search query in OSSMapper.xml

```
<select id="selectAllUsersUpdatedDivision" resultType="oss.fosslight.domain.T2Users" parameterType="String">
        SELECT
            A.USER_ID, A.USER_NAME, A.EMAIL, A.DIVISION AS DIVISION
        FROM
            T2_USERS A
        WHERE A.DIVISION = #{division} ORDER BY DIVISION, A.USER_NAME
</select>
```

<br>

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)