### PR TITLE
fix external service status message in checkOssLicensepopup

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/oss/checkOssLicensepopup.jsp
@@ -300,7 +300,7 @@
 					<div align="left" style="padding-bottom: 20px;">
 						<b><spring:message code="msg.project.check.license" /></b>
 						<c:choose>
-							<c:when test="${ct:getCodeExpString(ct:getConstDef('CD_SYSTEM_SETTING'), ct:getConstDef('CD_EXTERNAL_SERVICE_USED_FLAG')) eq 'N'}">
+							<c:when test="${ct:getProperty('external.service.useflag') eq 'N'}">
 								</br>
 								<b style="color:blue"><spring:message code="external.service.disable" /></b>
 							</c:when>


### PR DESCRIPTION
## Description
fix invalid external service popup message in checkOssLicensepopup


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)