### PR TITLE
Fix/apiv2/change return get oss info

### DIFF
--- a/src/main/java/oss/fosslight/api/controller/v2/ApiOssV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiOssV2Controller.java
@@ -87,6 +87,9 @@ public class ApiOssV2Controller extends CoTopComponent {
             ossQuery.setCountPerPage(countPerPage);
 
             var map = apiOssService.listOss(ossQuery);
+            if (!userService.isApiAdmin(authorization) && map.list != null) {
+                map.list.forEach(oss -> oss.setExclude(null));
+            }
             return ResponseEntity.ok(map);
         } catch (NumberFormatException e) {
             return ResponseEntity.badRequest().build();

--- a/src/main/java/oss/fosslight/api/dto/ListOssDto.java
+++ b/src/main/java/oss/fosslight/api/dto/ListOssDto.java
@@ -51,7 +51,7 @@ public class ListOssDto {
 
         @Builder.Default
         @Setter(AccessLevel.NONE)
-        private Boolean searchFlag = true;
+        private Boolean searchFlag = false;
         @Setter(AccessLevel.NONE)
         private String cvssScore;
         private Boolean versionCheck;
@@ -60,6 +60,10 @@ public class ListOssDto {
             url = url
                     .replaceFirst("^((http|https)://)?(www\\.)?", "")
                     .replaceFirst("/$", "");
+        }
+
+        public void setSearchFlag(Boolean searchFlag) {
+            this.searchFlag = searchFlag;
         }
 
         public void setDeactivate(List<String> flagList) {

--- a/src/main/java/oss/fosslight/api/dto/OssDto.java
+++ b/src/main/java/oss/fosslight/api/dto/OssDto.java
@@ -7,6 +7,8 @@ import oss.fosslight.domain.OssComponents;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Data
 public class OssDto implements ExcelData {
@@ -17,6 +19,7 @@ public class OssDto implements ExcelData {
     String licenseName;
     String licenseType;
     String downloadUrl = "";
+    List<String> downloadUrls = new ArrayList<>();
     String homepageUrl = "";
     String description = "";
     String cveId = "";
@@ -43,6 +46,11 @@ public class OssDto implements ExcelData {
             obligations.add(typeArr[0] == '0' ? 'N' : 'Y');
             obligations.add(typeArr[1] == '0' ? 'N' : 'Y');
         }
+    }
+
+    public void setDownloadUrl(String downloadUrl) {
+        this.downloadUrl = downloadUrl;
+        this.downloadUrls = splitDownloadUrls(downloadUrl);
     }
 
     @Override
@@ -91,5 +99,22 @@ public class OssDto implements ExcelData {
             rtn.add("v-Diff");
         }
         return String.join(", ", rtn);
+    }
+
+    public List<String> getDownloadUrls() {
+        if ((downloadUrls == null || downloadUrls.isEmpty()) && !CommonFunction.isEmpty(downloadUrl)) {
+            downloadUrls = splitDownloadUrls(downloadUrl);
+        }
+        return downloadUrls;
+    }
+
+    private List<String> splitDownloadUrls(String source) {
+        if (CommonFunction.isEmpty(source)) {
+            return new ArrayList<>();
+        }
+        return Stream.of(source.split(","))
+                .map(String::trim)
+                .filter(url -> !url.isEmpty())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/oss/fosslight/api/dto/OssDto.java
+++ b/src/main/java/oss/fosslight/api/dto/OssDto.java
@@ -36,6 +36,8 @@ public class OssDto implements ExcelData {
 
     String copyright = "";
     String nicknames = "";
+    @Setter(AccessLevel.NONE)
+    List<String> nicknameList = new ArrayList<>();
     String attribution = "";
 
     Boolean exclude = false;
@@ -60,6 +62,11 @@ public class OssDto implements ExcelData {
     public void setOssType(String ossTypeCode) {
         this.ossType = ossTypeCode;
         this.ossTypeMap = buildOssTypeMap(ossTypeCode);
+    }
+
+    public void setNicknames(String nicknames) {
+        this.nicknames = nicknames;
+        this.nicknameList = splitNicknames(nicknames);
     }
 
     @Override
@@ -140,6 +147,16 @@ public class OssDto implements ExcelData {
         return Stream.of(source.split(","))
                 .map(String::trim)
                 .filter(url -> !url.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    private List<String> splitNicknames(String source) {
+        if (CommonFunction.isEmpty(source)) {
+            return new ArrayList<>();
+        }
+        return Stream.of(source.split("\\|"))
+                .map(String::trim)
+                .filter(name -> !name.isEmpty())
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/oss/fosslight/api/dto/OssDto.java
+++ b/src/main/java/oss/fosslight/api/dto/OssDto.java
@@ -33,6 +33,8 @@ public class OssDto implements ExcelData {
     String modifier;
     String modified;
     List<Character> obligations;
+    @Setter(AccessLevel.NONE)
+    Map<String, String> obligationTypeMap = new LinkedHashMap<>();
 
     String copyright = "";
     String nicknames = "";
@@ -52,6 +54,20 @@ public class OssDto implements ExcelData {
             obligations.add(typeArr[0] == '0' ? 'N' : 'Y');
             obligations.add(typeArr[1] == '0' ? 'N' : 'Y');
         }
+        this.obligationTypeMap = buildObligationTypeMap(obligationType);
+    }
+
+    private Map<String, String> buildObligationTypeMap(String obligationType) {
+        Map<String, String> rtn = new LinkedHashMap<>();
+        var typeArr = obligationType.toCharArray();
+        if (typeArr.length == 0) {
+            rtn.put("Notice", "N");
+            rtn.put("Source", "N");
+        } else {
+            rtn.put("Notice", typeArr[0] == '0' ? "N" : "Y");
+            rtn.put("Source", typeArr[1] == '0' ? "N" : "Y");
+        }
+        return rtn;
     }
 
     public void setDownloadUrl(String downloadUrl) {

--- a/src/main/java/oss/fosslight/api/dto/OssDto.java
+++ b/src/main/java/oss/fosslight/api/dto/OssDto.java
@@ -58,6 +58,7 @@ public class OssDto implements ExcelData {
         var notice = 'Y' == obligations.get(0);
         var source = 'Y' == obligations.get(1);
         var obligationString = "";
+        var downloadUrlsString = String.join(",", getDownloadUrls());
         if (notice && source) obligationString = "Notice & Distribute";
         else if (notice) obligationString = "Notice";
         var nicknameString = "";
@@ -74,7 +75,7 @@ public class OssDto implements ExcelData {
                 licenseType,
                 obligationString,
                 homepageUrl,
-                downloadUrl,
+                downloadUrlsString,
                 copyright,
                 attribution,
                 cvssScore

--- a/src/main/java/oss/fosslight/api/dto/OssDto.java
+++ b/src/main/java/oss/fosslight/api/dto/OssDto.java
@@ -1,19 +1,23 @@
 package oss.fosslight.api.dto;
 
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Setter;
 import oss.fosslight.common.CommonFunction;
-import oss.fosslight.domain.OssComponents;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Data
 public class OssDto implements ExcelData {
     String ossId;
-    String ossType;
+    String ossType = "";
+    @Setter(AccessLevel.NONE)
+    Map<String, String> ossTypeMap = new LinkedHashMap<>();
     String ossName;
     String ossVersion;
     String licenseName;
@@ -53,6 +57,11 @@ public class OssDto implements ExcelData {
         this.downloadUrls = splitDownloadUrls(downloadUrl);
     }
 
+    public void setOssType(String ossTypeCode) {
+        this.ossType = ossTypeCode;
+        this.ossTypeMap = buildOssTypeMap(ossTypeCode);
+    }
+
     @Override
     public String[] toRow() {
         var notice = 'Y' == obligations.get(0);
@@ -84,22 +93,37 @@ public class OssDto implements ExcelData {
 
     private String getOssTypeString() {
         var rtn = new ArrayList<String>();
-        if (CommonFunction.isEmpty(ossType)) {
+        if (CommonFunction.isEmpty(ossType) || ossType.length() < 3) {
             return "";
         }
-        var ossTypeFlags = ossType.toCharArray();
-        if (ossType.toCharArray()[0] == '1') {
+        if (ossType.charAt(0) == '1') {
             rtn.add("Multi");
         }
 
-        if (ossType.toCharArray()[1] == '1') {
+        if (ossType.charAt(1) == '1') {
             rtn.add("Dual");
         }
 
-        if (ossType.toCharArray()[2] == '1') {
+        if (ossType.charAt(2) == '1') {
             rtn.add("v-Diff");
         }
         return String.join(", ", rtn);
+    }
+
+    private Map<String, String> buildOssTypeMap(String code) {
+        Map<String, String> rtn = new LinkedHashMap<>();
+        rtn.put("Multi", "N");
+        rtn.put("Dual", "N");
+        rtn.put("V-Diff", "N");
+
+        if (CommonFunction.isEmpty(code) || code.length() < 3) {
+            return rtn;
+        }
+
+        rtn.put("Multi", code.charAt(0) == '1' ? "Y" : "N");
+        rtn.put("Dual", code.charAt(1) == '1' ? "Y" : "N");
+        rtn.put("V-Diff", code.charAt(2) == '1' ? "Y" : "N");
+        return rtn;
     }
 
     public List<String> getDownloadUrls() {

--- a/src/main/java/oss/fosslight/api/dto/OssDto.java
+++ b/src/main/java/oss/fosslight/api/dto/OssDto.java
@@ -85,6 +85,10 @@ public class OssDto implements ExcelData {
         this.nicknameList = splitNicknames(nicknames);
     }
 
+    public void setExclude(Boolean exclude) {
+        this.exclude = exclude;
+    }
+
     @Override
     public String[] toRow() {
         var notice = 'Y' == obligations.get(0);

--- a/src/main/java/oss/fosslight/repository/T2UserMapper.java
+++ b/src/main/java/oss/fosslight/repository/T2UserMapper.java
@@ -75,4 +75,6 @@ public interface T2UserMapper {
 	public List<T2Users> selectUnusedDivisionUserList(@Param("unusedDivisionList") String[] unusedDivisionList);
 
 	public T2Users checkExpiredUser(T2Users bean);
+
+	public int selectApiAdminCount(@Param("token") String token);
 }

--- a/src/main/java/oss/fosslight/service/T2UserService.java
+++ b/src/main/java/oss/fosslight/service/T2UserService.java
@@ -72,8 +72,10 @@ public interface T2UserService extends UserDetailsService {
 	public int updateUserDivisionByUserId(String userId, String division, String modifier);
 	
 	public String[] checkUserInfo(T2Users userInfo);
-
+	
 	public boolean isAdmin(String _token);
+	
+	public boolean isApiAdmin(String _token);
 	
 	public Map<String, Object> checkByADUser(String user_id, String user_pw, Map<String, Object> rtnMap);
 	

--- a/src/main/java/oss/fosslight/service/impl/T2UserServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/T2UserServiceImpl.java
@@ -832,6 +832,12 @@ public class T2UserServiceImpl extends CoTopComponent implements T2UserService {
 		return false;
 	}
 
+	@Override
+	public boolean isApiAdmin(String _token) {
+		int adminCount = userMapper.selectApiAdminCount(_token);
+        return adminCount > 0;
+    }
+
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public Map<String, Object> checkByADUser(String user_id, String user_pw, Map<String, Object> rtnMap) {

--- a/src/main/resources/oss/fosslight/repository/ApiOssMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ApiOssMapper.xml
@@ -679,7 +679,7 @@
         , T1.LICENSE_DIV
         , T1.HOMEPAGE
         <choose>
-            <when test="@oss.fosslight.util.StringUtil@notEquals(searchFlag,'N')">
+            <when test="searchFlag">
                 , SUBSTRING_INDEX(T1.DOWNLOAD_LOCATION, ',', 1) AS DOWNLOAD_LOCATION
             </when>
             <otherwise>

--- a/src/main/resources/oss/fosslight/repository/T2UserMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/T2UserMapper.xml
@@ -130,6 +130,23 @@
         WHERE U.TOKEN = #{token}
       </if>
     </select>
+    
+    <!-- API 관리자 여부 확인 -->
+    <select id="selectApiAdminCount" parameterType="String" resultType="int">
+        SELECT
+            COUNT(1)
+        FROM
+            T2_USERS U
+            INNER JOIN T2_AUTHORITIES A ON U.USER_ID = A.USER_ID
+        WHERE
+            U.TOKEN = #{token}
+            AND U.USE_YN = 'Y'
+            AND A.AUTHORITY = 'ROLE_ADMIN'
+            AND (
+                U.EXPIRE_DATE IS NULL
+                OR DATE(U.EXPIRE_DATE) >= CURDATE()
+            )
+    </select>
     <!-- 특정 권한 사용자 목록 가져오기 -->
     <select id="getAuthorityUsers" parameterType="String" resultType="oss.fosslight.domain.T2Users"> 
         SELECT


### PR DESCRIPTION
## 📌 Description

`getOssInfo` API의 응답 구조를 개선하여 사용자가 데이터를 보다 직관적이고 쉽게 이해할 수 있도록 수정했습니다.  
기존 시스템과의 호환성을 보장하기 위해 **Legacy 응답 필드는 그대로 유지**했습니다.

---

## 🛠️ Key Changes

* **응답 데이터 구조 개선 및 버그 수정**
  * 전체 다운로드 위치가 정상 노출되도록 수정 (`Modify to show all download locations`)
  * `OssDto.toRow` 변환 로직 보완
* **신규 데이터 매핑 및 필드 추가**
  * `ossTypeMap` 추가
  * `nicknameList` 추가
  * `obligationTypeMap` 추가
* **하위 호환성 (Backward Compatibility) 유지**
  * 기존 클라이언트의 동작을 보장하기 위해 Legacy 필드 및 구조 유지
* **기타 수정**
  * 사용자 대상 `getOssApi`에서 불필요한 `exclude` 항목 제거