### PR TITLE
Change CheckOSSName Button in DEP tab

### DIFF
--- a/src/main/resources/static/css/commonIframe.css
+++ b/src/main/resources/static/css/commonIframe.css
@@ -225,6 +225,7 @@ input.btnCLightAnalysis {height:20px;padding-bottom:1px;line-height:auto;}
 .btnColor.blue, .btnCLight.blue, .btnCLight2.blue {border-color:#4d6080;background:#7a8fae;}
 .btnColor.purple, .btnCLight.purple, .btnCLight2.purple {border-color:#5f4b7c;background:#8d79ae;}
 .btnColor.gray, .btnCLight.gray, .btnCLight2.gray, .btnCLightAnalysis.gray {color:#666 !important;border-color:#c6c6c6;background:#f1f1f1;}
+.btnColor.gray.disabled {color: #bbbbbb !important; text-decoration: line-through}
 .btnColor.darkgray, .btnCLight.darkgray, .btnCLight2.darkgray {border-color:#656565;background:#939393;}
 .btnColor.brown, .btnCLight.brown, .btnCLight2.brown {border-color:#766554;background:#a59381;}
 .btnColor.pink, .btnCLight.pink, .btnCLight2.pink {border-color:#cf6a91;background:#d47f9a; vertical-align:middle !important;}

--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssNamepopup.jsp
@@ -201,7 +201,6 @@
 													/**
 													 * params["referenceDiv"] is id of identification type
 													 * 3RD, DEP, SRC, BIN, BIN-Android, BOM
-													 * 10 (3RD) -> tab index: 0
 													 * 16 (DEP) -> tab index: 1
 													 * 11 (SRC) -> tab index: 2
 													 * 15 (BIN) -> tab index: 3
@@ -399,7 +398,13 @@
 										}
 									}
 								}
-								
+
+								if ("identification" == targetName && referenceDiv.startsWith("16")) {
+									$("#btnChangeOss").removeClass('red');
+									$("#btnChangeOss").addClass('gray disabled');
+									$("#btnChangeOss").attr('disabled', true);
+								}
+
 								$('#loading_wrap_popup').hide();
 
 								if(ossValidMsg) {

--- a/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
@@ -335,9 +335,6 @@
 				</div>
 				<div class="btnLayout">
                     <span class="left">
-<%--						<c:if test="${project.dropYn ne 'Y' and (ct:isAdmin())}">--%>
-<%--							<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('DEP')" class="btnColor red srcBtn" style="width: 115px;" />--%>
-<%--						</c:if>--%>
 						<c:set var="isAdmin" value="${ct:isAdmin()}"/>
                     	<c:if test="${project.dropYn ne 'Y' and (ct:isAdmin() or project.viewOnlyFlag eq 'N')}">
 							<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('DEP')" style="width: 115px;" <c:choose> <c:when test="${isAdmin == 'true'}">class="btnColor red srcBtn"</c:when> <c:otherwise>class="btnColor gray disabled srcBtn" disabled</c:otherwise> </c:choose> />

--- a/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/project/identification.jsp
@@ -335,10 +335,12 @@
 				</div>
 				<div class="btnLayout">
                     <span class="left">
-						<c:if test="${project.dropYn ne 'Y' and (ct:isAdmin())}">
-							<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('DEP')" class="btnColor red srcBtn" style="width: 115px;" />
-						</c:if>
+<%--						<c:if test="${project.dropYn ne 'Y' and (ct:isAdmin())}">--%>
+<%--							<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('DEP')" class="btnColor red srcBtn" style="width: 115px;" />--%>
+<%--						</c:if>--%>
+						<c:set var="isAdmin" value="${ct:isAdmin()}"/>
                     	<c:if test="${project.dropYn ne 'Y' and (ct:isAdmin() or project.viewOnlyFlag eq 'N')}">
+							<input type="button" value="Check OSS Name" onclick="com_fn.CheckOssViewPage('DEP')" style="width: 115px;" <c:choose> <c:when test="${isAdmin == 'true'}">class="btnColor red srcBtn"</c:when> <c:otherwise>class="btnColor gray disabled srcBtn" disabled</c:otherwise> </c:choose> />
 							<input type="button" value="Check License" onclick="com_fn.CheckOssLicenseViewPage('DEP')" class="btnColor red srcBtn" style="width: 100px;" />
 							<input type="button" value="Bulk Edit" onclick="com_fn.bulkEdit('DEP')" class="btnColor btnColor red idenEdit" />
 						</c:if>


### PR DESCRIPTION
## Description
For UI consistency, the Check OSS Name button, which had disappeared, was made visible again and disabled.

AS-IS:
for user, "Check OSS Name" button is not shown in dep tab.
![image](https://github.com/fosslight/fosslight/assets/141611764/e63ab6a4-140e-4797-ae7d-8fa244af8342)

for admin, "Change OSS Name" button is enabled.
<img width="2519" alt="image" src="https://github.com/fosslight/fosslight/assets/141611764/fe098991-15bb-4ee5-b2af-fa8f7a9d30f5">

TO-BE:
for user, "Check OSS Name" button was displayed but disabled
![image](https://github.com/fosslight/fosslight/assets/141611764/a7300a29-4baa-4b11-ba3a-5a5674be4133)

for admin, "Change OSS Name" button visible but disabled in Check OSS Name popup in dep tab.
<img width="1984" alt="image" src="https://github.com/fosslight/fosslight/assets/141611764/b10f197d-d9cd-4be3-97ac-2cb346331a0a">


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
