### PR TITLE
Feature/apiv2/platform supplement notice

### DIFF
--- a/src/main/java/oss/fosslight/api/advice/ApiV2ExceptionAdvice.java
+++ b/src/main/java/oss/fosslight/api/advice/ApiV2ExceptionAdvice.java
@@ -63,10 +63,15 @@ public class ApiV2ExceptionAdvice extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(CProjectNotAvailableException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
     protected ResponseEntity<Map<String, Object>> userNoPermission(HttpServletRequest request, CProjectNotAvailableException e){
-        return responseService.errorResponse(HttpStatus.NOT_FOUND,
-                "The user does not have edit permissions for Project " + e.getMessage());
+        String message;
+        if (e.getPermissionType() == ProjectPermissionType.VIEW) {
+            message = "The user does not have view permissions for Project " + e.getMessage();
+        } else {
+            message = "The user does not have edit permissions for Project " + e.getMessage();
+        }
+        return responseService.errorResponse(HttpStatus.FORBIDDEN, message);
     }
 
     @ExceptionHandler(CUserNotFoundException.class)

--- a/src/main/java/oss/fosslight/api/advice/CProjectNotAvailableException.java
+++ b/src/main/java/oss/fosslight/api/advice/CProjectNotAvailableException.java
@@ -8,16 +8,30 @@ package oss.fosslight.api.advice;
 public class CProjectNotAvailableException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
+	
+	private ProjectPermissionType permissionType;
+
+    public CProjectNotAvailableException(String msg, ProjectPermissionType permissionType) {
+        super(msg);
+        this.permissionType = permissionType;
+    }
 
     public CProjectNotAvailableException(String msg, Throwable t) {
         super(msg, t);
+        this.permissionType = ProjectPermissionType.EDIT;
     }
 
     public CProjectNotAvailableException(String msg) {
         super(msg);
+        this.permissionType = ProjectPermissionType.EDIT;
     }
 
     public CProjectNotAvailableException() {
         super();
+        this.permissionType = ProjectPermissionType.EDIT;
     }
+
+	public ProjectPermissionType getPermissionType() {
+		return permissionType;
+	}
 }

--- a/src/main/java/oss/fosslight/api/advice/ProjectPermissionType.java
+++ b/src/main/java/oss/fosslight/api/advice/ProjectPermissionType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only 
+ */
+
+package oss.fosslight.api.advice;
+
+public enum ProjectPermissionType {
+	EDIT("edit"),
+	VIEW("view");
+	
+	private final String type;
+	
+	ProjectPermissionType(String type) {
+		this.type = type;
+	}
+	
+	public String getType() {
+		return type;
+	}
+}

--- a/src/main/java/oss/fosslight/common/Url.java
+++ b/src/main/java/oss/fosslight/common/Url.java
@@ -1055,6 +1055,9 @@ public final class Url {
 			/** API Project BOM Tab Export JSON*/
 			public static final String FOSSLIGHT_API_PROJECT_BOM_JSON	    = "/projects/{id}/sbom/json-data";
 
+			/** API Project Supplement Notice Download */
+			public static final String FOSSLIGHT_API_PROJECT_SUPPLEMENT_NOTICE = "/projects/{id}/platform/supplement-notice";
+
 			/** API BOM COMPARE */
 			public static final String FOSSLIGHT_API_PROJECT_BOM_COMPARE		= "/projects/{id}/sbom/compare-with/{compareId}";
 
@@ -1153,4 +1156,3 @@ public final class Url {
 	}
 
 }
-

--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -4667,6 +4667,12 @@ public class ProjectController extends CoTopComponent {
 		try {
 			String fileId = projectService.getSupplementNoticeFileId(prjId, zipFlag);
 			return makeJsonResponseHeader(fileId);
+		} catch (IllegalArgumentException e) {
+			// Validation error - message code 처리
+			String messageCode = e.getMessage();
+			String localizedMessage = getMessage(messageCode);
+			log.error("Validation failed for supplement notice: {}", messageCode);
+			return makeJsonResponseHeader(false, localizedMessage);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 			return makeJsonResponseHeader(false, e.getMessage());

--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -4665,6 +4665,7 @@ public class ProjectController extends CoTopComponent {
 		String zipFlag = (String) map.get("zipFlag");
 		
 		try {
+			// Authorization check: User must have view permission for the project (enforced by web security context)
 			String fileId = projectService.getSupplementNoticeFileId(prjId, zipFlag);
 			return makeJsonResponseHeader(fileId);
 		} catch (IllegalArgumentException e) {

--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -4675,7 +4675,7 @@ public class ProjectController extends CoTopComponent {
 			return makeJsonResponseHeader(false, localizedMessage);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
-			return makeJsonResponseHeader(false, e.getMessage());
+			return makeJsonResponseHeader(false, getMessage("msg.common.valid2"));
 		}
 	}
 	

--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -685,129 +685,7 @@ public class ProjectController extends CoTopComponent {
 				}
 			}
 		} else if (CoConstDef.CD_DTL_COMPONENT_ID_ANDROID.equals(code) && map != null) {
-			List<String> noticeBinaryList = null;
-			List<String> existsBinaryName = null;
-			
-			if (!isEmpty(identification.getReferenceId())) {
-				// 다른 project에서 load하는 경우
-				if (CoConstDef.FLAG_YES.equals(identification.getLoadFromAndroidProjectFlag())) {
-					if (!isEmpty(identification.getAndroidNoticeFileId())) {
-						log.info("identification.getAndroidNoticeFileId() : OK");
-						noticeBinaryList = CommonFunction.getNoticeBinaryList(fileService.selectFileInfoById(identification.getAndroidNoticeFileId()));
-					}
-					
-					if (!isEmpty(identification.getAndroidResultFileId())) {
-						List<String> removedCheckList = null;
-						List<OssComponents> addCheckList = null;
-						log.info("identification.getAndroidResultFileId() : OK");
-						existsBinaryName = CommonFunction.getExistsBinaryNames(
-								fileService.selectFileInfoById(identification.getAndroidResultFileId()));
-
-						List<String> _checkExistsBinaryName = new ArrayList<>();
-						List<ProjectIdentification> _list = (List<ProjectIdentification>) map.get("mainData");
-						
-						for (ProjectIdentification bean : _list) {
-							if (!isEmpty(bean.getBinaryName())) {
-								_checkExistsBinaryName.add(bean.getBinaryName());
-							}
-						}
-						
-						T2File resultFileInfo = fileService.selectFileInfoById(identification.getAndroidResultFileId());
-						Map<String, Object> _resultFileInfoMap = CommonFunction.getAndroidResultFileInfo(resultFileInfo,
-								_checkExistsBinaryName);
-						
-						if (_resultFileInfoMap.containsKey("removedCheckList")) {
-							removedCheckList = (List<String>) _resultFileInfoMap.get("removedCheckList");
-						}
-						
-						if (_resultFileInfoMap.containsKey("addCheckList")) {
-							addCheckList = (List<OssComponents>) _resultFileInfoMap.get("addCheckList");
-						}
-
-						if (removedCheckList != null) {
-							for (ProjectIdentification bean : _list) {
-								if (removedCheckList.contains(bean.getBinaryName())) {
-									bean.setExcludeYn(CoConstDef.FLAG_YES);
-								}
-							}
-						}
-
-						if (addCheckList != null) {
-							// ossComponent에서 ProjectIdentification으로 변환
-							try {
-								OssComponentUtil.getInstance().makeOssComponent(addCheckList, true);
-							} catch (IllegalAccessException | InstantiationException | InvocationTargetException
-									| NoSuchMethodException e) {
-								log.error(e.getMessage());
-							}
-
-							for (OssComponents bean : addCheckList) {
-								ProjectIdentification _tempBean = new ProjectIdentification();
-								_tempBean.setBinaryName(bean.getBinaryName());
-								_tempBean.setFilePath(bean.getFilePath());
-								_tempBean.setBinaryNotice(bean.getBinaryNotice());
-								_tempBean.setOssName(bean.getOssName());
-								_tempBean.setOssVersion(bean.getOssVersion());
-								_tempBean.setLicenseName(bean.getLicenseName());
-								_tempBean.setDownloadLocation(bean.getDownloadLocation());
-								_tempBean.setHomepage(bean.getHomepage());
-								_tempBean.setCopyrightText(bean.getCopyrightText());
-								_tempBean.setExcludeYn(bean.getExcludeYn());
-								_tempBean.setEditable(CoConstDef.FLAG_YES);
-
-								_list.add(_tempBean);
-							}
-						}
-
-						map.replace("mainData", _list);
-					}
-				} else {
-					Project prjInfo = projectService.getProjectBasicInfo(identification.getReferenceId());
-					
-					if (prjInfo != null) {
-						if (!isEmpty(prjInfo.getSrcAndroidNoticeFileId())) {
-							noticeBinaryList = CommonFunction.getNoticeBinaryList(fileService.selectFileInfoById(prjInfo.getSrcAndroidNoticeFileId()));
-						}
-						
-						if (isEmpty(prjInfo.getSrcAndroidNoticeFileId()) && !isEmpty(prjInfo.getSrcAndroidNoticeXmlId())) {
-							noticeBinaryList = CommonFunction.getNoticeBinaryList(fileService.selectFileInfoById(prjInfo.getSrcAndroidNoticeXmlId()));
-						}
-						
-						if (!isEmpty(prjInfo.getSrcAndroidResultFileId())) {
-							existsBinaryName = CommonFunction.getExistsBinaryNames(fileService.selectFileInfoById(prjInfo.getSrcAndroidResultFileId()));
-						}
-					}
-				}
-			}
-
-			pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_ANDROID);
-			pv.setAppendix("projectId", avoidNull(identification.getReferenceId()));
-			pv.setAppendix("mainList", (List<ProjectIdentification>) map.get("mainData"));
-			// sub grid
-			pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) map.get("subData"));
-
-			if (noticeBinaryList != null) {
-				pv.setAppendix("noticeBinaryList", noticeBinaryList);
-			}
-			
-			if (existsBinaryName != null) {
-				pv.setAppendix("existsResultBinaryName", existsBinaryName);
-			}
-			
-			T2CoValidationResult vr = pv.validate(new HashMap<>());
-			
-			if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
-				map.replace("mainData", CommonFunction.identificationSortByValidInfo((List<ProjectIdentification>) map.get("mainData"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false, true));
-				if (!vr.isValid()) {
-					map.put("validData", vr.getValidMessageMap());
-				}
-				if (!vr.isDiff()) {
-					map.put("diffData", vr.getDiffMessageMap(true));
-				}
-				if (vr.hasInfo()) {
-					map.put("infoData", vr.getInfoMessageMap());
-				}
-			}
+			map = projectService.applyAndroidIdentificationGridData(identification, map);
 		} else if ((CoConstDef.CD_DTL_COMPONENT_ID_BAT.equals(code) || CoConstDef.CD_DTL_COMPONENT_BAT.equals(code) || CoConstDef.CD_DTL_COMPONENT_PARTNER_BAT.equals(code))
 				&& map != null) {
 			pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_BAT);
@@ -4783,46 +4661,16 @@ public class ProjectController extends CoTopComponent {
 	@PostMapping(value = PROJECT.SUPPLEMENT_NOTICE_FILE)
 	public @ResponseBody ResponseEntity<Object> getSupplementNoticeFile(@RequestBody HashMap<String, Object> map,
 			HttpServletRequest req, HttpServletResponse res, Model model) {
-		String fileId = null;
 		String prjId = (String) map.get("referenceId");
 		String zipFlag = (String) map.get("zipFlag");
 		
 		try {
-			Project project = new Project();
-			project.setPrjId(prjId); 
-			Project projectDetail = projectService.getProjectDetail(project);
-			
-			ProjectIdentification identification = new ProjectIdentification();
-			identification.setReferenceId(prjId);
-			identification.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID);
-			Map<String, Object> result = getOssComponentDataInfo(identification, CoConstDef.CD_DTL_COMPONENT_ID_ANDROID);
-			
-			String validMsg = projectService.checkValidData(result);
-			
-			if (isEmpty(validMsg)) {
-				if (CoConstDef.FLAG_YES.equals(zipFlag)) {
-					fileId = projectService.makeZipFileId(result, projectDetail);
-				} else {
-					try {
-						String contents = projectService.makeNoticeFileContents(result);
-						fileId = projectService.makeSupplementFileId(contents, projectDetail);
-					} catch(Exception e) {
-						log.error(e.getMessage());
-					}
-				}
-			} else {
-				return makeJsonResponseHeader(false, validMsg);
-			}
-			
-			if (isEmpty(fileId)){
-				return makeJsonResponseHeader(false, "overflow");
-			}
+			String fileId = projectService.getSupplementNoticeFileId(prjId, zipFlag);
+			return makeJsonResponseHeader(fileId);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 			return makeJsonResponseHeader(false, e.getMessage());
 		}
-
-		return makeJsonResponseHeader(fileId);
 	}
 	
 	// 20210715_BOM COMPARE FUNC MOVE (LgeProjectController > ProjectController) >>>

--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -4675,7 +4675,7 @@ public class ProjectController extends CoTopComponent {
 			return makeJsonResponseHeader(false, localizedMessage);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
-			return makeJsonResponseHeader(false, getMessage("msg.common.valid2"));
+			return makeJsonResponseHeader(false, e.getMessage());
 		}
 	}
 	

--- a/src/main/java/oss/fosslight/repository/ApiProjectMapper.java
+++ b/src/main/java/oss/fosslight/repository/ApiProjectMapper.java
@@ -20,6 +20,8 @@ public interface ApiProjectMapper {
 	int selectProjectCount(Map<String, Object> paramMap);
 
 	boolean checkProjectExist(Map<String, Object> paramMap);
+
+	boolean checkProjectReadable(Map<String, Object> paramMap);
 	
 	Map<String, Object> selectVerificationCheck(@Param("prjId") String prjId);
 	

--- a/src/main/java/oss/fosslight/service/ApiProjectService.java
+++ b/src/main/java/oss/fosslight/service/ApiProjectService.java
@@ -29,6 +29,8 @@ public interface ApiProjectService {
 
 	public boolean checkProjectAvailability(T2Users userInfo, String prjId, String needToUploadReport);
 
+	public boolean checkUserAvailableToViewProject(T2Users userInfo, String prjId);
+
 	public boolean existProjectCnt(Map<String, Object> paramMap);
 
 	public Map<String, Object> getSheetData(UploadFile ufile, String prjId, String readType, String[] sheet);

--- a/src/main/java/oss/fosslight/service/ProjectService.java
+++ b/src/main/java/oss/fosslight/service/ProjectService.java
@@ -181,6 +181,10 @@ public interface ProjectService extends HistoryConfig{
 	
 	String makeZipFileId(Map<String, Object>paramMap, Project project);
 
+	String getSupplementNoticeFileId(String prjId, String zipFlag) throws Exception;
+
+	Map<String, Object> applyAndroidIdentificationGridData(ProjectIdentification identification, Map<String, Object> map);
+
 	public List<Map<String, String>> getBomCompare(List<ProjectIdentification> beforeBomList, List<ProjectIdentification> afterBomList, String flag) throws Exception;
 
 	public void deleteStatisticsMostUsedInfo(Project project);

--- a/src/main/java/oss/fosslight/service/ProjectService.java
+++ b/src/main/java/oss/fosslight/service/ProjectService.java
@@ -185,6 +185,8 @@ public interface ProjectService extends HistoryConfig{
 
 	Map<String, Object> applyAndroidIdentificationGridData(ProjectIdentification identification, Map<String, Object> map);
 
+	Map<String, Object> applyAndroidIdentificationGridData(ProjectIdentification identification, Map<String, Object> map, boolean forSupplementNotice);
+
 	public List<Map<String, String>> getBomCompare(List<ProjectIdentification> beforeBomList, List<ProjectIdentification> afterBomList, String flag) throws Exception;
 
 	public void deleteStatisticsMostUsedInfo(Project project);

--- a/src/main/java/oss/fosslight/service/impl/ApiProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiProjectServiceImpl.java
@@ -236,6 +236,16 @@ public class ApiProjectServiceImpl extends CoTopComponent implements ApiProjectS
 		return checkProjectAvailability(userInfo, prjId, CoConstDef.FLAG_NO);
 	}
 
+	@Override
+	public boolean checkUserAvailableToViewProject(T2Users userInfo, String prjId){
+		Map<String, Object> paramMap = new HashMap<>();
+		paramMap.put("userId", userInfo.getUserId());
+		paramMap.put("userRole", userRole(userInfo));
+		paramMap.put("prjId", prjId);
+
+		return apiProjectMapper.checkProjectReadable(paramMap);
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean existProjectCnt(Map<String, Object> paramMap) {

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -6582,7 +6582,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		// Check 3: 출력 조건을 만족하는 Binary가 있는지 확인 (BINARYNOTICE 메시지 확인)
 		String ruleMsg = (String) T2CoValidationConfig.getInstance().getRuleAllMap().get("BINARY_NOTICE.NOTICE_PERMISSIVE.MSG");
 		int validBinaryCnt = 0;
-		if (ruleMsg != null) {
+		if (ruleMsg != null && diffData != null) {
 			validBinaryCnt = diffData.entrySet().stream()
 									   .filter(c -> ((String) c.getValue()).equals(ruleMsg) && c.getKey().toUpperCase().contains("BINARYNOTICE"))
 									   .collect(Collectors.toList())
@@ -6751,8 +6751,9 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 					List<String> removedCheckList = null;
 					List<OssComponents> addCheckList = null;
 					log.info("identification.getAndroidResultFileId() : OK");
-					existsBinaryName = CommonFunction.getExistsBinaryNames(
-							fileService.selectFileInfoById(identification.getAndroidResultFileId()));
+
+					T2File resultFileInfo = fileService.selectFileInfoById(identification.getAndroidResultFileId());
+					existsBinaryName = CommonFunction.getExistsBinaryNames(resultFileInfo);
 
 					List<String> _checkExistsBinaryName = new ArrayList<>();
 					List<ProjectIdentification> _list = (List<ProjectIdentification>) map.get("mainData");
@@ -6763,7 +6764,6 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 						}
 					}
 
-					T2File resultFileInfo = fileService.selectFileInfoById(identification.getAndroidResultFileId());
 					Map<String, Object> _resultFileInfoMap = CommonFunction.getAndroidResultFileInfo(resultFileInfo,
 							_checkExistsBinaryName);
 
@@ -6894,7 +6894,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 
 		if (isEmpty(fileId)) {
-			throw new IllegalStateException("overflow");
+			throw new IllegalStateException("Failed to generate supplement notice file. Please verify that the project contains valid binary components.");
 		}
 
 		return fileId;

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -6547,20 +6547,17 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		List<ProjectIdentification> mainData = (List<ProjectIdentification>) map.get("mainData");
 		Map<String, Object> validData = (Map<String, Object>) map.get("validData");
 		Map<String, Object> diffData = (Map<String, Object>) map.get("diffData");
-		String validMsg = null;
+		String messageCode = null;
 		
-		int emptyBinaryPathCnt = 0;
-		int errCnt = 0;
-		int diffCnt = 0;
-		
-		if (mainData != null) {
-			emptyBinaryPathCnt = mainData.stream()
-											.filter(c -> isEmpty(c.getBinaryName()) && !CoConstDef.FLAG_YES.equals(avoidNull(c.getExcludeYn(), CoConstDef.FLAG_NO)))
-											.collect(Collectors.toList())
-											.size();
+		// Check 0: 기본 데이터 유무 확인 (mainData 또는 diffData가 없거나 비어있는 경우)
+		if (mainData == null || mainData.isEmpty() || diffData == null || diffData.isEmpty()) {
+			messageCode = "msg.project.no.binary";
+			return messageCode;
 		}
 		
-		if (validData != null) {
+		// Check 1: OSS Name, OSS Version, License에 Warning message가 있는지 확인
+		int errCnt = 0;
+		if (validData != null && !validData.isEmpty()) {
 			errCnt = validData.keySet().stream()
 								.filter(c -> c.toUpperCase().contains("OSS_NAME") 
 												|| c.toUpperCase().contains("OSS_VERSION") 
@@ -6569,41 +6566,35 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 								.size();
 		}
 		
-		if (diffData != null) {
-			Map<String, Object> diffDataMap = new HashMap<String, Object>();
-			for (String key : diffData.keySet()) {
-				if (key.toUpperCase().contains("LICENSENAME")) {
-					String diffMsg = (String) diffData.get(key);
-					if (!diffMsg.contains("Declared")) {
-						diffDataMap.put(key, diffData.get(key));
-					}
-				} else {
-					diffDataMap.put(key, diffData.get(key));
-				}
-			}
-			
-			if (!diffDataMap.isEmpty()) {
-				diffCnt = diffDataMap.keySet()
-						.stream()
-						.filter(c -> c.toUpperCase().contains("OSSNAME") 
-										|| c.toUpperCase().contains("OSSVERSION") 
-										|| c.toUpperCase().contains("LICENSENAME"))
-						.collect(Collectors.toList())
-						.size();
-			}
+		// Check 2: Binary Path이 공란인 Row 확인 (excludeYn != Y인 행만 체크)
+		int emptyBinaryPathCnt = 0;
+		emptyBinaryPathCnt = mainData.stream()
+										.filter(c -> isEmpty(c.getBinaryName()) && !CoConstDef.FLAG_YES.equals(avoidNull(c.getExcludeYn(), CoConstDef.FLAG_NO)))
+										.collect(Collectors.toList())
+										.size();
+		
+		// Check 1 또는 2 중 하나라도 위반 시: Error Message Code 1 반환
+		if (emptyBinaryPathCnt > 0 || errCnt > 0) {
+			messageCode = "msg.project.download.notice";
+			return messageCode;
 		}
 		
-		// OSS Name, OSS Version, License에 Warning message(빨간색, 파란색)가 있는 Row 또는 Binary Name이 공란인 Row
-		if (emptyBinaryPathCnt > 0 || errCnt > 0 ) {
-			validMsg = "You can download NOTICE only if there is no warning message in OSS Name, OSS Version, License or Binary Name is not null.";
+		// Check 3: 출력 조건을 만족하는 Binary가 있는지 확인 (BINARYNOTICE 메시지 확인)
+		String ruleMsg = (String) T2CoValidationConfig.getInstance().getRuleAllMap().get("BINARY_NOTICE.NOTICE_PERMISSIVE.MSG");
+		int validBinaryCnt = 0;
+		if (ruleMsg != null) {
+			validBinaryCnt = diffData.entrySet().stream()
+									   .filter(c -> ((String) c.getValue()).equals(ruleMsg) && c.getKey().toUpperCase().contains("BINARYNOTICE"))
+									   .collect(Collectors.toList())
+									   .size();
 		}
 		
-		// 출력할 Binary가 없는 경우(= 출력 조건에 해당하는 Row가 없는 경우)
-		if (mainData.size() == 0 || diffData.size() == 0) {
-			validMsg = "There is no binary that meets the conditions for creating NOTICE.";
+		// Check 3 위반 시: Error Message Code 2 반환
+		if (validBinaryCnt == 0) {
+			messageCode = "msg.project.no.binary";
 		}
 		
-		return validMsg;
+		return messageCode;
 	}
 	
 	@Override

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -6549,8 +6549,8 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		Map<String, Object> diffData = (Map<String, Object>) map.get("diffData");
 		String messageCode = null;
 		
-		// Check 0: 기본 데이터 유무 확인 (mainData 또는 diffData가 없거나 비어있는 경우)
-		if (mainData == null || mainData.isEmpty() || diffData == null || diffData.isEmpty()) {
+		// Check 0: 기본 데이터 유무 확인 (mainData가 없거나 비어있는 경우)
+		if (mainData == null || mainData.isEmpty()) {
 			messageCode = "msg.project.no.binary";
 			return messageCode;
 		}
@@ -6559,9 +6559,9 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		int errCnt = 0;
 		if (validData != null && !validData.isEmpty()) {
 			errCnt = validData.keySet().stream()
-								.filter(c -> c.toUpperCase().contains("OSS_NAME") 
-												|| c.toUpperCase().contains("OSS_VERSION") 
-												|| c.toUpperCase().contains("LICENSE_NAME"))
+								.filter(c -> c.toUpperCase().contains("OSSNAME")
+												|| c.toUpperCase().contains("OSSVERSION")
+												|| c.toUpperCase().contains("LICENSENAME"))
 								.collect(Collectors.toList())
 								.size();
 		}
@@ -6726,6 +6726,12 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	@Override
 	@SuppressWarnings("unchecked")
 	public Map<String, Object> applyAndroidIdentificationGridData(ProjectIdentification identification, Map<String, Object> map) {
+		return applyAndroidIdentificationGridData(identification, map, false);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Map<String, Object> applyAndroidIdentificationGridData(ProjectIdentification identification, Map<String, Object> map, boolean forSupplementNotice) {
 		if (map == null) {
 			return null;
 		}
@@ -6826,6 +6832,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 		T2CoProjectValidator pv = new T2CoProjectValidator();
 		pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_ANDROID);
+		pv.setCheckForAdmin(forSupplementNotice);
 		pv.setAppendix("projectId", avoidNull(identification.getReferenceId()));
 		pv.setAppendix("mainList", (List<ProjectIdentification>) map.get("mainData"));
 		pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) map.get("subData"));
@@ -6871,7 +6878,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		identification.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID);
 
 		Map<String, Object> result = getIdentificationGridList(identification, true);
-		result = applyAndroidIdentificationGridData(identification, result);
+		result = applyAndroidIdentificationGridData(identification, result, true);
 		String validMsg = checkValidData(result);
 
 		if (!isEmpty(validMsg)) {

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -108,7 +108,6 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	@Autowired private PartnerService partnerService;
 	@Autowired private ProjectService projectService;
 	@Autowired private HistoryService historyService;
-	@Autowired private oss.fosslight.service.ApiProjectService apiProjectService;
 	
 	// Mapper
 	@Autowired private ProjectMapper projectMapper;
@@ -6866,15 +6865,6 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	
 	@Override
 	public String getSupplementNoticeFileId(String prjId, String zipFlag) throws Exception {
-		// Check project view permission
-		T2Users userInfo = new T2Users();
-		userInfo.setUserId(loginUserName());
-		userInfo = t2UserService.getUser(userInfo);
-
-		if (!apiProjectService.checkUserAvailableToViewProject(userInfo, prjId)) {
-			throw new IllegalStateException("msg.common.cannot.access.page");
-		}
-
 		Project project = new Project();
 		project.setPrjId(prjId);
 
@@ -6904,7 +6894,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 
 		if (isEmpty(fileId)) {
-			throw new IllegalStateException("msg.project.notice.save");
+			throw new IllegalStateException("overflow");
 		}
 
 		return fileId;

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -108,6 +108,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	@Autowired private PartnerService partnerService;
 	@Autowired private ProjectService projectService;
 	@Autowired private HistoryService historyService;
+	@Autowired private oss.fosslight.service.ApiProjectService apiProjectService;
 	
 	// Mapper
 	@Autowired private ProjectMapper projectMapper;
@@ -6865,6 +6866,15 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	
 	@Override
 	public String getSupplementNoticeFileId(String prjId, String zipFlag) throws Exception {
+		// Check project view permission
+		T2Users userInfo = new T2Users();
+		userInfo.setUserId(loginUserName());
+		userInfo = t2UserService.getUser(userInfo);
+
+		if (!apiProjectService.checkUserAvailableToViewProject(userInfo, prjId)) {
+			throw new IllegalStateException("msg.common.cannot.access.page");
+		}
+
 		Project project = new Project();
 		project.setPrjId(prjId);
 
@@ -6894,7 +6904,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 
 		if (isEmpty(fileId)) {
-			throw new IllegalStateException("overflow");
+			throw new IllegalStateException("msg.project.notice.save");
 		}
 
 		return fileId;

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -7,6 +7,7 @@ package oss.fosslight.service.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.net.URLEncoder;
@@ -70,6 +71,7 @@ import org.springframework.web.util.HtmlUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import oss.fosslight.CoTopComponent;
+import oss.fosslight.util.OssComponentUtil;
 import oss.fosslight.common.CoCodeManager;
 import oss.fosslight.common.CoConstDef;
 import oss.fosslight.common.CommonFunction;
@@ -104,6 +106,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 	@Autowired private CommentService commentService;
 	@Autowired private T2UserService t2UserService;
 	@Autowired private PartnerService partnerService;
+	@Autowired private ProjectService projectService;
 	@Autowired private HistoryService historyService;
 	
 	// Mapper
@@ -6725,7 +6728,177 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 			// 파일 등록
 			fileId = fileService.registFileDownload(filePath, fileName, fileName);
 		}
-		
+
+		return fileId;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Map<String, Object> applyAndroidIdentificationGridData(ProjectIdentification identification, Map<String, Object> map) {
+		if (map == null) {
+			return null;
+		}
+
+		List<String> noticeBinaryList = null;
+		List<String> existsBinaryName = null;
+
+		if (!isEmpty(identification.getReferenceId())) {
+			// 다른 project에서 load하는 경우
+			if (CoConstDef.FLAG_YES.equals(identification.getLoadFromAndroidProjectFlag())) {
+				if (!isEmpty(identification.getAndroidNoticeFileId())) {
+					log.info("identification.getAndroidNoticeFileId() : OK");
+					noticeBinaryList = CommonFunction.getNoticeBinaryList(fileService.selectFileInfoById(identification.getAndroidNoticeFileId()));
+				}
+
+				if (!isEmpty(identification.getAndroidResultFileId())) {
+					List<String> removedCheckList = null;
+					List<OssComponents> addCheckList = null;
+					log.info("identification.getAndroidResultFileId() : OK");
+					existsBinaryName = CommonFunction.getExistsBinaryNames(
+							fileService.selectFileInfoById(identification.getAndroidResultFileId()));
+
+					List<String> _checkExistsBinaryName = new ArrayList<>();
+					List<ProjectIdentification> _list = (List<ProjectIdentification>) map.get("mainData");
+
+					for (ProjectIdentification bean : _list) {
+						if (!isEmpty(bean.getBinaryName())) {
+							_checkExistsBinaryName.add(bean.getBinaryName());
+						}
+					}
+
+					T2File resultFileInfo = fileService.selectFileInfoById(identification.getAndroidResultFileId());
+					Map<String, Object> _resultFileInfoMap = CommonFunction.getAndroidResultFileInfo(resultFileInfo,
+							_checkExistsBinaryName);
+
+					if (_resultFileInfoMap.containsKey("removedCheckList")) {
+						removedCheckList = (List<String>) _resultFileInfoMap.get("removedCheckList");
+					}
+
+					if (_resultFileInfoMap.containsKey("addCheckList")) {
+						addCheckList = (List<OssComponents>) _resultFileInfoMap.get("addCheckList");
+					}
+
+					if (removedCheckList != null) {
+						for (ProjectIdentification bean : _list) {
+							if (removedCheckList.contains(bean.getBinaryName())) {
+								bean.setExcludeYn(CoConstDef.FLAG_YES);
+							}
+						}
+					}
+
+					if (addCheckList != null) {
+						try {
+							OssComponentUtil.getInstance().makeOssComponent(addCheckList, true);
+						} catch (IllegalAccessException | InstantiationException | InvocationTargetException
+								| NoSuchMethodException e) {
+							log.error(e.getMessage());
+						}
+
+						for (OssComponents bean : addCheckList) {
+							ProjectIdentification _tempBean = new ProjectIdentification();
+							_tempBean.setBinaryName(bean.getBinaryName());
+							_tempBean.setFilePath(bean.getFilePath());
+							_tempBean.setBinaryNotice(bean.getBinaryNotice());
+							_tempBean.setOssName(bean.getOssName());
+							_tempBean.setOssVersion(bean.getOssVersion());
+							_tempBean.setLicenseName(bean.getLicenseName());
+							_tempBean.setDownloadLocation(bean.getDownloadLocation());
+							_tempBean.setHomepage(bean.getHomepage());
+							_tempBean.setCopyrightText(bean.getCopyrightText());
+							_tempBean.setExcludeYn(bean.getExcludeYn());
+							_tempBean.setEditable(CoConstDef.FLAG_YES);
+
+							_list.add(_tempBean);
+						}
+					}
+
+					map.replace("mainData", _list);
+				}
+			} else {
+				Project prjInfo = projectService.getProjectBasicInfo(identification.getReferenceId());
+
+				if (prjInfo != null) {
+					if (!isEmpty(prjInfo.getSrcAndroidNoticeFileId())) {
+						noticeBinaryList = CommonFunction.getNoticeBinaryList(fileService.selectFileInfoById(prjInfo.getSrcAndroidNoticeFileId()));
+					}
+
+					if (isEmpty(prjInfo.getSrcAndroidNoticeFileId()) && !isEmpty(prjInfo.getSrcAndroidNoticeXmlId())) {
+						noticeBinaryList = CommonFunction.getNoticeBinaryList(fileService.selectFileInfoById(prjInfo.getSrcAndroidNoticeXmlId()));
+					}
+
+					if (!isEmpty(prjInfo.getSrcAndroidResultFileId())) {
+						existsBinaryName = CommonFunction.getExistsBinaryNames(fileService.selectFileInfoById(prjInfo.getSrcAndroidResultFileId()));
+					}
+				}
+			}
+		}
+
+		T2CoProjectValidator pv = new T2CoProjectValidator();
+		pv.setProcType(pv.PROC_TYPE_IDENTIFICATION_ANDROID);
+		pv.setAppendix("projectId", avoidNull(identification.getReferenceId()));
+		pv.setAppendix("mainList", (List<ProjectIdentification>) map.get("mainData"));
+		pv.setAppendix("subListMap", (Map<String, List<ProjectIdentification>>) map.get("subData"));
+
+		if (noticeBinaryList != null) {
+			pv.setAppendix("noticeBinaryList", noticeBinaryList);
+		}
+
+		if (existsBinaryName != null) {
+			pv.setAppendix("existsResultBinaryName", existsBinaryName);
+		}
+
+		T2CoValidationResult vr = pv.validate(new HashMap<>());
+
+		if (!vr.isValid() || !vr.isDiff() || vr.hasInfo()) {
+			map.replace("mainData", CommonFunction.identificationSortByValidInfo((List<ProjectIdentification>) map.get("mainData"), vr.getValidMessageMap(), vr.getDiffMessageMap(), vr.getInfoMessageMap(), false, true));
+			if (!vr.isValid()) {
+				map.put("validData", vr.getValidMessageMap());
+			}
+			if (!vr.isDiff()) {
+				map.put("diffData", vr.getDiffMessageMap(true));
+			}
+			if (vr.hasInfo()) {
+				map.put("infoData", vr.getInfoMessageMap());
+			}
+		}
+
+		return map;
+	}
+	
+	@Override
+	public String getSupplementNoticeFileId(String prjId, String zipFlag) throws Exception {
+		Project project = new Project();
+		project.setPrjId(prjId);
+
+		Project projectDetail = getProjectDetail(project);
+		if (projectDetail == null) {
+			throw new IllegalStateException("Project not found.");
+		}
+
+		ProjectIdentification identification = new ProjectIdentification();
+		identification.setReferenceId(prjId);
+		identification.setReferenceDiv(CoConstDef.CD_DTL_COMPONENT_ID_ANDROID);
+
+		Map<String, Object> result = getIdentificationGridList(identification, true);
+		result = applyAndroidIdentificationGridData(identification, result);
+		String validMsg = checkValidData(result);
+
+		if (!isEmpty(validMsg)) {
+			throw new IllegalArgumentException(validMsg);
+		}
+
+		String fileId;
+		if (CoConstDef.FLAG_YES.equals(zipFlag)) {
+			fileId = makeZipFileId(result, projectDetail);
+		} else {
+			String contents = makeNoticeFileContents(result);
+			fileId = makeSupplementFileId(contents, projectDetail);
+		}
+
+		if (isEmpty(fileId)) {
+			throw new IllegalStateException("overflow");
+		}
+
 		return fileId;
 	}
 	

--- a/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
+++ b/src/main/java/oss/fosslight/validation/custom/T2CoProjectValidator.java
@@ -1887,7 +1887,7 @@ public class T2CoProjectValidator extends T2CoValidator {
 		if (CollectionUtils.isEmpty(ossComponetList)) {
 			return;
 		}
-		boolean isAdmin = CommonFunction.isAdmin();
+		boolean isAdmin = CommonFunction.isAdmin() || isCheckForAdmin();
 		String basicKey;
 		String gridKey;
 		String errKey;

--- a/src/main/resources/oss/fosslight/repository/ApiProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ApiProjectMapper.xml
@@ -411,6 +411,29 @@
 		AND T1.PRJ_ID = #{prjId}
 	</select>
 
+	<select id="checkProjectReadable" parameterType="hashMap" resultType="boolean">
+		SELECT IF(COUNT(*) = 1, 1, 0)
+		FROM PROJECT_MASTER T1
+		WHERE T1.USE_YN = 'Y'
+		AND T1.PRJ_ID = #{prjId}
+		<choose>
+			<when test="@oss.fosslight.util.StringUtil@equals('ROLE_ADMIN', userRole)">
+			</when>
+			<otherwise>
+				AND (
+					T1.PUBLIC_YN = 'Y'
+					OR T1.CREATOR = #{userId}
+					OR EXISTS (
+						SELECT 1
+						FROM PROJECT_WATCHER A1
+						WHERE A1.PRJ_ID = T1.PRJ_ID
+						AND A1.USER_ID = #{userId}
+					)
+				)
+			</otherwise>
+		</choose>
+	</select>
+
 	
 	<select id="selectProjectCount" parameterType="hashMap" resultType="int">
 		/* ProjectMapper.selectProjectCount */

--- a/src/main/resources/oss/fosslight/repository/ApiProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ApiProjectMapper.xml
@@ -427,7 +427,10 @@
 						SELECT 1
 						FROM PROJECT_WATCHER A1
 						WHERE A1.PRJ_ID = T1.PRJ_ID
-						AND A1.USER_ID = #{userId}
+						AND (
+							A1.USER_ID = #{userId}
+							OR (A1.USER_ID = 'all' AND A1.DIVISION = (SELECT DIVISION FROM T2_USERS A2 WHERE A2.USER_ID = #{userId}) )
+						)
 					)
 				)
 			</otherwise>

--- a/src/main/resources/oss/fosslight/repository/ApiProjectMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ApiProjectMapper.xml
@@ -427,10 +427,7 @@
 						SELECT 1
 						FROM PROJECT_WATCHER A1
 						WHERE A1.PRJ_ID = T1.PRJ_ID
-						AND (
-							A1.USER_ID = #{userId}
-							OR (A1.USER_ID = 'all' AND A1.DIVISION = (SELECT DIVISION FROM T2_USERS A2 WHERE A2.USER_ID = #{userId}) )
-						)
+						AND A1.USER_ID = #{userId}
 					)
 				)
 			</otherwise>


### PR DESCRIPTION
## Description
 **Platform Supplement Notice API Development and Fix validation logic to download the supplement notice:**
    *   Developed a new API, `downloadSupplementNotice`, to download supplementary notices.
    *   Moved validation logic from the frontend to the backend and improved related logic to enhance stability.
    *   Fix validation logic to work same as spec
    *   Add permission check level by adding a permission check for viewing projects.
   


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added supplement notice download support in both ZIP and HTML formats.
  * Introduced a dedicated check for whether a user can view a project.

* **Bug Fixes**
  * Permission errors now return HTTP **403 (FORBIDDEN)** instead of **404 (NOT_FOUND)**.
  * Error messaging now differentiates **view** vs **edit** permission requirements.
  * Improved Android supplement notice validation and localized error handling.
  * Enhanced admin-level validation behavior for project grid checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->