### PR TITLE
feat: add API to search discovered CVE IDs by date

### DIFF
--- a/src/main/java/oss/fosslight/api/controller/v2/ApiVulnerabilityV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiVulnerabilityV2Controller.java
@@ -103,4 +103,29 @@ public class ApiVulnerabilityV2Controller extends CoTopComponent {
             return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @ApiOperation(value = "Search CVE IDs by Email Send Date", notes = "Get CVE IDs from discovered OSS vulnerability notification emails")
+    @GetMapping(value = {APIV2.FOSSLIGHT_API_VULNERABILITY_DISCOVERED_CVE})
+    public ResponseEntity<Map<String, Object>> getDiscoveredCveIdsByDate(
+            @ApiParam(hidden=true) @RequestHeader String authorization,
+            @ApiParam(value = "Send Date (YYYY-MM-DD)", required = true) @RequestParam(required = true) String sendDate,
+            @ApiParam(value = "Search after this date (true: search from this date onward, false: search only this date)", required = false, defaultValue = "false") @RequestParam(required = false, defaultValue = "false") boolean isAfterDate) {
+
+        // 사용자 인증
+        userService.checkApiUserAuth(authorization);
+        Map<String, Object> resultMap = new HashMap<String, Object>();
+
+        try {
+            List<String> cveIdList = apiVulnerabilityService.selectCveIdsBySendDate(sendDate, isAfterDate);
+
+            resultMap.put("success", true);
+            resultMap.put("count", cveIdList.size());
+            resultMap.put("list", cveIdList);
+
+            return new ResponseEntity<>(resultMap, HttpStatus.OK);
+        } catch (Exception e) {
+            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
+                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE));
+        }
+    }
 }

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiVulnerabilityV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiVulnerabilityV2Controller.java
@@ -18,6 +18,8 @@ import oss.fosslight.common.Url.APIV2;
 import oss.fosslight.service.ApiVulnerabilityService;
 import oss.fosslight.service.T2UserService;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,6 +118,13 @@ public class ApiVulnerabilityV2Controller extends CoTopComponent {
         Map<String, Object> resultMap = new HashMap<String, Object>();
 
         try {
+            try {
+                LocalDate.parse(sendDate);
+            } catch (DateTimeParseException e) {
+                return responseService.errorResponse(HttpStatus.BAD_REQUEST,
+                        "Invalid sendDate format. Expected YYYY-MM-DD (e.g. 2024-01-31).");
+            }
+
             List<String> cveIdList = apiVulnerabilityService.selectCveIdsBySendDate(sendDate, isAfterDate);
 
             resultMap.put("success", true);

--- a/src/main/java/oss/fosslight/common/Url.java
+++ b/src/main/java/oss/fosslight/common/Url.java
@@ -1100,6 +1100,9 @@ public final class Url {
 			/** vulnerability max score info search */
 			public static final String FOSSLIGHT_API_VULNERABILITY_MAX_DATA	= "/max-vulnerabilities";
 
+			/** discovered CVE IDs by email send date */
+			public static final String FOSSLIGHT_API_VULNERABILITY_DISCOVERED_CVE = "/discovered-cves";
+
 
 		/** SELFCHECK */
 			/** create SelfCheck */

--- a/src/main/java/oss/fosslight/repository/ApiVulnerabilityMapper.java
+++ b/src/main/java/oss/fosslight/repository/ApiVulnerabilityMapper.java
@@ -26,4 +26,5 @@ public interface ApiVulnerabilityMapper {
 	VulnerabilityDetailsDto selectVulnerabilityById(String id);
 	List<OssDto> selectOssByCveId(String id);
 	List<VulnerabilityDto> selectRecentVulnerabilities(int limit);
+	List<String> selectCveIdsBySendDate(Map<String, Object> paramMap);
 }

--- a/src/main/java/oss/fosslight/service/ApiVulnerabilityService.java
+++ b/src/main/java/oss/fosslight/service/ApiVulnerabilityService.java
@@ -18,4 +18,5 @@ public interface ApiVulnerabilityService {
 
 	public ListVulnerabilityDto.Result listVulnerabilities(ListVulnerabilityDto.Request request);
 	public GetVulnerabilityDetailsDto.Result getVulnerabilityDetails(String id);
+	public List<String> selectCveIdsBySendDate(String sendDate, boolean isAfterDate);
 }

--- a/src/main/java/oss/fosslight/service/impl/ApiVulnerabilityServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ApiVulnerabilityServiceImpl.java
@@ -137,4 +137,14 @@ public class ApiVulnerabilityServiceImpl implements ApiVulnerabilityService {
                 .vulnerability(vulnerability)
                 .build();
     }
+
+    @Override
+    public List<String> selectCveIdsBySendDate(String sendDate, boolean isAfterDate) {
+        Map<String, Object> paramMap = new HashMap<String, Object>();
+        paramMap.put("sendDate", sendDate);
+        paramMap.put("isAfterDate", isAfterDate);
+        
+        List<String> cveIdList = apiVulnerabilityMapper.selectCveIdsBySendDate(paramMap);
+        return cveIdList != null ? cveIdList : new ArrayList<>();
+    }
 }

--- a/src/main/resources/oss/fosslight/repository/ApiVulnerabilityMapper.xml
+++ b/src/main/resources/oss/fosslight/repository/ApiVulnerabilityMapper.xml
@@ -567,4 +567,19 @@
         ORDER BY MODIFIED DESC
         LIMIT ${limit}
     </select>
+
+    <select id="selectCveIdsBySendDate" parameterType="hashMap" resultType="string">
+        SELECT DISTINCT CVE_ID
+        FROM OSS_DISCOVERED_SND_EMAIL
+        WHERE SND_YN = 'Y'
+        <choose>
+            <when test="isAfterDate">
+                AND DATE(SND_DATE) >= DATE(#{sendDate})
+            </when>
+            <otherwise>
+                AND DATE(SND_DATE) = DATE(#{sendDate})
+            </otherwise>
+        </choose>
+        ORDER BY CVE_ID ASC
+    </select>
 </mapper>


### PR DESCRIPTION

## Description
Add GET /api/v2/discovered-cves endpoint to retrieve CVE IDs discovered on or after a specific date

### Query Parameters

| Parameter | Type | Required | Description |
| :--- | :--- | :--- | :--- |
| `sendDate` | `string` | **Yes** | Target date to filter CVEs (`YYYY-MM-DD`). |
| `isAfterDate` | `boolean` | No | Search condition flag.<br>- `true`: Search CVEs discovered on or after `sendDate`.<br>- `false`: Search CVEs discovered only on `sendDate` *(Default)*. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve CVE IDs from vulnerability notification emails by send date.
  * Supports exact-date searches or searches from a specified date onward.
  * Results include success status, total count, and the matching CVE ID list.
  * Results are returned in ascending CVE ID order.

* **Bug Fixes**
  * Invalid date formats now return a clear client error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->