### PR TITLE
Add download-location PURL generation tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ repositories {
 test {
 	maxHeapSize="2048m"
 	useJUnitPlatform()
+	testLogging {
+		// Needed so PURL result table (System.out in @AfterAll) appears in the console.
+		showStandardStreams = true
+		events "failed", "skipped", "standard_out", "standard_error"
+	}
 }
 
 processResources {

--- a/docs/PURL_writing_rules.md
+++ b/docs/PURL_writing_rules.md
@@ -1,0 +1,377 @@
+<!--
+Copyright (c) 2021 LG Electronics
+SPDX-License-Identifier: AGPL-3.0-only
+ -->
+
+# PURL 작성 규칙
+
+- PURL SPEC: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst
+- purl-spec v1.0.1 기준으로 작성
+
+## 공통 사항
+
+- protocol을 제거한다 (`git+`, `sum:`, `com:`, `ssh:` 등) 또는 `://` 이전 문자열 모두 제거
+- 호스트 문자열 변경
+  - `www.github.com` → `github.com`
+  - 다른 pkg들에 대해서 호스트 문자열 변경이 필요할까? (PURL의 default repository 형태?)
+    - 예) `pypi.org/project/fosslight-android` → `pypi.python.org/project/fosslight-android` (`pypi.python.org`는 `pypi.org`로 리다이렉트 처리됨)
+    - 각 pkg 타입별로 로직이 추가되어야 함
+- Port number를 제거한다.
+  - 예) `github.com:443/{org}/{repo}` → `github.com/{org}/{repo}`
+- 제거된 URL의 호스트 타입이 Package Type 별 표준화 방식에 정의된 기본 repository url에 해당하는 지 확인한다
+  - 해당하면 PURL 규칙에 맞게 PURL 생성
+  - 해당하지 않으면 generic 타입으로 PURL 생성
+- 마지막 `/`는 제거
+- OSS name 및 download location에 separator character (purl > specification > Core specification) `:/@?=&#` 및 공백 포함된 경우, 퍼센트 인코딩되어야 하며 타입별로 대소문자 구분 여부 다름
+  - 단, purl에서 qualifier (`?` 뒤에 `key=value`) 다음 규칙을 따름
+    - **key**: 인코딩하지 않음, `a-z`, `0-9`, `.`, `-`, `_` 만 허용
+    - **value**
+      - 인코딩하지 않음: `.-_~`, `:`, `A-Z a-z 0-9`
+      - 인코딩함:
+
+        | 문자  | 인코딩  |
+        | ----- | ------- |
+        | `/` | `%2F` |
+        | `@` | `%40` |
+        | `?` | `%3F` |
+        | `=` | `%3D` |
+        | `&` | `%26` |
+        | `#` | `%23` |
+        | 공백  | `%20` |
+      - 예)
+
+        - `download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz`
+        - `repository_url=https:%2F%2Fmaven.google.com`
+        - `vcs_url=git%2Bhttps:%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32`
+  - 그외
+    - `:` → `%3A`
+    - `/` → `%2F`
+    - `@` → `%40`
+    - `?` → `%3F`
+    - `=` → `%3D`
+    - `&` → `%26`
+    - `#` → `%23`
+    - 공백 → `%20`
+- 대소문자 구별해야 함 → URL로부터 추출한 namespace 또는 name의 대소문자 유지
+
+## Package Type 별 표준화 방식
+
+### Github
+
+- 기본 repository url
+  - `https://github.com/{organization}/{repository}`
+- syntax: `pkg:github/<namespace>/<name>`
+- namespace
+  - required
+  - organization 정보
+- name
+  - required
+  - repository 이름
+- Purl 예)
+  - `pkg:github/package-url/purl-spec`
+
+### Npm
+
+- 기본 repository url
+  - `https://registry.npmjs.org/{package_name}`
+  - `https://www.npmjs.com/package/{package_name}`
+  - `https://www.npmjs.com/package/{@organization}/{package_name}`
+- syntax: `pkg:npm/<namespace>/<name>`
+- namespace
+  - optional, 대소문자 구별해야 함
+  - organization (항상 `@` prefix로 시작함, `@`는 `%40`으로 인코딩되어야 함)
+- name
+  - required, 대소문자 구별해야 함
+  - package name
+- Purl 예)
+  - `pkg:npm/foobar`
+  - `pkg:npm/%40angular/animation`
+
+### Pypi
+
+- 기본 repository url
+  - `https://pypi.python.org/project/{package_name}`
+  - `https://pypi.org/project/{package_name}`
+  - `https://pypi.python.org/pypi/{package_name}`
+  - `https://files.pythonhosted.org/packages/source/*/{package_name}/{package_name}-{version}.tar.gz`
+- syntax: `pkg:pypi/<name>@<version>`
+- name
+  - required
+  - python package 이름
+  - Pypi에서는 `-`(dash)와 `_`(underscore)를 같은 것으로 판단하기 때문에 underscore는 dash로 치환
+  - 소문자로 변경
+- Purl 예)
+  - `pkg:pypi/django`
+  - `pkg:pypi/django-allauth`
+  - `https://files.pythonhosted.org/packages/source/m/{package_name}/mcp-1.20.0.tar.gz`
+    - `pkg:pypi/mcp`
+
+### Maven
+
+- 기본 repository url
+  - `https://repo.maven.apache.org/maven2/{group id}/{artifact id}`
+  - `https://mvnrepository.com/artifact/{group id}/{artifact id}`
+  - `https://repo.maven.apache.org/`
+  - `https://repo1.maven.org/maven2/`
+  - `https://maven.google.com/web/index.html#{group id}/{artifact id}`에 대한 purl
+    - `https://maven.google.com/web/index.html#androidx.test.ext:junit` → `pkg:maven/androidx.test.ext/junit?repository_url=https:%2F%2Fmaven.google.com`
+  - `https://repo.spring.io/milestone/org/springframework/data/spring-data-r2dbc/1.5.0-M1/spring-data-r2dbc-1.5.0-M1-sources.jar` → `pkg:maven/org.springframework.data/spring-data-r2dbc?repository_url=https:%2F%2Frepo.spring.io`
+  - `https://dl.google.com/android/maven2/androidx/test/ext/junit/1.2.0/junit-1.2.0.pom` → `pkg:maven/androidx.test.ext/junit?repository_url=https:%2F%2Fmaven.google.com`
+  - Maven은 매우 다양한 레포지토리 주소를 가진다. 각각의 케이스에 대해서는 리뷰 요청 들어온 경우 추가하기로 결정.
+    - `https://packages.atlassian.com/content/repositories/atlassian-public`
+    - `https://repo.hortonworks.com/repository/releases`
+    - `https://repo.spring.io/artifactory/libs-release`
+    - `https://repository.jboss.org/nexus/content/repositories/releases`
+    - `https://jitpack.io`
+- syntax: `pkg:maven/<namespace>/<name>`
+- namespace
+  - required, 대소문자 구별해야 함
+  - group id 정보
+- name
+  - required, 대소문자 구별해야 함
+  - artifact id 정보
+- Purl 예)
+  - `pkg:maven/org.apache.xmlgraphics/batik-anim`
+  - `pkg:maven/net.sf.jacob-projec/jacob`
+
+### Cocoapods
+
+- 기본 repository url
+  - `https://cocoapods.org/pods/{pod name}`
+  - `https://cdn.cocoapods.org/` → 형태 확인이 안됨. 일단 규칙에서 제외 필요.
+- syntax: `pkg:cocoapods/<name>`
+- name
+  - required, 대소문자 구별해야 함
+  - pod 이름
+- Purl 예)
+  - `pkg:cocoapods/Alamofire`
+  - `pkg:cocoapods/MapsIndoors`
+- 일반적으로 기본 레포지토리 형태로 구성되지 않고 `github.com/{org}/{name}` 형태로 구성된다. Github Package로 구성될 가능성이 높다.
+  - 예) `https://cocoapods.org/pods/Alamofire#installation`
+
+### Gem
+
+- 기본 repository url
+  - `https://rubygems.org/gems/{package name}`
+- syntax: `pkg:gem/<name>`
+- name
+  - required
+  - package name
+- Purl 예)
+  - `pkg:gem/ruby-advisory-db-check`
+  - `pkg:gem/jruby-launcher`
+  - `https://rubygems.org/gems/ropencv` → `pkg:gem/ropencv`
+
+### Golang
+
+- 기본 repository url
+  - `https://pkg.go.dev/{namespace&name}`
+  - pkg.go.dev url의 경우, `pkg.go.dev` 이후 url에 대해 namespace 및 name 포함된 값으로 처리
+- syntax: `pkg:golang/<namespace>/<name>@<version>?<qualifiers>#<subpath>`
+- namespace
+  - required, 소문자로만 구성
+  - ex) `google.golang.org`
+- name
+  - required, 소문자로만 구성
+- subpath: 패키지 안에 특정 구성 요소를 지정할 때 사용
+- Purl 예)
+  - `pkg:golang/github.com/gorilla/context` : namespace, name 구성
+  - `pkg:golang/google.golang.org/genproto#googleapis/api/annotations` : namespace, name, subpath 구성의 경우
+  - `pkg:golang/google.golang.org/genproto`
+    - namespace: `google.golang.org`, name: `genproto`, subpath: `googleapis/api/annotations`
+- 일반적으로 `github.com` 등의 주소를 바로 사용하기 때문에 github package url로 구분될 가능성이 높다.
+
+### Android
+
+- purl-spec v1.0.1으로 정의되지 않음 → git url로 처리
+- 기본 repository url
+  - `https://android.googlesource.com/platform/{하위 URL 구성}`
+  - `https://android.googlesource.com/platform/bionic/+/refs/tags/aml_tz3_312511020`와 같이 `+/` 제거
+- syntax: `pkg:git/<namespace>/<name>@<version>?<qualifiers>#<subpath>`
+- namespace, name
+  - required, 대소문자 구별해야 함
+  - git url에 대해 namespace & name으로 처리
+- Purl 예)
+  - `pkg:git/android.googlesource.com/platform/external/alsa-lib`
+  - `pkg:git/android.googlesource.com/platform/bionic`
+
+### Cargo
+
+- 기본 repository url
+  - `https://crates.io/crates/{package name}`
+- syntax: `pkg:cargo/<name>`
+- name
+  - required, 대소문자 구별해야 함
+  - package name
+- Purl 예)
+  - `pkg:cargo/rand`
+  - `pkg:cargo/clap`
+
+### Nuget
+
+- 기본 repository url
+  - `https://nuget.org/packages/{package name}`
+  - `https://www.nuget.org/packages/{package name}`
+- syntax: `pkg:nuget/<name>`
+- name
+  - required, 대소문자 구별해야 함
+  - package name
+- Purl 예)
+  - `pkg:nuget/SocketIO.Serializer.Core`
+  - `https://www.nuget.org/packages/Honoo.Net.UPnP` → `pkg:nuget/Honoo.Net.UPnP`
+
+### Bitbucket
+
+- 기본 repository url
+  - `https://bitbucket.org/{user or organization}/{repository name}`
+- syntax: `pkg:bitbucket/<namespace>/<name>`
+- namespace
+  - required, 소문자여야 함
+  - the user or organization
+- name
+  - required, 소문자여야 함
+  - repository name
+- Purl 예)
+  - `pkg:bitbucket/birkenfeld/pygments-main`
+  - `https://bitbucket.org/blackteckel/job-board-tails-njs/get/v0.1.5.zip` → `pkg:bitbucket/blackteckel/job-board-tails-njs`
+
+### Composer
+
+- 기본 repository url
+  - `https://packagist.org/packages/{vendor}/{name}`
+- syntax: `pkg:composer/<namespace>/<name>`
+- namespace
+  - required, 소문자여야 함
+  - vendor
+- name
+  - required, 소문자여야 함 (private 또는 로컬 패키지인 경우, name 존재하지 않으므로 purl 생성할 수 없음)
+  - name
+- Purl 예)
+  - `pkg:composer/laravel/laravel`
+  - `https://packagist.org/packages/geerlingguy/ping` → `pkg:composer/geerlingguy/ping`
+
+### CPAN
+
+- 기본 repository url
+  - `https://www.cpan.org/`
+  - `https://metacpan.org/pod/{name}`
+- syntax: `pkg:cpan/<namespace>/<name>`
+- namespace
+  - Optional, 무조건 대문자여야 함
+- name
+  - required, 대소문자 구별해야 함
+  - distribution name (CPAN 자체의 표준 명명 규칙에 따라 모듈의 구분자 `::`는 배포판 이름으로 변환될 때 항상 `-`로 치환)
+- Purl 예)
+  - `https://www.cpan.org/authors/id/O/OA/OALDERS/libwww-perl-6.18.tar.gz` → `pkg:cpan/libwww-perl`
+  - `https://www.cpan.org/authors/id/I/IN/INA/Jacode4e/RoundTrip/Jacode4e-RoundTrip-2.13.81.6.tar.gz` → `pkg:cpan/Jacode4e-RoundTrip`
+
+### CRAN
+
+- 기본 repository url
+  - `https://cran.r-project.org`
+- syntax: `pkg:cran/<name>`
+- name
+  - required, 대소문자 구별해야 함
+  - package name
+- Purl 예)
+  - `pkg:cran/rJava`
+  - `https://cran.r-project.org/web/packages/ECharts2Shiny/index.html` → `pkg:cran/ECharts2Shiny`
+
+### Docker
+
+- 기본 repository url
+  - `https://hub.docker.com`
+- syntax: `pkg:docker/<namespace>/<name>`
+- namespace
+  - optional
+  - registry/user/organization 존재하는 경우에만
+- name
+  - required
+  - package name
+- Purl 예)
+  - `https://hub.docker.com/_/cassandra` → `pkg:docker/cassandra`
+  - `https://hub.docker.com/r/bitnami/mariadb-galera` → `pkg:docker/bitnami/mariadb-galera`
+  - `https://hub.docker.com/hardened-images/catalog/dhi/python` → `pkg:docker/python?repository_url=dhi.io`
+    - `"^https?://hub\\.docker\\.com/hardened-images/catalog/dhi/([^/?#]+)/?$"` 인 경우, `repository_url=dhi.io`를 붙임
+
+### Hackage
+
+- 기본 repository url
+  - `https://hackage.haskell.org/package/{package name}`
+- syntax: `pkg:hackage/<name>`
+- name
+  - required, 대소문자 구별해야 함 (kebab-case normalization)
+  - package name
+- Purl 예)
+  - `pkg:hackage/AC-HalfInteger`
+  - `https://hackage.haskell.org/package/csg` → `pkg:hackage/csg`
+
+### Huggingface
+
+- 기본 repository url
+  - `https://huggingface.co/{organization}/{repository name}`
+- syntax: `pkg:huggingface/<namespace>/<name>`
+- namespace
+  - required, 대소문자 구별해야 함
+  - model repository username or organization 존재하는 경우에만 (대소문자 구별해야 함)
+- name
+  - required, 대소문자 구별해야 함
+  - model repository name
+- Purl 예)
+  - `https://huggingface.co/openai/whisper-small` → `pkg:huggingface/openai/whisper-small`
+  - `https://huggingface.co/datasets/stanfordnlp/snli` → `pkg:huggingface/datasets/stanfordnlp/snli` (dataset에 대한 정확한 spec은 없음, spec은 모델에 대해서만 표준화되어 있음, 이에 datasets 추가하여 표시하도록 함)
+
+### Yocto
+
+- namespace: name of the layer which provides the recipe
+- name: BPN (https://docs.yoctoproject.org/ref-manual/variables.html#term-BPN) in a yocto recipe (대소문자 구별해야 함)
+- Purl 예) `pkg:yocto/<namespace>/<name>`
+- ex. `https://git.openembedded.org/openembedded-core/tree/meta/recipes-core/gettext/gettext_1.0.bb`
+  - `pkg:yocto/core/gettext?repository_url=https:%2F%2Fgit.openembedded.org%2Fopenembedded-core`
+- URL에서 추출 방법
+  1. url에 `/meta*/`가 존재하고 맨 끝이 `.bb`인 경우
+  2. url에서 가장 뒤에 있는 `/meta*/` 하위 `conf/layer.conf`로 이동 (ex. `https://git.openembedded.org/openembedded-core/tree/meta/conf/layer.conf`)하여 `BBFILE_COLLECTIONS` 값을 읽어 소문자로 변경하고 namespace로 저장
+  3. URL에서 파일명만 추출. ex. `gettext_1.0.bb`
+  4. `_` 앞을 PN으로 추출 (`_` 없을 수도 있음)
+  5. PN에서 접미/접두 제거 → BPN으로 변경 (대소문자 구별해야 함)
+     - suffix 제거:
+       - `-native`
+       - `-cross`
+       - `-initial`
+       - `-intermediate`
+       - `-crosssdk`
+       - `-cross-canadian`
+     - prefix 제거 (고정 목록 없음. class가 runtime에 설정)
+       - `lib32-`
+       - `lib64-`
+       - `libx32-`
+       - `nativesdk-`
+     - ex. `binutils-cross` → `binutils`
+  6. `repo_url`은 `tree`/`blob` 제거하고, layer의 git repository url로 추출 (인코딩 필요)
+  7. `pkg:yocto/{namespace}/{BPN}`으로 하고 `repository_url={repo_url}`을 붙임.
+
+### Git
+
+- 링크가 git 저장소인 경우
+- ex. `.git`으로 끝나거나 `git://` 그 외는 `git ls-remote <url>`를 이용하여 git인지 체크
+- namespace: The url path to the git host 대소문자 구별해야 함
+- name: repository name with owner 대소문자 구별해야 함
+- ex.
+  - `pkg:git/codeberg.org/forgejo/forgejo`
+  - `pkg:git/cygwin.com/cgit/newlib-cygwin`
+  - `pkg:git/projects.blender.org/blender/blender`
+  - `pkg:git/gitlab.gnome.org/GNOME/adwaita-fonts`
+  - `https://git.codelinaro.org/clo/la/platform/external/volley` → `pkg:git/git.codelinaro.org/clo/la/platform/external/volley`
+  - `https://source.codeaurora.org/external/imx/weston-imx/` → `pkg:git/source.codeaurora.org/external/imx/weston-imx`
+- 특이 사항. repo 끝 git을 허용하고 있음. (우리는 끝 `.git` 제거해야 함. 그래야 purl 일치 체크)
+
+### Generic
+
+- 위 사항이 아닌 경우 모두 generic type으로 PURL 생성
+- syntax: `pkg:generic/<namespace>/<name>@<version>?<qualifiers>#<subpath>`
+- namespace: optional이므로 사용하지 않음
+- name: OSS name
+- qualifiers: `download_url` 선택 후, Download location 정보
+- Purl 예)
+  - `pkg:generic/<OSS name>?download_url=<Download location>`
+  - `pkg:generic/openssl?download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz`

--- a/src/test/java/oss/fosslight/service/OssServicePurlDbTest.java
+++ b/src/test/java/oss/fosslight/service/OssServicePurlDbTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package oss.fosslight.service;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import oss.fosslight.common.CoCodeManager;
+import oss.fosslight.common.CoConstDef;
+import oss.fosslight.domain.OssMaster;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Download location → PURL tests against a live FOSSLight DB.
+ * Loads code table 913 via {@link CoCodeManager} (same path as production).
+ * Runs only when MariaDB is reachable (skipped otherwise).
+ * Cases: {@code classpath:purl/download-location-purl-cases.json}
+ * (all types; JSON {@code unimplementedTypes} soft-pass when actual ≠ expected).
+ * <p>
+ * Override JDBC with {@code spring.datasource.url|username|password}
+ * system properties or {@code SPRING_DATASOURCE_*} env vars.
+ */
+@EnabledIf("oss.fosslight.service.PurlTestSupport#isDatabaseAvailable")
+@SpringBootTest
+@WithMockUser(username = "user", roles = {"USER"})
+class OssServicePurlDbTest {
+
+	@Autowired
+	private OssService ossService;
+
+	@BeforeAll
+	static void logMode() {
+		PurlTestSupport.clearResults();
+		System.out.println("[OssServicePurlDbTest] mode=database (CoCodeManager from T2_CODE_DTL)");
+	}
+
+	@AfterAll
+	static void printResultTable() {
+		PurlTestSupport.printResultTable("database");
+	}
+
+	@Test
+	@DisplayName("code table 913 should be loaded from DB")
+	void codeTable913ShouldBeLoadedFromDb() {
+		List<String> prefixes = CoCodeManager.getCodeNames(CoConstDef.CD_CHECK_OSS_DOWNLOADLOCAION_PURL);
+		assertThat(prefixes)
+				.as("CD_CHECK_OSS_DOWNLOADLOCAION_PURL (913) must be present in DB")
+				.isNotEmpty();
+		assertThat(prefixes.get(0)).isEqualTo("github.com");
+	}
+
+	@ParameterizedTest(name = "[{index}] {3}: {0} → {2}")
+	@MethodSource("downloadLocationToPurlCases")
+	@DisplayName("should generate purl from download location (DB)")
+	void shouldGeneratePurlFromDownloadLocation(String downloadLocation, String ossName, String expectedPurl, String type) {
+		OssMaster ossMaster = new OssMaster();
+		ossMaster.setOssName(ossName);
+		ossMaster.setDownloadLocation(downloadLocation);
+
+		String actual = ossService.getPurlByDownloadLocation(ossMaster);
+		PurlTestSupport.assertPurl(type, downloadLocation, expectedPurl, actual);
+	}
+
+	@Test
+	@DisplayName("should return empty string When download location is empty (DB)")
+	void shouldReturnEmptyWhenDownloadLocationIsEmpty() {
+		OssMaster ossMaster = new OssMaster();
+		ossMaster.setOssName("sample");
+		ossMaster.setDownloadLocation("");
+
+		assertThat(ossService.getPurlByDownloadLocation(ossMaster)).isEmpty();
+	}
+
+	static Stream<Arguments> downloadLocationToPurlCases() throws Exception {
+		return PurlTestSupport.downloadLocationToPurlCases();
+	}
+}

--- a/src/test/java/oss/fosslight/service/PurlTestSupport.java
+++ b/src/test/java/oss/fosslight/service/PurlTestSupport.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package oss.fosslight.service;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * Shared helpers for download-location → PURL tests.
+ * Cases and unimplemented types: {@code classpath:purl/download-location-purl-cases.json}.
+ */
+final class PurlTestSupport {
+
+	static final String CASES_RESOURCE = "purl/download-location-purl-cases.json";
+
+	private static final String DEFAULT_JDBC_URL = "jdbc:mariadb://127.0.0.1:3306/fosslight";
+	private static final String DEFAULT_USER = "fosslight";
+	private static final String DEFAULT_PASSWORD = "fosslight";
+
+	private static final int COL_TYPE = 12;
+	private static final int COL_URL = 48;
+	private static final int COL_PURL = 52;
+
+	private static Boolean databaseAvailable;
+	private static PurlCaseFile caseFile;
+	private static final List<CaseResult> RESULTS = Collections.synchronizedList(new ArrayList<>());
+
+	private PurlTestSupport() {
+	}
+
+	static void clearResults() {
+		RESULTS.clear();
+	}
+
+	static boolean isUnimplementedType(String type) {
+		try {
+			return unimplementedTypes().contains(type);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Record result and assert. Types in JSON {@code unimplementedTypes} always pass
+	 * the assertion even when actual differs from expected (gap still shown in the table).
+	 */
+	static void assertPurl(String type, String downloadLocation, String expectedPurl, String actualPurl) {
+		boolean matches = Objects.equals(expectedPurl, actualPurl);
+		boolean unimplemented = isUnimplementedType(type);
+		boolean testPass = matches || unimplemented;
+		RESULTS.add(new CaseResult(type, downloadLocation, expectedPurl, actualPurl, matches, unimplemented, testPass));
+		if (!unimplemented) {
+			org.assertj.core.api.Assertions.assertThat(actualPurl)
+					.as("type=%s downloadLocation=%s", type, downloadLocation)
+					.isEqualTo(expectedPurl);
+		}
+	}
+
+	/** Print a console summary table of recorded parameterized cases. Long values keep the prefix. */
+	static void printResultTable(String mode) {
+		System.out.println();
+		System.out.println("========== PURL download-location results (" + mode + ") ==========");
+		if (RESULTS.isEmpty()) {
+			System.out.println("(no parameterized cases recorded)");
+			System.out.println("=================================================================");
+			return;
+		}
+
+		String header = String.format(
+				"| %3s | %-4s | %-13s | %-" + COL_TYPE + "s | %-" + COL_URL + "s | %-" + COL_PURL + "s | %-" + COL_PURL + "s |",
+				"#", "OK", "Gap", "type", "downloadLocation", "expectedPurl", "actualPurl");
+		String sep = "-".repeat(header.length());
+		System.out.println(sep);
+		System.out.println(header);
+		System.out.println(sep);
+
+		int passExact = 0;
+		int passUnimplementedGap = 0;
+		int failMismatch = 0;
+		int i = 1;
+		for (CaseResult r : RESULTS) {
+			String gap = gapLabel(r);
+			if (r.matches) {
+				passExact++;
+			} else if (r.unimplemented) {
+				passUnimplementedGap++;
+			} else {
+				failMismatch++;
+			}
+			System.out.printf(
+					"| %3d | %-4s | %-13s | %-" + COL_TYPE + "s | %-" + COL_URL + "s | %-" + COL_PURL + "s | %-" + COL_PURL + "s |%n",
+					i++,
+					r.testPass ? "PASS" : "FAIL",
+					gap,
+					truncate(r.type, COL_TYPE),
+					truncate(r.downloadLocation, COL_URL),
+					truncate(r.expectedPurl, COL_PURL),
+					truncate(r.actualPurl, COL_PURL));
+		}
+		System.out.println(sep);
+		System.out.printf(
+				"summary: total=%d  PASS=%d (exact=%d, unimplemented-gap=%d)  FAIL=%d (mismatch)%n",
+				RESULTS.size(),
+				passExact + passUnimplementedGap,
+				passExact,
+				passUnimplementedGap,
+				failMismatch);
+		System.out.println("=================================================================");
+		System.out.println();
+	}
+
+	private static String gapLabel(CaseResult r) {
+		if (r.matches) {
+			return "";
+		}
+		return r.unimplemented ? "unimplemented" : "mismatch";
+	}
+
+	/** Keep the start of {@code value}; drop the suffix when longer than {@code max}. */
+	private static String truncate(String value, int max) {
+		if (value == null) {
+			return "";
+		}
+		if (value.length() <= max) {
+			return value;
+		}
+		if (max <= 3) {
+			return value.substring(0, max);
+		}
+		return value.substring(0, max - 3) + "...";
+	}
+
+	/** True when JDBC to FOSSLight DB succeeds (cached per JVM). */
+	public static boolean isDatabaseAvailable() {
+		if (databaseAvailable == null) {
+			databaseAvailable = probeDatabase();
+		}
+		return databaseAvailable;
+	}
+
+	/** Types listed under {@code unimplementedTypes} in the JSON resource. */
+	static Set<String> unimplementedTypes() throws Exception {
+		return new HashSet<>(loadCaseFile().unimplementedTypesOrEmpty());
+	}
+
+	/** All JSON cases (including unimplemented types). */
+	static Stream<Arguments> downloadLocationToPurlCases() throws Exception {
+		return loadCases().stream()
+				.map(c -> arguments(c.downloadLocation, c.ossName, c.expectedPurl, c.type));
+	}
+
+	static List<PurlCase> loadCases() throws Exception {
+		List<PurlCase> cases = loadCaseFile().cases;
+		if (cases == null || cases.isEmpty()) {
+			throw new IllegalStateException("No cases found in " + CASES_RESOURCE);
+		}
+		return cases;
+	}
+
+	private static PurlCaseFile loadCaseFile() throws Exception {
+		if (caseFile != null) {
+			return caseFile;
+		}
+		InputStream in = PurlTestSupport.class.getClassLoader().getResourceAsStream(CASES_RESOURCE);
+		if (in == null) {
+			throw new IllegalStateException("Missing test resource: " + CASES_RESOURCE);
+		}
+		try (InputStreamReader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+			caseFile = new Gson().fromJson(reader, PurlCaseFile.class);
+			if (caseFile == null) {
+				throw new IllegalStateException("Failed to parse " + CASES_RESOURCE);
+			}
+			return caseFile;
+		}
+	}
+
+	private static boolean probeDatabase() {
+		String url = firstNonBlank(
+				System.getProperty("spring.datasource.url"),
+				System.getenv("SPRING_DATASOURCE_URL"),
+				DEFAULT_JDBC_URL);
+		String user = firstNonBlank(
+				System.getProperty("spring.datasource.username"),
+				System.getenv("SPRING_DATASOURCE_USERNAME"),
+				DEFAULT_USER);
+		String password = firstNonBlank(
+				System.getProperty("spring.datasource.password"),
+				System.getenv("SPRING_DATASOURCE_PASSWORD"),
+				DEFAULT_PASSWORD);
+
+		try {
+			Class.forName("org.mariadb.jdbc.Driver");
+			try (Connection conn = DriverManager.getConnection(url, user, password)) {
+				boolean ok = conn.isValid(3);
+				if (ok) {
+					System.out.println("[OssServicePurlDbTest] DB reachable: " + url);
+				}
+				return ok;
+			}
+		} catch (Exception e) {
+			System.out.println("[OssServicePurlDbTest] DB unavailable (" + url + "): " + e.getMessage());
+			return false;
+		}
+	}
+
+	private static String firstNonBlank(String... values) {
+		if (values == null) {
+			return null;
+		}
+		for (String v : values) {
+			if (v != null && !v.isBlank()) {
+				return v;
+			}
+		}
+		return null;
+	}
+
+	static class PurlCaseFile {
+		List<String> unimplementedTypes;
+		List<PurlCase> cases;
+
+		List<String> unimplementedTypesOrEmpty() {
+			return unimplementedTypes != null ? unimplementedTypes : Collections.emptyList();
+		}
+	}
+
+	static class PurlCase {
+		String type;
+		String downloadLocation;
+		String ossName;
+		String expectedPurl;
+	}
+
+	private static final class CaseResult {
+		final String type;
+		final String downloadLocation;
+		final String expectedPurl;
+		final String actualPurl;
+		final boolean matches;
+		final boolean unimplemented;
+		final boolean testPass;
+
+		CaseResult(String type, String downloadLocation, String expectedPurl, String actualPurl,
+				boolean matches, boolean unimplemented, boolean testPass) {
+			this.type = type;
+			this.downloadLocation = downloadLocation;
+			this.expectedPurl = expectedPurl;
+			this.actualPurl = actualPurl;
+			this.matches = matches;
+			this.unimplemented = unimplemented;
+			this.testPass = testPass;
+		}
+	}
+}

--- a/src/test/resources/purl/download-location-purl-cases.json
+++ b/src/test/resources/purl/download-location-purl-cases.json
@@ -1,0 +1,471 @@
+{
+  "unimplementedTypes": [
+    "bitbucket",
+    "composer",
+    "cpan",
+    "cran",
+    "docker",
+    "hackage",
+    "huggingface",
+    "yocto",
+    "git"
+  ],
+  "cases": [
+    {
+      "type": "github",
+      "downloadLocation": "https://github.com/package-url/purl-spec",
+      "ossName": "purl-spec",
+      "expectedPurl": "pkg:github/package-url/purl-spec"
+    },
+    {
+      "type": "github",
+      "downloadLocation": "https://github.com/fosslight/fosslight",
+      "ossName": "fosslight",
+      "expectedPurl": "pkg:github/fosslight/fosslight"
+    },
+    {
+      "type": "github",
+      "downloadLocation": "https://github.com/fosslight/fosslight.git",
+      "ossName": "fosslight",
+      "expectedPurl": "pkg:github/fosslight/fosslight"
+    },
+    {
+      "type": "github",
+      "downloadLocation": "http://www.github.com/apache/tomcat",
+      "ossName": "tomcat",
+      "expectedPurl": "pkg:github/apache/tomcat"
+    },
+    {
+      "type": "github",
+      "downloadLocation": "https://github.com:443/package-url/purl-spec",
+      "ossName": "purl-spec",
+      "expectedPurl": "pkg:github/package-url/purl-spec"
+    },
+    {
+      "type": "npm",
+      "downloadLocation": "https://www.npmjs.com/package/foobar",
+      "ossName": "foobar",
+      "expectedPurl": "pkg:npm/foobar"
+    },
+    {
+      "type": "npm",
+      "downloadLocation": "https://www.npmjs.com/package/lodash",
+      "ossName": "lodash",
+      "expectedPurl": "pkg:npm/lodash"
+    },
+    {
+      "type": "npm",
+      "downloadLocation": "https://npmjs.com/package/express",
+      "ossName": "express",
+      "expectedPurl": "pkg:npm/express"
+    },
+    {
+      "type": "npm",
+      "downloadLocation": "https://www.npmjs.com/package/@angular/core",
+      "ossName": "@angular/core",
+      "expectedPurl": "pkg:npm/%40angular/core"
+    },
+    {
+      "type": "npm",
+      "downloadLocation": "https://www.npmjs.com/package/@angular/animation",
+      "ossName": "@angular/animation",
+      "expectedPurl": "pkg:npm/%40angular/animation"
+    },
+    {
+      "type": "npm",
+      "downloadLocation": "https://registry.npmjs.org/lodash",
+      "ossName": "lodash",
+      "expectedPurl": "pkg:npm/lodash"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://pypi.org/project/requests",
+      "ossName": "requests",
+      "expectedPurl": "pkg:pypi/requests"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://pypi.python.org/project/Django",
+      "ossName": "Django",
+      "expectedPurl": "pkg:pypi/django"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://pypi.org/project/django",
+      "ossName": "django",
+      "expectedPurl": "pkg:pypi/django"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://pypi.org/project/django-allauth",
+      "ossName": "django-allauth",
+      "expectedPurl": "pkg:pypi/django-allauth"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://pypi.org/project/django_allauth",
+      "ossName": "django-allauth",
+      "expectedPurl": "pkg:pypi/django-allauth"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://pypi.org/project/PyYAML",
+      "ossName": "PyYAML",
+      "expectedPurl": "pkg:pypi/pyyaml"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://pypi.python.org/pypi/requests",
+      "ossName": "requests",
+      "expectedPurl": "pkg:pypi/requests"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://pypi.org/pypi/requests",
+      "ossName": "requests",
+      "expectedPurl": "pkg:pypi/requests"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://files.pythonhosted.org/packages/source/r/requests/requests-2.31.0.tar.gz",
+      "ossName": "requests",
+      "expectedPurl": "pkg:pypi/requests"
+    },
+    {
+      "type": "pypi",
+      "downloadLocation": "https://files.pythonhosted.org/packages/source/m/mcp/mcp-1.20.0.tar.gz",
+      "ossName": "mcp",
+      "expectedPurl": "pkg:pypi/mcp"
+    },
+    {
+      "type": "maven",
+      "downloadLocation": "https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-anim",
+      "ossName": "batik-anim",
+      "expectedPurl": "pkg:maven/org.apache.xmlgraphics/batik-anim"
+    },
+    {
+      "type": "maven",
+      "downloadLocation": "https://mvnrepository.com/artifact/net.sf.jacob-projec/jacob",
+      "ossName": "jacob",
+      "expectedPurl": "pkg:maven/net.sf.jacob-projec/jacob"
+    },
+    {
+      "type": "maven",
+      "downloadLocation": "https://mvnrepository.com/artifact/org.apache.commons/commons-lang3",
+      "ossName": "commons-lang3",
+      "expectedPurl": "pkg:maven/org.apache.commons/commons-lang3"
+    },
+    {
+      "type": "maven",
+      "downloadLocation": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.jar",
+      "ossName": "commons-lang3",
+      "expectedPurl": "pkg:maven/org.apache.commons/commons-lang3"
+    },
+    {
+      "type": "maven",
+      "downloadLocation": "https://maven.google.com/web/index.html#androidx.test.ext:junit",
+      "ossName": "junit",
+      "expectedPurl": "pkg:maven/androidx.test.ext/junit?repository_url=https:%2F%2Fmaven.google.com"
+    },
+    {
+      "type": "maven",
+      "downloadLocation": "https://maven.google.com/web/index.html#com.google.android.material:material:1.11.0",
+      "ossName": "material",
+      "expectedPurl": "pkg:maven/com.google.android.material/material?repository_url=https:%2F%2Fmaven.google.com"
+    },
+    {
+      "type": "maven",
+      "downloadLocation": "https://repo.spring.io/milestone/org/springframework/data/spring-data-r2dbc/1.5.0-M1/spring-data-r2dbc-1.5.0-M1-sources.jar",
+      "ossName": "spring-data-r2dbc",
+      "expectedPurl": "pkg:maven/org.springframework.data/spring-data-r2dbc?repository_url=https:%2F%2Frepo.spring.io"
+    },
+    {
+      "type": "maven",
+      "downloadLocation": "https://dl.google.com/android/maven2/androidx/test/ext/junit/1.2.0/junit-1.2.0.pom",
+      "ossName": "junit",
+      "expectedPurl": "pkg:maven/androidx.test.ext/junit?repository_url=https:%2F%2Fmaven.google.com"
+    },
+    {
+      "type": "maven",
+      "downloadLocation": "https://dl.google.com/dl/android/maven2/androidx/core/core/1.12.0/core-1.12.0.aar",
+      "ossName": "core",
+      "expectedPurl": "pkg:maven/androidx.core/core?repository_url=https:%2F%2Fmaven.google.com"
+    },
+    {
+      "type": "golang",
+      "downloadLocation": "https://pkg.go.dev/github.com/gorilla/context",
+      "ossName": "context",
+      "expectedPurl": "pkg:golang/github.com/gorilla/context"
+    },
+    {
+      "type": "golang",
+      "downloadLocation": "https://pkg.go.dev/golang.org/x/text",
+      "ossName": "text",
+      "expectedPurl": "pkg:golang/golang.org/x/text"
+    },
+    {
+      "type": "golang",
+      "downloadLocation": "https://pkg.go.dev/google.golang.org/genproto",
+      "ossName": "genproto",
+      "expectedPurl": "pkg:golang/google.golang.org/genproto"
+    },
+    {
+      "type": "golang",
+      "downloadLocation": "https://pkg.go.dev/google.golang.org/genproto#googleapis/api/annotations",
+      "ossName": "genproto",
+      "expectedPurl": "pkg:golang/google.golang.org/genproto#googleapis/api/annotations"
+    },
+    {
+      "type": "cocoapods",
+      "downloadLocation": "https://cocoapods.org/pods/Alamofire",
+      "ossName": "Alamofire",
+      "expectedPurl": "pkg:cocoapods/Alamofire"
+    },
+    {
+      "type": "cocoapods",
+      "downloadLocation": "https://cocoapods.org/pods/Alamofire#installation",
+      "ossName": "Alamofire",
+      "expectedPurl": "pkg:cocoapods/Alamofire"
+    },
+    {
+      "type": "cocoapods",
+      "downloadLocation": "https://cocoapods.org/pods/MapsIndoors",
+      "ossName": "MapsIndoors",
+      "expectedPurl": "pkg:cocoapods/MapsIndoors"
+    },
+    {
+      "type": "gem",
+      "downloadLocation": "https://rubygems.org/gems/rails",
+      "ossName": "rails",
+      "expectedPurl": "pkg:gem/rails"
+    },
+    {
+      "type": "gem",
+      "downloadLocation": "https://rubygems.org/gems/ropencv",
+      "ossName": "ropencv",
+      "expectedPurl": "pkg:gem/ropencv"
+    },
+    {
+      "type": "gem",
+      "downloadLocation": "https://rubygems.org/gems/ruby-advisory-db-check",
+      "ossName": "ruby-advisory-db-check",
+      "expectedPurl": "pkg:gem/ruby-advisory-db-check"
+    },
+    {
+      "type": "gem",
+      "downloadLocation": "https://rubygems.org/gems/jruby-launcher",
+      "ossName": "jruby-launcher",
+      "expectedPurl": "pkg:gem/jruby-launcher"
+    },
+    {
+      "type": "cargo",
+      "downloadLocation": "https://crates.io/crates/serde",
+      "ossName": "serde",
+      "expectedPurl": "pkg:cargo/serde"
+    },
+    {
+      "type": "cargo",
+      "downloadLocation": "https://crates.io/crates/rand",
+      "ossName": "rand",
+      "expectedPurl": "pkg:cargo/rand"
+    },
+    {
+      "type": "cargo",
+      "downloadLocation": "https://crates.io/crates/clap",
+      "ossName": "clap",
+      "expectedPurl": "pkg:cargo/clap"
+    },
+    {
+      "type": "nuget",
+      "downloadLocation": "https://www.nuget.org/packages/Newtonsoft.Json",
+      "ossName": "Newtonsoft.Json",
+      "expectedPurl": "pkg:nuget/Newtonsoft.Json"
+    },
+    {
+      "type": "nuget",
+      "downloadLocation": "https://www.nuget.org/packages/Honoo.Net.UPnP",
+      "ossName": "Honoo.Net.UPnP",
+      "expectedPurl": "pkg:nuget/Honoo.Net.UPnP"
+    },
+    {
+      "type": "nuget",
+      "downloadLocation": "https://nuget.org/packages/SocketIO.Serializer.Core",
+      "ossName": "SocketIO.Serializer.Core",
+      "expectedPurl": "pkg:nuget/SocketIO.Serializer.Core"
+    },
+    {
+      "type": "android",
+      "downloadLocation": "https://android.googlesource.com/platform/external/alsa-lib",
+      "ossName": "alsa-lib",
+      "expectedPurl": "pkg:git/android.googlesource.com/platform/external/alsa-lib"
+    },
+    {
+      "type": "android",
+      "downloadLocation": "https://android.googlesource.com/platform/bionic",
+      "ossName": "bionic",
+      "expectedPurl": "pkg:git/android.googlesource.com/platform/bionic"
+    },
+    {
+      "type": "android",
+      "downloadLocation": "https://android.googlesource.com/platform/bionic/+/refs/tags/aml_tz3_312511020",
+      "ossName": "bionic",
+      "expectedPurl": "pkg:git/android.googlesource.com/platform/bionic"
+    },
+    {
+      "type": "android",
+      "downloadLocation": "https://android.googlesource.com/platform/external/sqlite",
+      "ossName": "sqlite",
+      "expectedPurl": "pkg:git/android.googlesource.com/platform/external/sqlite"
+    },
+    {
+      "type": "bitbucket",
+      "downloadLocation": "https://bitbucket.org/birkenfeld/pygments-main",
+      "ossName": "pygments-main",
+      "expectedPurl": "pkg:bitbucket/birkenfeld/pygments-main"
+    },
+    {
+      "type": "bitbucket",
+      "downloadLocation": "https://bitbucket.org/blackteckel/job-board-tails-njs/get/v0.1.5.zip",
+      "ossName": "job-board-tails-njs",
+      "expectedPurl": "pkg:bitbucket/blackteckel/job-board-tails-njs"
+    },
+    {
+      "type": "composer",
+      "downloadLocation": "https://packagist.org/packages/laravel/laravel",
+      "ossName": "laravel",
+      "expectedPurl": "pkg:composer/laravel/laravel"
+    },
+    {
+      "type": "composer",
+      "downloadLocation": "https://packagist.org/packages/geerlingguy/ping",
+      "ossName": "ping",
+      "expectedPurl": "pkg:composer/geerlingguy/ping"
+    },
+    {
+      "type": "cpan",
+      "downloadLocation": "https://www.cpan.org/authors/id/O/OA/OALDERS/libwww-perl-6.18.tar.gz",
+      "ossName": "libwww-perl",
+      "expectedPurl": "pkg:cpan/libwww-perl"
+    },
+    {
+      "type": "cpan",
+      "downloadLocation": "https://www.cpan.org/authors/id/I/IN/INA/Jacode4e/RoundTrip/Jacode4e-RoundTrip-2.13.81.6.tar.gz",
+      "ossName": "Jacode4e-RoundTrip",
+      "expectedPurl": "pkg:cpan/Jacode4e-RoundTrip"
+    },
+    {
+      "type": "cran",
+      "downloadLocation": "https://cran.r-project.org/web/packages/rJava/index.html",
+      "ossName": "rJava",
+      "expectedPurl": "pkg:cran/rJava"
+    },
+    {
+      "type": "cran",
+      "downloadLocation": "https://cran.r-project.org/web/packages/ECharts2Shiny/index.html",
+      "ossName": "ECharts2Shiny",
+      "expectedPurl": "pkg:cran/ECharts2Shiny"
+    },
+    {
+      "type": "docker",
+      "downloadLocation": "https://hub.docker.com/_/cassandra",
+      "ossName": "cassandra",
+      "expectedPurl": "pkg:docker/cassandra"
+    },
+    {
+      "type": "docker",
+      "downloadLocation": "https://hub.docker.com/r/bitnami/mariadb-galera",
+      "ossName": "mariadb-galera",
+      "expectedPurl": "pkg:docker/bitnami/mariadb-galera"
+    },
+    {
+      "type": "docker",
+      "downloadLocation": "https://hub.docker.com/hardened-images/catalog/dhi/python",
+      "ossName": "python",
+      "expectedPurl": "pkg:docker/python?repository_url=dhi.io"
+    },
+    {
+      "type": "hackage",
+      "downloadLocation": "https://hackage.haskell.org/package/AC-HalfInteger",
+      "ossName": "AC-HalfInteger",
+      "expectedPurl": "pkg:hackage/AC-HalfInteger"
+    },
+    {
+      "type": "hackage",
+      "downloadLocation": "https://hackage.haskell.org/package/csg",
+      "ossName": "csg",
+      "expectedPurl": "pkg:hackage/csg"
+    },
+    {
+      "type": "huggingface",
+      "downloadLocation": "https://huggingface.co/openai/whisper-small",
+      "ossName": "whisper-small",
+      "expectedPurl": "pkg:huggingface/openai/whisper-small"
+    },
+    {
+      "type": "huggingface",
+      "downloadLocation": "https://huggingface.co/datasets/stanfordnlp/snli",
+      "ossName": "snli",
+      "expectedPurl": "pkg:huggingface/datasets/stanfordnlp/snli"
+    },
+    {
+      "type": "yocto",
+      "downloadLocation": "https://git.openembedded.org/openembedded-core/tree/meta/recipes-core/gettext/gettext_1.0.bb",
+      "ossName": "gettext",
+      "expectedPurl": "pkg:yocto/core/gettext?repository_url=https:%2F%2Fgit.openembedded.org%2Fopenembedded-core"
+    },
+    {
+      "type": "git",
+      "downloadLocation": "https://codeberg.org/forgejo/forgejo",
+      "ossName": "forgejo",
+      "expectedPurl": "pkg:git/codeberg.org/forgejo/forgejo"
+    },
+    {
+      "type": "git",
+      "downloadLocation": "https://cygwin.com/cgit/newlib-cygwin",
+      "ossName": "newlib-cygwin",
+      "expectedPurl": "pkg:git/cygwin.com/cgit/newlib-cygwin"
+    },
+    {
+      "type": "git",
+      "downloadLocation": "https://projects.blender.org/blender/blender",
+      "ossName": "blender",
+      "expectedPurl": "pkg:git/projects.blender.org/blender/blender"
+    },
+    {
+      "type": "git",
+      "downloadLocation": "https://gitlab.gnome.org/GNOME/adwaita-fonts",
+      "ossName": "adwaita-fonts",
+      "expectedPurl": "pkg:git/gitlab.gnome.org/GNOME/adwaita-fonts"
+    },
+    {
+      "type": "git",
+      "downloadLocation": "https://git.codelinaro.org/clo/la/platform/external/volley",
+      "ossName": "volley",
+      "expectedPurl": "pkg:git/git.codelinaro.org/clo/la/platform/external/volley"
+    },
+    {
+      "type": "git",
+      "downloadLocation": "https://source.codeaurora.org/external/imx/weston-imx/",
+      "ossName": "weston-imx",
+      "expectedPurl": "pkg:git/source.codeaurora.org/external/imx/weston-imx"
+    },
+    {
+      "type": "pub",
+      "downloadLocation": "https://pub.dev/packages/http",
+      "ossName": "http",
+      "expectedPurl": "pkg:pub/http"
+    },
+    {
+      "type": "generic",
+      "downloadLocation": "https://openssl.org/source/openssl-1.1.0g.tar.gz",
+      "ossName": "openssl",
+      "expectedPurl": "pkg:generic/openssl?download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz"
+    },
+    {
+      "type": "generic",
+      "downloadLocation": "https://example.com/downloads/sample-1.0.tar.gz",
+      "ossName": "Sample OSS",
+      "expectedPurl": "pkg:generic/sample%20oss?download_url=https:%2F%2Fexample.com%2Fdownloads%2Fsample-1.0.tar.gz"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
* **Documentation**
  * Added comprehensive PURL writing guidelines, including URL normalization, package-specific formats, repository handling, and generic downloads.
  
- **Testing**
  - Expanded coverage for package URL generation across a broad range of ecosystems and download formats.
  - Add validation for unsupported package types and empty download locations. 
  - Add purl test to github action's test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## How to test
<!-- 
Please describe what this PR do.
 -->
`./gradlew test --tests 'oss.fosslight.service.OssServicePurl*'`