### PR TITLE
Fix to prevent Korean language from being broken in PDF

### DIFF
--- a/src/main/java/oss/fosslight/util/PdfUtil.java
+++ b/src/main/java/oss/fosslight/util/PdfUtil.java
@@ -1,6 +1,11 @@
 package oss.fosslight.util;
 
+import com.itextpdf.html2pdf.ConverterProperties;
 import com.itextpdf.html2pdf.HtmlConverter;
+import com.itextpdf.html2pdf.resolver.font.DefaultFontProvider;
+import com.itextpdf.io.font.FontProgram;
+import com.itextpdf.io.font.FontProgramFactory;
+import com.itextpdf.layout.font.FontProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
@@ -9,14 +14,12 @@ import oss.fosslight.CoTopComponent;
 import oss.fosslight.common.CoConstDef;
 import oss.fosslight.common.CommonFunction;
 import oss.fosslight.domain.*;
+import oss.fosslight.domain.File;
 import oss.fosslight.repository.*;
 import oss.fosslight.service.ProjectService;
 import oss.fosslight.service.VulnerabilityService;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.StringWriter;
-import java.io.Writer;
+import java.io.*;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -48,9 +51,17 @@ public final class PdfUtil extends CoTopComponent {
         }
         return instance;
     }
-    public static ByteArrayInputStream html2pdf(String html) {
+    public static ByteArrayInputStream html2pdf(String html) throws IOException {
+        String font = "src/main/resources/static/NanumGothicBold.ttf";
+
+        ConverterProperties properties = new ConverterProperties();
+        FontProvider fontProvider = new DefaultFontProvider(false,false,false);
+        FontProgram fontProgram = FontProgramFactory.createFont(font);
+        fontProvider.addFont(fontProgram);
+        properties.setFontProvider(fontProvider);
+
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        HtmlConverter.convertToPdf(html, outputStream);
+        HtmlConverter.convertToPdf(html, outputStream, properties);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
         return inputStream;
     }
@@ -165,6 +176,7 @@ public final class PdfUtil extends CoTopComponent {
         props.put("resource.loader", "class");
         props.put("class.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
         props.put("input.encoding", "UTF-8");
+        props.put("output.encoding", "UTF-8");
 
         vf.init(props);
 


### PR DESCRIPTION
## Description
close #1005 
- #1005 

# AS IS
Korean is broken in PDF.
<img width="601" alt="image" src="https://github.com/fosslight/fosslight/assets/91003734/d465f893-4eaa-4e91-a391-2405f574c268">

# TO BE 
<img width="601" alt="image" src="https://github.com/fosslight/fosslight/assets/91003734/22443b0a-9ca5-4744-a3b8-a20e55f80c4b">


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
