### PR TITLE
Replace docker base image from adopt to temulin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN gradle build --no-daemon --exclude-task test
 
 
 # Create the containerized app
-FROM adoptopenjdk/openjdk11:jre-11.0.15_10-ubuntu
+FROM eclipse-temurin:11.0.21_9-jre-jammy
 LABEL maintainer="FOSSLight <fosslight-dev@lge.com>"
 
 COPY --from=build /home/gradle/src/build/libs/*.war /app/FOSSLight.war


### PR DESCRIPTION
## Description
<!-- 
Please describe what this PR do.
 -->

Closes #825 

> NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).

Replaced docker base image from [adoptopenjdk/openjdk11:jre-11.0.15_10-ubuntu](https://hub.docker.com/layers/adoptopenjdk/openjdk11/jre-11.0.15_10-ubuntu/images/sha256-47731bdd8db0cc80536915e5337d66008bf94f3e7ada123b6f3e09b7edcc739f?context=explore) to [eclipse-temurin/11.0.21_9-jre-jammy](https://hub.docker.com/layers/library/eclipse-temurin/11.0.21_9-jre-jammy/images/sha256-a4fa5b3c626e96ae0ca406dad4f2c41c492b9caeb05e72af9c58d767fe41af1b?context=explore).

The new base image fully supports current multi-arch builds:

https://github.com/fosslight/fosslight/blob/1c8bcf0bda93ca7af4b6910e079e0c2e3556d19f/.github/workflows/release-publish.yml#L67-L72

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
