### PR TITLE
Fix API (/api/v1/prj_bom_export)

### DIFF
--- a/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
+++ b/src/main/java/oss/fosslight/api/controller/v1/ApiProjectController.java
@@ -519,7 +519,8 @@ public class ApiProjectController extends CoTopComponent {
 			
 			if (searchFlag) {
 				if ("Y".equals(mergeSaveFlag)) {
-					apiProjectService.registBom(prjId, mergeSaveFlag);
+//					apiProjectService.registBom(prjId, mergeSaveFlag);
+					projectService.registBom(prjId, mergeSaveFlag, new ArrayList<>(), new ArrayList<>());
 				}
 				downloadId = ExcelDownLoadUtil.getExcelDownloadId("bom", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
 				fileInfo = fileService.selectFileInfo(downloadId);


### PR DESCRIPTION
## Description
The API /api/v1/prj_bom_export dosen't work properly.
When set mergeSaveFlag as 'Y", sometimes the request causes DB error.
Therefore, change the way to merge BOM in API as same as project.
Call the Project's registBOM function instead of API's registBOM function.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
