### PR TITLE
Fix OSS Rename performance issues and Project Search UI bugs

### DIFF
--- a/src/main/resources/templates/oss/edit-script.html
+++ b/src/main/resources/templates/oss/edit-script.html
@@ -3344,7 +3344,7 @@
 					const renameFormData = new FormData(form);
 					
 					$.ajax({
-						url : suffix + '/oss/validation',
+						url : '/oss/validation',
 						type : 'POST',
 						data : renameFormData,
 						cache : false,

--- a/src/main/resources/templates/project/3rd-script.html
+++ b/src/main/resources/templates/project/3rd-script.html
@@ -515,7 +515,9 @@ var party_evt = {
 			mtype: 'GET',
 			loadComplete: function(data){
 				$('.commentDiv').find('p').css('margin','0px 0px');
-				tableRefreshNew("_list-1");
+				if (typeof tableRefreshContentsAreaEdit === 'function') {
+                    tableRefreshContentsAreaEdit("_list-1");
+                }
 			},
 			gridComplete : function() {
 				$('#_list-1').closest(".ui-jqgrid-bdiv").children(":first").css({"max-height":"360px"});
@@ -817,8 +819,6 @@ var part_grid = {
 			colModelArr.push(colModelObj);
 			colModelObj = {name: 'referenceId', index: 'referenceId', width: 29, align: 'center', hidden:true};
 			colModelArr.push(colModelObj);
-			colModelObj = {name: 'refPartnerId', index: 'refPartnerId', width: 29, align: 'center', hidden:true};
-			colModelArr.push(colModelObj);
 			colModelObj = {name: 'refPrjId', index: 'refPrjId', width: 29, align: 'center', hidden:true};
 			colModelArr.push(colModelObj);
 			colModelObj = {name: 'referenceDiv', index: 'referenceDiv', width: 29, align: 'center', hidden:true};
@@ -861,7 +861,7 @@ var part_grid = {
 			partList.jqGrid({
 				datatype: 'local',
 				data : partMainData,
-				colNames: ['gridId','ID_KEY','ID','3rd Party', 'Binary Name or Source Path','ReferenceId','RefPartnerId','RefPrjId','ReferenceDiv', 'OssId','OSS Name','OSS Version','License','Download Location'
+				colNames: ['gridId','ID_KEY','ID','3rd Party', 'Binary Name or Source Path','ReferenceId','RefPrjId','ReferenceDiv', 'OssId','OSS Name','OSS Version','License','Download Location'
 							, 'Homepage','LicenseId','Copyright Text', 'Vulnera<br/>bility', 'CVE ID'	
 							, '<input type="checkbox" onclick="fn_grid_com.onCboxClickAll(this,\'list3\');">Exclude', 'refComponentId'],
 				colModel: colModelArr,

--- a/src/main/resources/templates/project/bom-script.html
+++ b/src/main/resources/templates/project/bom-script.html
@@ -1457,7 +1457,7 @@ var bom_data = {
 	                	appendBtn += "<button type=\"button\" class=\"btn btn-sm btn-grid-light-gray float-left ml-1\" onclick=\"com_fn.gridAddFunc('bom', 'bomList', true)\"><i class=\"fas fa-plus gridIconDisabled\"></i></button>";
                 		appendBtn += "<button type=\"button\" class=\"btn btn-sm btn-grid-light-gray float-left ml-1\" onclick=\"com_fn.gridDelFunc('bom', 'bomList', '_bomAddList', 'main', true)\"><i class=\"far fa-trash-alt gridIconDisabled\"></i></button>";
 	                	appendBtn += "<button type=\"button\" class=\"btn btn-sm btn-grid-light-gray float-left ml-1\" onclick=\"com_fn.bulkEdit('bom')\"><i class=\"fas fa-pencil-alt gridIconDisabled\"></i></button>";
-	                	appendBtn += "<button id=\"bomDropTop\" class=\"btn btn-sm btn-grid-light-gray float-left ml-1\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\")\"><i class=\"fas fa-download customGridIcon\"></i></button>";
+	                	appendBtn += "<button id=\"bomDropTop\" class=\"btn btn-sm btn-grid-light-gray float-left ml-1\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"><i class=\"fas fa-download customGridIcon\"></i></button>";
 	                	appendBtn += "<div class=\"dropdown-menu\" aria-labelledby=\"bomDropTop\">";
 	                	appendBtn += "<span class=\"dropdown-item pointer\" onclick=\"bom_fn.selectDownloadFile('report_sub')\">FOSSLight Report (Spreadsheet)</span>";
 	                	appendBtn += "<span class=\"dropdown-item pointer\" onclick=\"bom_fn.selectDownloadFile('YAML')\">FOSSLight Report (YAML)</span>";
@@ -1467,7 +1467,7 @@ var bom_data = {
 	                	appendBtn += "<span class=\"dropdown-item pointer\" onclick=\"bom_fn.selectDownloadFile('JSON_sub')\">SPDX (JSON)</span>";
 	                	appendBtn += "<span class=\"dropdown-item pointer\" onclick=\"bom_fn.selectDownloadFile('YAML_sub')\">SPDX (YAML)</span>";
 	                	appendBtn += "<span class=\"dropdown-item pointer\" onclick=\"bom_fn.selectDownloadFile('cdxJSON')\">CycloneDX (JSON)</span>";
-	                	appendBtn += "<span class=\"dropdown-item pointer\" onclick=\"bom_fn.selectDownloadFile('cdxXML')\">CycloneDX ((XML)</span>";
+	                	appendBtn += "<span class=\"dropdown-item pointer\" onclick=\"bom_fn.selectDownloadFile('cdxXML')\">CycloneDX (XML)</span>";
                         appendBtn += "<span class=\"dropdown-item pointer\" onclick=\"bom_fn.selectDownloadFile('reviewReport')\">ReviewReport</span></div>";
 	                                        
 	                    $("#bomList_toppager_left").append(appendBtn);
@@ -1563,18 +1563,17 @@ var bom_data = {
 					com_fn.checkGridComplete(false);
 					adjustMultiPageGridSize();
 					updateGridRowCount('bomList', 'bomPager');
+					// $("#bomList").jqGrid('navGrid',"#bomPager",{add:false,edit:false,del:false,search:false,refresh:false});
+					$("#bomList").jqGrid('filterToolbar',{stringResult: true, searchOnEnter: true, searchOperators: true, defaultSearch: "cn",
+						beforeSearch : function () {
+							if(!this.p.postData.referenceId) {
+								this.p.postData.referenceId = [[${project.prjId}]];
+							}
+						}, afterSearch : function () { 
+							updateGridRowCount('bomList', 'bomPager') 
+						}	
+					});
 				}
-			});
-
-			// $("#bomList").jqGrid('navGrid',"#bomPager",{add:false,edit:false,del:false,search:false,refresh:false});
-			$("#bomList").jqGrid('filterToolbar',{stringResult: true, searchOnEnter: true, searchOperators: true, defaultSearch: "cn",
-				beforeSearch : function () {
-					if(!this.p.postData.referenceId) {
-						this.p.postData.referenceId = [[${project.prjId}]];
-					}
-				}, afterSearch : function () { 
-					updateGridRowCount('bomList', 'bomPager') 
-				}	
 			});
 		}
 	}

--- a/src/main/resources/templates/project/fragments/edit.html
+++ b/src/main/resources/templates/project/fragments/edit.html
@@ -62,7 +62,7 @@
 					<input type="hidden" name="prjName" />
 					<input type="hidden" name="prjVersion" />
 					<input type="hidden" name="prjId" />
-					<div class="partyProjectSearch" style="display: none;">
+					<div id="projectSearch" class="partyProjectSearch" style="display: none;">
 						<div class="row mt-5">
 							<div class="col-md-2">
 								<div class="form-group">


### PR DESCRIPTION
## Description
- Incorrect URL path: OSS validation endpoint includes unnecessary suffix variable
- Incorrect refresh function: 3rd party grid uses tableRefreshNew() which doesn't exist in edit mode context
- Duplicate column definitions: In colModel, refPartnerId is declared twice. In colNames, 'RefPartnerId' appears as a separate column even though '3rd Party' column already uses refPartnerId as its key, causing duplicate column references
- Syntax errors: Extra closing parenthesis in button attribute
- Typo: "CycloneDX ((XML)" has double opening parenthesis
- Timing issue in BOM grid: filterToolbar setup executes before grid initialization completes, causing Uncaught TypeError: - Cannot read properties of undefined (reading 'hDiv') error because the header DOM element doesn't exist yet


Missing element ID: Project search div lacks an ID attribute, making it difficult to reference programmatically

## Changes
- Fixed URL from suffix + '/oss/validation' to /oss/validation (oss/edit-script.html)
- Fixed 3rd party grid refresh to use tableRefreshContentsAreaEdit("_list-1") with function existence check (project/3rd-script.html)
- Removed duplicate refPartnerId from colModel and 'RefPartnerId' from colNames (already referenced by '3rd Party' column) (project/3rd-script.html)
- Fixed button syntax error by removing extra ) (project/bom-script.html)
- Fixed typo: CycloneDX ((XML) → CycloneDX (XML) (project/bom-script.html)
- Moved filterToolbar setup code inside gridComplete callback to ensure grid and header DOM are fully initialized before adding search toolbar (project/bom-script.html)
- Added id="projectSearch" to project search div (project/fragments/edit.html)




## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
