### PR TITLE
Remove "Type of change" section from PR default template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,14 +2,3 @@
 <!-- 
 Please describe what this PR do.
  -->
-
-
-## Type of change
-<!--
-Please insert 'x' one of the type of change.
- -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Documentation update
-- [ ] Refactoring, Maintenance
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### PR DESCRIPTION
## Description
Remove "Type of change" section from PR default template
