### PR TITLE
refactor(api/v2): remove per-endpoint try-catch and unify error handl…

### DIFF
--- a/src/main/java/oss/fosslight/api/advice/ApiV2ExceptionAdvice.java
+++ b/src/main/java/oss/fosslight/api/advice/ApiV2ExceptionAdvice.java
@@ -35,7 +35,7 @@ public class ApiV2ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected ResponseEntity<Map<String, Object>> handleInternalServerError(
             HttpServletRequest request, Exception e) {
-        log.error("Unhandled exception", e);
+        log.error("Unhandled exception [{} {}]", request.getMethod(), request.getRequestURI(), e);
         return responseService.errorResponse(
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE)
@@ -74,6 +74,18 @@ public class ApiV2ExceptionAdvice extends ResponseEntityExceptionHandler {
     protected ResponseEntity<Map<String, Object>> handleCInvalidProjectTypeException(HttpServletRequest request, CInvalidProjectTypeException e){
         return responseService.errorResponse(HttpStatus.UNPROCESSABLE_ENTITY,
                 "Project Type is invalid. " + e.getMessage());
+    }
+
+    @ExceptionHandler(CProjectNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    protected ResponseEntity<Map<String, Object>> handleProjectNotFound(HttpServletRequest request, CProjectNotFoundException e) {
+        return responseService.errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+    }
+
+    @ExceptionHandler(CSupplementNoticeGenerationException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    protected ResponseEntity<Map<String, Object>> handleSupplementNoticeGenerationFailure(HttpServletRequest request, CSupplementNoticeGenerationException e) {
+        return responseService.errorResponse(HttpStatus.UNPROCESSABLE_ENTITY, e.getMessage());
     }
 
     @ExceptionHandler(CProjectNotAvailableException.class)

--- a/src/main/java/oss/fosslight/api/advice/CProjectNotFoundException.java
+++ b/src/main/java/oss/fosslight/api/advice/CProjectNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package oss.fosslight.api.advice;
+
+/**
+ * Thrown when a project referenced by an API call does not exist.
+ * Mapped to HTTP 404 Not Found by {@link ApiV2ExceptionAdvice}.
+ */
+public class CProjectNotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public CProjectNotFoundException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public CProjectNotFoundException(String msg) {
+        super(msg);
+    }
+
+    public CProjectNotFoundException() {
+        super();
+    }
+}

--- a/src/main/java/oss/fosslight/api/advice/CSupplementNoticeGenerationException.java
+++ b/src/main/java/oss/fosslight/api/advice/CSupplementNoticeGenerationException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package oss.fosslight.api.advice;
+
+/**
+ * Thrown when a supplement notice file could not be generated because the
+ * project does not contain valid binary components (or other business-rule
+ * failure). Mapped to HTTP 422 Unprocessable Entity by
+ * {@link ApiV2ExceptionAdvice}.
+ */
+public class CSupplementNoticeGenerationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public CSupplementNoticeGenerationException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public CSupplementNoticeGenerationException(String msg) {
+        super(msg);
+    }
+
+    public CSupplementNoticeGenerationException() {
+        super();
+    }
+}

--- a/src/main/java/oss/fosslight/api/annotation/InternalApi.java
+++ b/src/main/java/oss/fosslight/api/annotation/InternalApi.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package oss.fosslight.api.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an API endpoint (or whole controller) as internal-only.
+ *
+ * <p>Endpoints annotated with {@code @InternalApi} are:
+ * <ul>
+ *   <li><b>Excluded</b> from the public {@code v2} Swagger group (hidden from external users).</li>
+ *   <li><b>Included</b> in the {@code v2-internal} Swagger group, which is only visible to
+ *       authenticated {@code ROLE_ADMIN} users (see the custom {@code SwaggerResourcesProvider}
+ *       and {@code SwaggerInternalGroupFilter} in {@code SwaggerConfig}).</li>
+ *   <li><b>Still callable</b> at runtime &mdash; the annotation only affects Swagger documentation
+ *       visibility, not request handling. Actual access control is enforced inside each controller
+ *       (e.g. {@code userService.isAdmin(authorization)}).</li>
+ * </ul>
+ *
+ * <p>This annotation can be placed at the class level (applies to all endpoints in the controller)
+ * or at the method level (applies to a single endpoint).
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InternalApi {
+}

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiCodeV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiCodeV2Controller.java
@@ -47,15 +47,11 @@ public class ApiCodeV2Controller extends CoTopComponent {
         userService.checkApiUserAuth(authorization);
         Map<String, Object> result = new HashMap<>();
 
-        try {
-            List<Map<String, Object>> contents = apiCodeService.getCodeList(codeType, detailValue);
-            if (contents.size() == 0) {
-                return ResponseEntity.notFound().build();
-            }
-            result.put("content", contents);
-            return ResponseEntity.ok(result);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
+        List<Map<String, Object>> contents = apiCodeService.getCodeList(codeType, detailValue);
+        if (contents.size() == 0) {
+            return ResponseEntity.notFound().build();
         }
+        result.put("content", contents);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiCommonV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiCommonV2Controller.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import oss.fosslight.CoTopComponent;
+import oss.fosslight.api.annotation.InternalApi;
 import oss.fosslight.api.service.RestResponseService;
 import oss.fosslight.common.Url.APIV2;
 import oss.fosslight.domain.T2Users;
@@ -38,6 +39,7 @@ public class ApiCommonV2Controller extends CoTopComponent {
 
     protected static final Logger log = LoggerFactory.getLogger("DEFAULT_LOG");
 
+    @InternalApi
     @ApiOperation(value = "Merge division", notes = "Merge division (from -> to)")
     @PostMapping(value = {APIV2.FOSSLIGHT_API_COMMON_MERGE_DIVISION})
     public ResponseEntity<Map<String, Object>> mergeDivision(
@@ -60,6 +62,7 @@ public class ApiCommonV2Controller extends CoTopComponent {
         }
     }
 
+    @InternalApi
     @ApiOperation(value = "Add division", notes = "Add a user division (T2_CODE_DTL, CD_NO=200). Detail Name maps to CD_DTL_NM, Detail Description to CD_DTL_EXP.")
     @PostMapping(value = {APIV2.FOSSLIGHT_API_COMMON_DIVISION})
     public ResponseEntity<Map<String, Object>> addDivision(
@@ -83,6 +86,7 @@ public class ApiCommonV2Controller extends CoTopComponent {
         }
     }
 
+    @InternalApi
     @ApiOperation(value = "Update division", notes = "Update CD_DTL_NM and/or CD_DTL_EXP for a user division (T2_CODE_DTL, CD_NO=200) by CD_DTL_NO. Omit a field to leave it unchanged; at least one of cdDtlNm or cdDtlExp must be sent.")
     @PutMapping(value = {APIV2.FOSSLIGHT_API_COMMON_UPDATE_DIVISION})
     public ResponseEntity<Map<String, Object>> updateDivision(
@@ -114,6 +118,7 @@ public class ApiCommonV2Controller extends CoTopComponent {
         }
     }
 
+    @InternalApi
     @ApiOperation(value = "Get division list", notes = "Get division list (T2_CODE_DTL, CD_NO=200)")
     @GetMapping(value = {APIV2.FOSSLIGHT_API_COMMON_DIVISION})
     public ResponseEntity<Map<String, Object>> getDivisionList(
@@ -131,6 +136,7 @@ public class ApiCommonV2Controller extends CoTopComponent {
         }
     }
 
+    @InternalApi
     @ApiOperation(value = "Get all users (basic)", notes = "Returns all rows from T2_USERS with user_id, user_name, email, division, use_yn")
     @GetMapping(value = {APIV2.FOSSLIGHT_API_COMMON_USERS})
     public ResponseEntity<Map<String, Object>> getAllUsersBasic(
@@ -161,6 +167,7 @@ public class ApiCommonV2Controller extends CoTopComponent {
         }
     }
 
+    @InternalApi
     @ApiOperation(value = "Update user division", notes = "Admin only. Update T2_USERS.DIVISION by USER_ID.")
     @PutMapping(value = {APIV2.FOSSLIGHT_API_COMMON_USER_DIVISION})
     public ResponseEntity<Map<String, Object>> updateUserDivision(

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiOssV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiOssV2Controller.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import oss.fosslight.CoTopComponent;
+import oss.fosslight.api.annotation.InternalApi;
 import oss.fosslight.api.dto.ListLicenseDto;
 import oss.fosslight.api.dto.ListOssDto;
 import oss.fosslight.api.service.RestResponseService;
@@ -181,6 +182,7 @@ public class ApiOssV2Controller extends CoTopComponent {
 //        }
 //    }
 
+    @InternalApi
     @ApiOperation(value = "Register New OSS", notes = "Register New OSS")
     @PostMapping(value = {APIV2.FOSSLIGHT_API_OSS_REGISTER})
     public ResponseEntity<Map<String, Object>> registerOss(
@@ -197,6 +199,7 @@ public class ApiOssV2Controller extends CoTopComponent {
                 CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
     }
     
+    @InternalApi
     @ApiOperation(value = "Refine OSS Download Location", notes = "Refine ALL is processed in the following order. <ol><li>UPDATE DOWNLOAD LOCATION FORMAT</li><li>REMOVE DUPLICATED DOWNLOAD LOCATION</li><li>PUT PURL</li><li>REMOVE DUPLICATED PURL</li><li>REORDER GITHUB PRIORITY</li></ol><br>* If doUpdateFlag is N, the database will not be updated.")
 	@GetMapping(value = {APIV2.FOSSLIGHT_API_OSS_REFINE_DOWNLOAD_LOCATION})
     public ResponseEntity<Map<String, Object>> refineOssDownloadLocation(

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiOssV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiOssV2Controller.java
@@ -70,33 +70,26 @@ public class ApiOssV2Controller extends CoTopComponent {
             @ApiParam(value = "Page", required = false)
             @Min(value=1, message="Input value=${validatedValue}. page must be larger than {value}") @RequestParam(required = false, defaultValue="1") int page
     ) {
-        try {
-            // 사용자 인증
-            userService.checkApiUserAuth(authorization);
+        // 사용자 인증
+        userService.checkApiUserAuth(authorization);
 
-            ListOssDto.Request ossQuery =
-                    ListOssDto.Request.builder()
-                            .ossName(ossName)
-                            .url(downloadLocation)
-                            .ossVersion(ossVersion)
-                            .ossNameExact(Objects.equals(ossNameExact, "Y"))
-                            .urlExact(Objects.equals(downloadLocationExact, "Y"))
-                            .cveId(cveId != null ? cveId.trim() : null)
-                            .build();
-            ossQuery.setPage(page);
-            ossQuery.setCountPerPage(countPerPage);
+        ListOssDto.Request ossQuery =
+                ListOssDto.Request.builder()
+                        .ossName(ossName)
+                        .url(downloadLocation)
+                        .ossVersion(ossVersion)
+                        .ossNameExact(Objects.equals(ossNameExact, "Y"))
+                        .urlExact(Objects.equals(downloadLocationExact, "Y"))
+                        .cveId(cveId != null ? cveId.trim() : null)
+                        .build();
+        ossQuery.setPage(page);
+        ossQuery.setCountPerPage(countPerPage);
 
-            var map = apiOssService.listOss(ossQuery);
-            if (!userService.isApiAdmin(authorization) && map.list != null) {
-                map.list.forEach(oss -> oss.setExclude(null));
-            }
-            return ResponseEntity.ok(map);
-        } catch (NumberFormatException e) {
-            return ResponseEntity.badRequest().build();
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return ResponseEntity.internalServerError().build();
+        var map = apiOssService.listOss(ossQuery);
+        if (!userService.isApiAdmin(authorization) && map.list != null) {
+            map.list.forEach(oss -> oss.setExclude(null));
         }
+        return ResponseEntity.ok(map);
     }
 
 
@@ -115,23 +108,16 @@ public class ApiOssV2Controller extends CoTopComponent {
         userService.checkApiUserAuth(authorization);
         Map<String, Object> resultMap = new HashMap<String, Object>();
 
-        try {
-            ListLicenseDto.Request licenseQuery =
-                    ListLicenseDto.Request.builder()
-                            .licenseName(licenseName)
-                            .licenseNameExact(Objects.equals(licenseNameExact, "Y"))
-                            .build();
-            licenseQuery.setPage(page);
-            licenseQuery.setCountPerPage(countPerPage);
+        ListLicenseDto.Request licenseQuery =
+                ListLicenseDto.Request.builder()
+                        .licenseName(licenseName)
+                        .licenseNameExact(Objects.equals(licenseNameExact, "Y"))
+                        .build();
+        licenseQuery.setPage(page);
+        licenseQuery.setCountPerPage(countPerPage);
 
-            var map = apiLicenseService.listLicenses(licenseQuery);
-            return ResponseEntity.ok(map);
-        } catch (NumberFormatException e) {
-            return ResponseEntity.badRequest().build();
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return ResponseEntity.internalServerError().build();
-        }
+        var map = apiLicenseService.listLicenses(licenseQuery);
+        return ResponseEntity.ok(map);
     }
 
 //
@@ -203,14 +189,9 @@ public class ApiOssV2Controller extends CoTopComponent {
 
         if (userService.isAdmin(authorization)) {
             Map<String, Object> resultMap = new HashMap<String, Object>();
-            try {
-                resultMap = ossService.saveOss(ossMaster);
-                resultMap = ossService.sendMailForSaveOss(resultMap);
-                return ResponseEntity.ok(resultMap);
-            } catch (Exception e) {
-                return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR
-                        , CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE));
-            }
+            resultMap = ossService.saveOss(ossMaster);
+            resultMap = ossService.sendMailForSaveOss(resultMap);
+            return ResponseEntity.ok(resultMap);
         }
         return responseService.errorResponse(HttpStatus.FORBIDDEN,
                 CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
@@ -225,16 +206,10 @@ public class ApiOssV2Controller extends CoTopComponent {
     		@ApiParam(value = "Refine Type", required = true, allowableValues = "0.UPDATE DOWNLOAD LOCATION FORMAT,1.REMOVE DUPLICATED DOWNLOAD LOCATION,2.PUT PURL,3.REMOVE DUPLICATED PURL,4.REORDER GITHUB PRIORITY,5.REFINE ALL") @RequestParam(required = true) String refineType){
 		
 		// 사용자 인증
-		try {
-			if (!userService.isAdmin(authorization)) {
-				return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
-						CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
-			}
-			return ResponseEntity.ok(refineOssService.refineDownloadLocation(ossName, refineType, "Y".equalsIgnoreCase(doUpdateFlag)));
-		} catch (Exception e) {
-			log.error(e.getMessage(), e);
-			return responseService.errorResponse(HttpStatus.FORBIDDEN,
-					CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE));
+		if (!userService.isAdmin(authorization)) {
+			return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
+					CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
 		}
+		return ResponseEntity.ok(refineOssService.refineDownloadLocation(ossName, refineType, "Y".equalsIgnoreCase(doUpdateFlag)));
     }
 }

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiPartnerV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiPartnerV2Controller.java
@@ -76,29 +76,22 @@ public class ApiPartnerV2Controller extends CoTopComponent {
         Map<String, Object> resultMap = new HashMap<String, Object>();
         Map<String, Object> paramMap = new HashMap<String, Object>();
 
-        try {
-            CommonFunction.splitDate(createDate, paramMap, "-", "createDate");
-            CommonFunction.splitDate(updateDate, paramMap, "-", "updateDate");
+        CommonFunction.splitDate(createDate, paramMap, "-", "createDate");
+        CommonFunction.splitDate(updateDate, paramMap, "-", "updateDate");
 
 //			paramMap.put("userRole", userInfo.getAuthority());
-            paramMap.put("creator", creator);
-            paramMap.put("userId", userInfo.getUserId());
-            paramMap.put("userRole", userRole(userInfo));
-            paramMap.put("division", division);
-            paramMap.put("status", status);
-            paramMap.put("partnerIdList", partnerIdList);
-            paramMap.put("countPerPage", countPerPage);
-            paramMap.put("offset", (page - 1) * countPerPage);
+        paramMap.put("creator", creator);
+        paramMap.put("userId", userInfo.getUserId());
+        paramMap.put("userRole", userRole(userInfo));
+        paramMap.put("division", division);
+        paramMap.put("status", status);
+        paramMap.put("partnerIdList", partnerIdList);
+        paramMap.put("countPerPage", countPerPage);
+        paramMap.put("offset", (page - 1) * countPerPage);
 
-            resultMap = apiPartnerService.getPartnerMasterList(paramMap);
+        resultMap = apiPartnerService.getPartnerMasterList(paramMap);
 
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (NumberFormatException e) {
-            return ResponseEntity.badRequest().build();
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.BAD_REQUEST,
-                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
-        }
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
 
     }
 
@@ -116,34 +109,29 @@ public class ApiPartnerV2Controller extends CoTopComponent {
             throw new CProjectNotAvailableException(partnerId);
         }
 
-        try {
-            for (String email : emailList) {
-                boolean ldapCheck = true;
-                if (CoConstDef.FLAG_YES.equals(avoidNull(CommonFunction.getProperty("ldap.check.flag")))) {
-                    ldapCheck = apiPartnerService.existLdapUserToEmail(email);
-                }
-                if (!ldapCheck) {
-                    return responseService.errorResponse(HttpStatus.BAD_REQUEST,
-                            CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
-                }
-                boolean watcherFlag = apiPartnerService.existsWatcherByEmail(partnerId, email);
-                if (watcherFlag) {
-                    Map<String, Object> param = new HashMap<>();
-                    param.put("partnerId", partnerId);
-                    param.put("division", "");
-                    param.put("userId", "");
-                    param.put("partnerEmail", email);
-                    apiPartnerService.insertWatcher(param);
-                } else {
-                    return responseService.errorResponse(HttpStatus.BAD_REQUEST,
-                            CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
-                }
+        for (String email : emailList) {
+            boolean ldapCheck = true;
+            if (CoConstDef.FLAG_YES.equals(avoidNull(CommonFunction.getProperty("ldap.check.flag")))) {
+                ldapCheck = apiPartnerService.existLdapUserToEmail(email);
             }
-            return new ResponseEntity(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
-                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+            if (!ldapCheck) {
+                return responseService.errorResponse(HttpStatus.BAD_REQUEST,
+                        CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+            }
+            boolean watcherFlag = apiPartnerService.existsWatcherByEmail(partnerId, email);
+            if (watcherFlag) {
+                Map<String, Object> param = new HashMap<>();
+                param.put("partnerId", partnerId);
+                param.put("division", "");
+                param.put("userId", "");
+                param.put("partnerEmail", email);
+                apiPartnerService.insertWatcher(param);
+            } else {
+                return responseService.errorResponse(HttpStatus.BAD_REQUEST,
+                        CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+            }
         }
+        return new ResponseEntity(resultMap, HttpStatus.OK);
     }
 
     @ApiOperation(value = "3rd Party Export report", notes = "3rd Party > Export report")
@@ -215,12 +203,7 @@ public class ApiPartnerV2Controller extends CoTopComponent {
             throw new CProjectNotAvailableException(partnerId);
         }
 
-        try {
-            resultMap = apiPartnerService.getExportJson(partnerId);
-
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.BAD_REQUEST);
-        }
+        resultMap = apiPartnerService.getExportJson(partnerId);
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 }

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiProjectV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiProjectV2Controller.java
@@ -120,40 +120,32 @@ public class ApiProjectV2Controller extends CoTopComponent {
         Map<String, Object> resultMap = new HashMap<String, Object>();
         Map<String, Object> paramMap = new HashMap<String, Object>();
 
-        try {
-            CommonFunction.splitDate(createDate, paramMap, "-", "createDate");
-            CommonFunction.splitDate(updateDate, paramMap, "-", "updateDate");
+        CommonFunction.splitDate(createDate, paramMap, "-", "createDate");
+        CommonFunction.splitDate(updateDate, paramMap, "-", "updateDate");
 
 //			paramMap.put("userRole", userInfo.getAuthority());
-            paramMap.put("creator", creator);
-            paramMap.put("userId", userInfo.getUserId());
-            paramMap.put("userRole", userRole(userInfo));
-            paramMap.put("division", division);
-            paramMap.put("modelName", modelName);
-            paramMap.put("modelNameExactYn", modelNameExactYn);
-            paramMap.put("status", status);
-            paramMap.put("prjIdList", prjIdList);
-            paramMap.put("prjName", prjName);
-            paramMap.put("prjNameExactYn", prjNameExactYn);
-            paramMap.put("countPerPage", countPerPage);
-            paramMap.put("offset", (page - 1) * countPerPage);
-            if (!isEmpty(ossName)) {
-                paramMap.put("ossName", ossName);
-            }
-            if (!isEmpty(ossVersion)) {
-                paramMap.put("ossVersion", ossVersion);
-            }
-
-            try {
-                resultMap = apiProjectService.selectProjectList(paramMap);
-            } catch (Exception e) {
-                return responseService.errorResponse(HttpStatus.BAD_REQUEST);
-            }
-
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
+        paramMap.put("creator", creator);
+        paramMap.put("userId", userInfo.getUserId());
+        paramMap.put("userRole", userRole(userInfo));
+        paramMap.put("division", division);
+        paramMap.put("modelName", modelName);
+        paramMap.put("modelNameExactYn", modelNameExactYn);
+        paramMap.put("status", status);
+        paramMap.put("prjIdList", prjIdList);
+        paramMap.put("prjName", prjName);
+        paramMap.put("prjNameExactYn", prjNameExactYn);
+        paramMap.put("countPerPage", countPerPage);
+        paramMap.put("offset", (page - 1) * countPerPage);
+        if (!isEmpty(ossName)) {
+            paramMap.put("ossName", ossName);
         }
+        if (!isEmpty(ossVersion)) {
+            paramMap.put("ossVersion", ossVersion);
+        }
+
+        resultMap = apiProjectService.selectProjectList(paramMap);
+
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 
     @ApiOperation(value = "Retrieve the model list of the project", notes = "Retrieve Project Model Information")
@@ -166,20 +158,11 @@ public class ApiProjectV2Controller extends CoTopComponent {
         userService.checkApiUserAuth(authorization);
         Map<String, Object> resultMap = new HashMap<String, Object>();
 
-        try {
-            try {
-                Map<String, Object> paramMap = new HashMap<String, Object>();
-                paramMap.put("prjIdList", prjIdList);
+        Map<String, Object> paramMap = new HashMap<String, Object>();
+        paramMap.put("prjIdList", prjIdList);
+        resultMap = apiProjectService.selectModelList(paramMap);
 
-                resultMap = apiProjectService.selectModelList(paramMap);
-            } catch (Exception e) {
-                return responseService.errorResponse(HttpStatus.BAD_REQUEST);
-            }
-
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 
     @ApiOperation(value = "Update model list of project", notes = "Basic Information > Model list")
@@ -203,31 +186,24 @@ public class ApiProjectV2Controller extends CoTopComponent {
             throw new CProjectNotAvailableException(prjId);
         }
 
-        try {
-            Project project = projectService.getProjectBasicInfo(prjId);
-            if (modelListToUpdate != null) {
-                List<String[]> models = new ArrayList<>();
-                for (String strModel : modelListToUpdate) {
-                    String[] model = strModel.replaceAll("\"", "").split("\\|");
-                    if (model.length > 2) {
-                        models.add(model);
-                    }
-                }
-                if (models.size() > 0) {
-                    modelList = ExcelUtil.readModelFromList(models, prjId, CoConstDef.FLAG_YES, "0", project.getDistributeTarget());
+        Project project = projectService.getProjectBasicInfo(prjId);
+        if (modelListToUpdate != null) {
+            List<String[]> models = new ArrayList<>();
+            for (String strModel : modelListToUpdate) {
+                String[] model = strModel.replaceAll("\"", "").split("\\|");
+                if (model.length > 2) {
+                    models.add(model);
                 }
             }
-
-            if (modelList != null) {
-                project.setModelList(modelList.get("currentModelList"));
-                projectService.insertProjectModel(project);
-                return new ResponseEntity<>(resultMap, HttpStatus.OK);
+            if (models.size() > 0) {
+                modelList = ExcelUtil.readModelFromList(models, prjId, CoConstDef.FLAG_YES, "0", project.getDistributeTarget());
             }
+        }
 
-        } catch (Exception e) {
-            log.error(e.getMessage());
-//			errorCode = CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE;
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        if (modelList != null) {
+            project.setModelList(modelList.get("currentModelList"));
+            projectService.insertProjectModel(project);
+            return new ResponseEntity<>(resultMap, HttpStatus.OK);
         }
 
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -269,9 +245,6 @@ public class ApiProjectV2Controller extends CoTopComponent {
                 }
             } catch (IndexOutOfBoundsException e) {
                 return responseService.errorResponse(HttpStatus.BAD_REQUEST, "Error while parsing given file");
-            } catch (Exception e) {
-                log.error(e.getMessage());
-                return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
             }
         }
 
@@ -301,8 +274,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
         T2Users userInfo = userService.checkApiUserAuth(authorization);
         Map<String, Object> result = new HashMap<String, Object>();
 
-        try {
-            Map<String, Object> paramMap = new HashMap<String, Object>();
+        Map<String, Object> paramMap = new HashMap<String, Object>();
 
             String osTypeStr = CoCodeManager.getCodeString(CoConstDef.CD_OS_TYPE, osType);
 
@@ -443,10 +415,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
                 log.error(e.getMessage(), e);
             }
 
-            return new ResponseEntity<>(result, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
 
@@ -458,7 +427,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
             @ApiParam(value = "Save Flag (YES : Y, NO : N)", allowableValues = "Y,N")
             @ValuesAllowed(propName = "saveFlag", values = {"Y", "N"}) @RequestParam(required = false, defaultValue = "Y") String saveFlag,
             @ApiParam(value = "Format", allowableValues = "Spreadsheet")
-            @ValuesAllowed(propName = "format", values = {"Spreadsheet"}) @RequestParam String format) {
+            @ValuesAllowed(propName = "format", values = {"Spreadsheet"}) @RequestParam String format) throws Exception {
         return getPrjBomDownloadInternal(authorization, prjId, saveFlag, format);
     }
 
@@ -470,11 +439,11 @@ public class ApiProjectV2Controller extends CoTopComponent {
             @ApiParam(value = "Save Flag (YES : Y, NO : N)", allowableValues = "Y,N")
             @ValuesAllowed(propName = "saveFlag", values = {"Y", "N"}) @RequestParam(required = false, defaultValue = "Y") String saveFlag,
             @ApiParam(value = "Format", allowableValues = "Spreadsheet")
-            @ValuesAllowed(propName = "format", values = {"Spreadsheet"}) @RequestParam String format) {
+            @ValuesAllowed(propName = "format", values = {"Spreadsheet"}) @RequestParam String format) throws Exception {
         return getPrjBomDownloadInternal(authorization, prjId, saveFlag, format);
     }
 
-    private ResponseEntity<FileSystemResource> getPrjBomDownloadInternal(String authorization, String prjId, String saveFlag, String format) {
+    private ResponseEntity<FileSystemResource> getPrjBomDownloadInternal(String authorization, String prjId, String saveFlag, String format) throws Exception {
         log.info("Project Bom Download as File :: " + prjId + " :: " + saveFlag + " :: " + format);
 
         // 사용자 인증
@@ -483,33 +452,28 @@ public class ApiProjectV2Controller extends CoTopComponent {
             throw new CProjectNotAvailableException(prjId);
         }
 
-        try {
-            String downloadId = "";
-            T2File fileInfo = new T2File();
-            String type = "";
+        String downloadId = "";
+        T2File fileInfo = new T2File();
+        String type = "";
 
-            if (CoConstDef.FLAG_YES.equals(saveFlag)) {
-                apiProjectService.registBom(prjId, saveFlag, userInfo.getUserId());
-                projectService.updateSecurityDataForProject(prjId);
-            }
-
-            Project project = new Project();
-            project.setPrjId(prjId);
-            Project projectMaster = projectService.getProjectDetail(project);
-
-            if (projectMaster.getNoticeType().equals(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED)) {
-                type = "binAndroidBom";
-            } else {
-                type = "bom";
-            }
-            downloadId = ExcelDownLoadUtil.getExcelDownloadId(type, prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
-            fileInfo = fileService.selectFileInfo(downloadId);
-
-            return excelToResponseEntity(fileInfo.getLogiPath() + fileInfo.getLogiNm(), fileInfo.getOrigNm());
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return null;
+        if (CoConstDef.FLAG_YES.equals(saveFlag)) {
+            apiProjectService.registBom(prjId, saveFlag, userInfo.getUserId());
+            projectService.updateSecurityDataForProject(prjId);
         }
+
+        Project project = new Project();
+        project.setPrjId(prjId);
+        Project projectMaster = projectService.getProjectDetail(project);
+
+        if (projectMaster.getNoticeType().equals(CoConstDef.CD_NOTICE_TYPE_PLATFORM_GENERATED)) {
+            type = "binAndroidBom";
+        } else {
+            type = "bom";
+        }
+        downloadId = ExcelDownLoadUtil.getExcelDownloadId(type, prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
+        fileInfo = fileService.selectFileInfo(downloadId);
+
+        return excelToResponseEntity(fileInfo.getLogiPath() + fileInfo.getLogiNm(), fileInfo.getOrigNm());
     }
 
     @ApiOperation(value = "Get Project Bom Tab As Json", notes = "Project > Get Bom tab data as json")
@@ -540,29 +504,25 @@ public class ApiProjectV2Controller extends CoTopComponent {
 
         Map<String, Object> resultMap = new HashMap<String, Object>();
 
-        try {
-            List<String> prjIdList = new ArrayList<String>();
-            prjIdList.add(prjId);
+        List<String> prjIdList = new ArrayList<String>();
+        prjIdList.add(prjId);
 
-            Map<String, Object> paramMap = new HashMap<String, Object>();
-            paramMap.put("userId", userInfo.getUserId());
-            paramMap.put("userRole", userRole(userInfo));
-            paramMap.put("prjId", prjIdList);
-            paramMap.put("distributionType", "normal");
+        Map<String, Object> paramMap = new HashMap<String, Object>();
+        paramMap.put("userId", userInfo.getUserId());
+        paramMap.put("userRole", userRole(userInfo));
+        paramMap.put("prjId", prjIdList);
+        paramMap.put("distributionType", "normal");
 
-            boolean searchFlag = apiProjectService.existProjectCnt(paramMap);
+        boolean searchFlag = apiProjectService.existProjectCnt(paramMap);
 
-            if (searchFlag) {
-                resultMap = apiProjectService.getBomExportJson(prjId);
-                if (CoConstDef.FLAG_YES.equals(saveFlag)) {
-                    apiProjectService.registBom(prjId, saveFlag, userInfo.getUserId());
-                    projectService.updateSecurityDataForProject(prjId);
-                }
+        if (searchFlag) {
+            resultMap = apiProjectService.getBomExportJson(prjId);
+            if (CoConstDef.FLAG_YES.equals(saveFlag)) {
+                apiProjectService.registBom(prjId, saveFlag, userInfo.getUserId());
+                projectService.updateSecurityDataForProject(prjId);
             }
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.BAD_REQUEST);
         }
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 
     @ApiOperation(value = "Project Bom Compare", notes = "Project > Bom tab Compare")
@@ -587,9 +547,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
         T2Users userInfo = userService.checkApiUserAuth(authorization);
         Map<String, Object> resultMap = new HashMap<>();
 
-        try {
-
-            Map<String, Object> paramMap = new HashMap<>();
+        Map<String, Object> paramMap = new HashMap<>();
 
             if (!isEmpty(beforePrjId) && beforePrjId.equals(afterPrjId)) {
                 paramMap.put("status", "same");
@@ -628,7 +586,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
                 }
 
                 if (beforeBomList.isEmpty() || afterBomList.isEmpty()) {
-                    throw new Exception();
+                    return responseService.errorResponse(HttpStatus.BAD_REQUEST);
                 }
 
                 resultMap.put("contents", apiProjectService.getBomCompare(beforeBomList, afterBomList));
@@ -640,9 +598,6 @@ public class ApiProjectV2Controller extends CoTopComponent {
                 resultMap.put("contents", paramMap);
                 return new ResponseEntity<>(resultMap, HttpStatus.OK);
             }
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.BAD_REQUEST);
-        }
     }
 
     @ApiOperation(value = "Reset specific identification tab", notes = "Identification > reset")
@@ -727,8 +682,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
             throw new CProjectNotAvailableException(String.format("%s. Check Permission or Project Status", prjId));
         }
 
-        try {
-            String oldFileId = "";
+        String oldFileId = "";
 //            if (CoConstDef.FLAG_NO.equals(avoidNull(resetFlag))) {
 //                Map<String, Object> prjInfo = apiProjectService.selectProjectMaster(prjId);
 //                if (prjInfo.get(tabName.toLowerCase() + "CsvFileId") != null) {
@@ -847,7 +801,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
                 projectService.updateSecurityDataForProject(prjId);
             }
 
-            if (!resultMap.containsKey(KEY_ERROR_MESSAGE) && !resultMap.containsKey(KEY_VALID_ERROR)) {
+        if (!resultMap.containsKey(KEY_ERROR_MESSAGE) && !resultMap.containsKey(KEY_VALID_ERROR)) {
                 // 정상처리된 경우 세션 삭제
                 switch (tabName) {
                     case "DEP":
@@ -866,19 +820,16 @@ public class ApiProjectV2Controller extends CoTopComponent {
 
                 resultMap.put("success", true);
                 return new ResponseEntity<>(resultMap, HttpStatus.OK);
+        } else {
+            if (resultMap.containsKey(CoConstDef.CD_OPEN_API_FILE_DATA_EMPTY_MESSAGE)) {
+                return responseService.errorResponse(HttpStatus.BAD_REQUEST, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_FILE_DATA_EMPTY_MESSAGE));
+            } else if (resultMap.containsKey(KEY_VALID_ERROR)) {
+                return responseService.errorResponse(HttpStatus.BAD_REQUEST, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_DATA_VALIDERROR_MESSAGE));
+            } else if (resultMap.containsKey(KEY_ERROR_MESSAGE)) {
+                return responseService.errorResponse(HttpStatus.BAD_REQUEST, (String) resultMap.get(KEY_ERROR_MESSAGE));
             } else {
-                if (resultMap.containsKey(CoConstDef.CD_OPEN_API_FILE_DATA_EMPTY_MESSAGE)) {
-                    return responseService.errorResponse(HttpStatus.BAD_REQUEST, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_FILE_DATA_EMPTY_MESSAGE));
-                } else if (resultMap.containsKey(KEY_VALID_ERROR)) {
-                    return responseService.errorResponse(HttpStatus.BAD_REQUEST, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_DATA_VALIDERROR_MESSAGE));
-                } else if (resultMap.containsKey(KEY_ERROR_MESSAGE)) {
-                    return responseService.errorResponse(HttpStatus.BAD_REQUEST, (String) resultMap.get(KEY_ERROR_MESSAGE));
-                } else {
-                    return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE));
-                }
+                return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE));
             }
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -956,9 +907,8 @@ public class ApiProjectV2Controller extends CoTopComponent {
             throw new CProjectNotAvailableException(String.format("%s. Check Permission or Project Status", prjId));
         }
 
-        try {
-            // 1. Parse tabSheetMapping JSON
-            Map<String, List<String>> tabSheetMap = null;
+        // 1. Parse tabSheetMapping JSON
+        Map<String, List<String>> tabSheetMap = null;
             try {
                 Type mapType = new TypeToken<Map<String, List<String>>>() {
                 }.getType();
@@ -1335,11 +1285,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
             resultMap.put("uploaded", uploadedList);
             resultMap.put("error", errorList);
 
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 
     @SuppressWarnings("unchecked")
@@ -1495,29 +1441,24 @@ public class ApiProjectV2Controller extends CoTopComponent {
             throw new CProjectNotAvailableException(String.format("%s. Check Permission or Project Status", prjId));
         }
 
-        try {
-            if (idList == null) {
-                return responseService.errorResponse(HttpStatus.BAD_REQUEST, "Editor ID list is required.");
-            }
-
-            for (String id : idList) {
-                T2Users targetUser = new T2Users();
-                targetUser.setUserId(id);
-                T2Users existingUser = userService.getUser(targetUser);
-                if (existingUser == null) {
-                    return responseService.errorResponse(HttpStatus.NOT_FOUND, "User not found in FOSSLight Hub. User ID: " + id);
-                }
-                Map<String, Object> param = new HashMap<>();
-                param.put("prjId", prjId);
-                param.put("division", existingUser.getDivision());
-                param.put("userId", existingUser.getUserId());
-                apiProjectService.insertWatcher(param);
-            }
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.BAD_REQUEST,
-                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+        if (idList == null) {
+            return responseService.errorResponse(HttpStatus.BAD_REQUEST, "Editor ID list is required.");
         }
+
+        for (String id : idList) {
+            T2Users targetUser = new T2Users();
+            targetUser.setUserId(id);
+            T2Users existingUser = userService.getUser(targetUser);
+            if (existingUser == null) {
+                return responseService.errorResponse(HttpStatus.NOT_FOUND, "User not found in FOSSLight Hub. User ID: " + id);
+            }
+            Map<String, Object> param = new HashMap<>();
+            param.put("prjId", prjId);
+            param.put("division", existingUser.getDivision());
+            param.put("userId", existingUser.getUserId());
+            apiProjectService.insertWatcher(param);
+        }
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 
     @ApiOperation(value = "Project Add Security Responsible Person", notes = "Project Add Security Responsible Person")
@@ -1692,35 +1633,31 @@ public class ApiProjectV2Controller extends CoTopComponent {
             @ApiParam(hidden = true) @RequestHeader String authorization,
             @ApiParam(value = "project ID", required = false) @PathVariable(required = true, name = "id") String prjId,
             HttpServletRequest req
-    ) {
+    ) throws Exception {
 
         T2Users userInfo = userService.checkApiUserAuth(authorization);
         if (!apiProjectService.checkUserHasProject(userInfo, prjId)) {
             throw new CProjectNotAvailableException(prjId);
         }
 
-        try {
-            OssNotice ossNotice = verificationService.selectOssNoticeOne(prjId);
+        OssNotice ossNotice = verificationService.selectOssNoticeOne(prjId);
 
-            if (ossNotice == null) {
-                return responseService.errorResponse(HttpStatus.NOT_FOUND, "Notice has not been published for given project.");
-            }
-
-            var downloadId = verificationService.getNoticeHtmlFileForPreview(ossNotice);
-
-            T2File fileInfo = fileService.selectFileInfo(downloadId);
-            String filePath = fileInfo.getLogiPath();
-
-            if (!filePath.endsWith("/")) {
-                filePath += "/";
-            }
-
-            filePath += fileInfo.getLogiNm();
-
-            return excelToResponseEntity(filePath, fileInfo.getOrigNm());
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().build();
+        if (ossNotice == null) {
+            return responseService.errorResponse(HttpStatus.NOT_FOUND, "Notice has not been published for given project.");
         }
+
+        var downloadId = verificationService.getNoticeHtmlFileForPreview(ossNotice);
+
+        T2File fileInfo = fileService.selectFileInfo(downloadId);
+        String filePath = fileInfo.getLogiPath();
+
+        if (!filePath.endsWith("/")) {
+            filePath += "/";
+        }
+
+        filePath += fileInfo.getLogiNm();
+
+        return excelToResponseEntity(filePath, fileInfo.getOrigNm());
     }
 
 
@@ -1750,8 +1687,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
             throw new CProjectNotAvailableException(String.format("%s. Check Permission or Project Status", targetPrjId));
         }
 
-        try {
-            Map<String, Object> paramMap = new HashMap<>();
+        Map<String, Object> paramMap = new HashMap<>();
 
             // Parameter validation check:
             if (!StringUtils.isEmpty(targetPrjId) && !targetPrjId.chars().allMatch(Character::isDigit)) {
@@ -1810,12 +1746,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
                 return responseService.errorResponse(HttpStatus.BAD_REQUEST, (String) resultMap.get("msg"));
             }
 
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 
     @ApiOperation(value = "Delete Target Project", notes = "Delete Project'")

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiSelfCheckV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiSelfCheckV2Controller.java
@@ -92,28 +92,23 @@ public class ApiSelfCheckV2Controller extends CoTopComponent {
         T2Users userInfo = userService.checkApiUserAuth(authorization);
         Map<String, Object> result = new HashMap<String, Object>();
 
-        try {
-            int createCnt = apiSelfCheckService.getCreateProjectCnt(userInfo.getUserId());
+        int createCnt = apiSelfCheckService.getCreateProjectCnt(userInfo.getUserId());
 
-            if (CoConstDef.CD_OPEN_API_CREATE_PROJECT_LIMIT <= createCnt) {
-                return responseService.errorResponse(HttpStatus.BAD_REQUEST,
-                        CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_CREATE_OVERFLOW_MESSAGE));
-            }
-            Map<String, Object> paramMap = new HashMap<String, Object>();
+        if (CoConstDef.CD_OPEN_API_CREATE_PROJECT_LIMIT <= createCnt) {
+            return responseService.errorResponse(HttpStatus.BAD_REQUEST,
+                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_CREATE_OVERFLOW_MESSAGE));
+        }
+        Map<String, Object> paramMap = new HashMap<String, Object>();
 
-            paramMap.put("prjName", prjName);
-            paramMap.put("prjVersion", avoidNull(prjVersion, ""));
-            paramMap.put("loginUserName", userInfo.getUserId());
+        paramMap.put("prjName", prjName);
+        paramMap.put("prjVersion", avoidNull(prjVersion, ""));
+        paramMap.put("loginUserName", userInfo.getUserId());
 
-            result = apiSelfCheckService.createSelfCheck(paramMap);
-            String prjId = (String) result.get("prjId");
+        result = apiSelfCheckService.createSelfCheck(paramMap);
+        String prjId = (String) result.get("prjId");
 
-            if (isEmpty(prjId)) {
-                throw new Exception(); // parameter Error -> create Failure
-            }
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
-                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+        if (isEmpty(prjId)) {
+            throw new IllegalStateException("Failed to create self check project.");
         }
 
         return new ResponseEntity<>(result, HttpStatus.OK);
@@ -127,141 +122,134 @@ public class ApiSelfCheckV2Controller extends CoTopComponent {
             @ApiParam(value = "Project id", required = true) @PathVariable(name = "id", required = true) String prjId,
             @ApiParam(value = "OSS Report > sheetName : 'Start with Self-Check, SRC or BIN '") @RequestPart(required = false) MultipartFile ossReport,
             @ApiParam(value = "Reset Flag (YES : Y, NO : N)", allowableValues = "Y,N") @RequestParam(required = false, defaultValue="Y") String resetFlag,
-            @ApiParam(value = "Sheet Names") @RequestParam(required = false) String sheetNames) {
+            @ApiParam(value = "Sheet Names") @RequestParam(required = false) String sheetNames) throws Exception {
 
         T2Users userInfo = userService.checkApiUserAuth(authorization);
         Map<String, Object> resultMap = new HashMap<String, Object>(); // 성공, 실패에 대한 정보를 return하기 위한 map;
 
-        try {
-            Map<String, Object> paramMap = new HashMap<>();
-            paramMap.put("userId", userInfo.getUserId());
-            paramMap.put("userRole", userRole(userInfo));
-            paramMap.put("prjId", prjId);
-            boolean searchFlag = apiSelfCheckService.existProjectCnt(paramMap); // 조회가 안된다면 권한이 없는 project id를 입력함.
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put("userId", userInfo.getUserId());
+        paramMap.put("userRole", userRole(userInfo));
+        paramMap.put("prjId", prjId);
+        boolean searchFlag = apiSelfCheckService.existProjectCnt(paramMap); // 조회가 안된다면 권한이 없는 project id를 입력함.
 
-            if (!searchFlag) {
+        if (!searchFlag) {
 
-                return responseService.errorResponse(HttpStatus.FORBIDDEN,
-                        CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
+            return responseService.errorResponse(HttpStatus.FORBIDDEN,
+                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
+        }
+        String oldFileId = "";
+        if (CoConstDef.FLAG_NO.equals(avoidNull(resetFlag))) {
+            Map<String, Object> prjInfo = apiSelfCheckService.selectProjectMaster(prjId);
+            if (prjInfo.get("srcCsvFileId") != null) {
+                oldFileId = String.valueOf((int) prjInfo.get("srcCsvFileId"));
             }
-            String oldFileId = "";
-            if (CoConstDef.FLAG_NO.equals(avoidNull(resetFlag))) {
-                Map<String, Object> prjInfo = apiSelfCheckService.selectProjectMaster(prjId);
-                if (prjInfo.get("srcCsvFileId") != null) {
-                    oldFileId = String.valueOf((int) prjInfo.get("srcCsvFileId"));
-                }
-            }
+        }
 
-            if (ossReport == null) {
-                return responseService.errorResponse(HttpStatus.BAD_REQUEST,
-                        CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
-            }
-            UploadFile bean = null;
-            if (!isEmpty(oldFileId)) {
-                bean = apiFileService.uploadFile(ossReport, null, oldFileId);
-            } else {
-                bean = apiFileService.uploadFile(ossReport); // file 등록 처리 이후 upload된 file정보를 return함.
-            }
+        if (ossReport == null) {
+            return responseService.errorResponse(HttpStatus.BAD_REQUEST,
+                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+        }
+        UploadFile bean = null;
+        if (!isEmpty(oldFileId)) {
+            bean = apiFileService.uploadFile(ossReport, null, oldFileId);
+        } else {
+            bean = apiFileService.uploadFile(ossReport); // file 등록 처리 이후 upload된 file정보를 return함.
+        }
 
-            List<UploadFile> list = new ArrayList<UploadFile>();
-            list.add(bean);
-            ArrayList<Object> checkFileLimit = null;
-            if (bean.getFileExt().contains("csv")) {
-                checkFileLimit = CommonFunction.checkCsvFileLimit(list);
-            } else {
-                checkFileLimit = CommonFunction.checkXlsxFileLimit(list);
-            }
+        List<UploadFile> list = new ArrayList<UploadFile>();
+        list.add(bean);
+        ArrayList<Object> checkFileLimit = null;
+        if (bean.getFileExt().contains("csv")) {
+            checkFileLimit = CommonFunction.checkCsvFileLimit(list);
+        } else {
+            checkFileLimit = CommonFunction.checkXlsxFileLimit(list);
+        }
 
-            if (checkFileLimit != null && checkFileLimit.contains("FILE_SIZE_LIMIT_OVER")) {
-                return responseService.errorResponse(HttpStatus.PAYLOAD_TOO_LARGE,
-                        CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_FILE_SIZEOVER_MESSAGE));
-            }
+        if (checkFileLimit != null && checkFileLimit.contains("FILE_SIZE_LIMIT_OVER")) {
+            return responseService.errorResponse(HttpStatus.PAYLOAD_TOO_LARGE,
+                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_FILE_SIZEOVER_MESSAGE));
+        }
 
 //					if (ossReport.getOriginalFilename().contains("xls") // 확장자 xls, xlsx, xlsm 허용
 //							&& CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT > bean.getSize()) { // file size 5MB 이하만 허용.
 
-            if (CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT <= bean.getSize()) {
-                return responseService.errorResponse(HttpStatus.PAYLOAD_TOO_LARGE,
-                        CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_FILE_SIZEOVER_MESSAGE));
-            }
+        if (CoConstDef.CD_XLSX_UPLOAD_FILE_SIZE_LIMIT <= bean.getSize()) {
+            return responseService.errorResponse(HttpStatus.PAYLOAD_TOO_LARGE,
+                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_FILE_SIZEOVER_MESSAGE));
+        }
 //					UploadFile bean = apiFileService.uploadFile(ossReport); // file 등록 처리 이후 upload된 file정보를 return함.
 
-            List<String> sheetList = new ArrayList<>();
-            boolean sheetNamesEmptyFlag = isEmpty(sheetNames) ? true : false;
+        List<String> sheetList = new ArrayList<>();
+        boolean sheetNamesEmptyFlag = isEmpty(sheetNames) ? true : false;
 
-            if (sheetNamesEmptyFlag) {
-                List<Object> sheets = ExcelUtil.getSheetNames(list, CommonFunction.emptyCheckProperty("upload.path", "/upload"));
-                for (Object obj : sheets) {
-                    Map<String, Object> sheetMap = (Map<String, Object>) obj;
-                    if (sheetMap.containsKey("name")) {
-                        sheetList.add((String) sheetMap.get("name"));
-                    }
+        if (sheetNamesEmptyFlag) {
+            List<Object> sheets = ExcelUtil.getSheetNames(list, CommonFunction.emptyCheckProperty("upload.path", "/upload"));
+            for (Object obj : sheets) {
+                Map<String, Object> sheetMap = (Map<String, Object>) obj;
+                if (sheetMap.containsKey("name")) {
+                    sheetList.add((String) sheetMap.get("name"));
+                }
+            }
+        } else {
+            if (sheetNames.contains(",")) {
+                for (String sheetName : sheetNames.split(",")) {
+                    if (!isEmpty(sheetName.trim())) sheetList.add(sheetName.trim());
                 }
             } else {
-                if (sheetNames.contains(",")) {
-                    for (String sheetName : sheetNames.split(",")) {
-                        if (!isEmpty(sheetName.trim())) sheetList.add(sheetName.trim());
+                sheetList.add(sheetNames);
+            }
+        }
+
+        String[] sheet = sheetList.toArray(new String[sheetList.size()]);
+        Map<String, Object> rtnMap = null;
+        List<ProjectIdentification> ossComponentList = new ArrayList<>();
+        List<List<ProjectIdentification>> ossComponentsLicenseList = new ArrayList<>();
+
+        for (String sheetNm : sheetList) {
+            Map<String, Object> result = apiProjectService.getSheetData(bean, prjId, sheetNm, sheet, sheetNamesEmptyFlag);
+            resultMap = getSheetDataResult(result);
+
+            if (!resultMap.isEmpty()) {
+                rtnMap = resultMap;
+                if (rtnMap.containsKey(CoConstDef.CD_OPEN_API_FILE_DATA_EMPTY_MESSAGE) ||
+                        rtnMap.containsKey(KEY_ERROR_MESSAGE)) {
+                    rtnMap = null;
+                    continue;
+                } else if (rtnMap.containsKey("ossComponents")) {
+                    ossComponentList.addAll((List<ProjectIdentification>) rtnMap.get("ossComponents"));
+                    List<List<ProjectIdentification>> ossComponentsLicenses = (List<List<ProjectIdentification>>) rtnMap.get("ossComponentsLicense");
+                    if (!ossComponentsLicenses.isEmpty()) {
+                        ossComponentsLicenseList.addAll(ossComponentsLicenses);
                     }
                 } else {
-                    sheetList.add(sheetNames);
+                    break;
                 }
             }
-
-            String[] sheet = sheetList.toArray(new String[sheetList.size()]);
-            Map<String, Object> rtnMap = null;
-            List<ProjectIdentification> ossComponentList = new ArrayList<>();
-            List<List<ProjectIdentification>> ossComponentsLicenseList = new ArrayList<>();
-
-            for (String sheetNm : sheetList) {
-                Map<String, Object> result = apiProjectService.getSheetData(bean, prjId, sheetNm, sheet, sheetNamesEmptyFlag);
-                resultMap = getSheetDataResult(result);
-
-                if (!resultMap.isEmpty()) {
-                    rtnMap = resultMap;
-                    if (rtnMap.containsKey(CoConstDef.CD_OPEN_API_FILE_DATA_EMPTY_MESSAGE) ||
-                            rtnMap.containsKey(KEY_ERROR_MESSAGE)) {
-                        rtnMap = null;
-                        continue;
-                    } else if (rtnMap.containsKey("ossComponents")) {
-                        ossComponentList.addAll((List<ProjectIdentification>) rtnMap.get("ossComponents"));
-                        List<List<ProjectIdentification>> ossComponentsLicenses = (List<List<ProjectIdentification>>) rtnMap.get("ossComponentsLicense");
-                        if (!ossComponentsLicenses.isEmpty()) {
-                            ossComponentsLicenseList.addAll(ossComponentsLicenses);
-                        }
-                    } else {
-                        break;
-                    }
-                }
-            }
-
-            if (rtnMap != null && rtnMap.containsKey(KEY_VALID_ERROR)) {
-                return responseService.errorResponse(HttpStatus.UNPROCESSABLE_ENTITY, getMessage("api.dataValidationError.msg")); // data validation error
-            }
-
-            if (!ossComponentList.isEmpty()) {
-                rtnMap = null;
-
-                if (CoConstDef.FLAG_NO.equals(avoidNull(resetFlag))) {
-                    apiSelfCheckService.getIdentificationGridList(prjId, CoConstDef.CD_DTL_SELF_COMPONENT_ID, ossComponentList, ossComponentsLicenseList);
-                }
-
-                Project project = new Project();
-                project.setPrjId(prjId);
-                project.setSrcCsvFileId(bean.getRegistFileId()); // set file id
-                selfCheckService.registSrcOss(ossComponentList, ossComponentsLicenseList, project);
-
-                // 정상처리된 경우 세션 삭제
-                deleteSession(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.CD_DTL_COMPONENT_ID_SRC, prjId));
-                deleteSession(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_UPLOAD_REPORT_PROJECT_SRC, prjId));
-            }
-
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
-                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE));
         }
+
+        if (rtnMap != null && rtnMap.containsKey(KEY_VALID_ERROR)) {
+            return responseService.errorResponse(HttpStatus.UNPROCESSABLE_ENTITY, getMessage("api.dataValidationError.msg")); // data validation error
+        }
+
+        if (!ossComponentList.isEmpty()) {
+            rtnMap = null;
+
+            if (CoConstDef.FLAG_NO.equals(avoidNull(resetFlag))) {
+                apiSelfCheckService.getIdentificationGridList(prjId, CoConstDef.CD_DTL_SELF_COMPONENT_ID, ossComponentList, ossComponentsLicenseList);
+            }
+
+            Project project = new Project();
+            project.setPrjId(prjId);
+            project.setSrcCsvFileId(bean.getRegistFileId()); // set file id
+            selfCheckService.registSrcOss(ossComponentList, ossComponentsLicenseList, project);
+
+            // 정상처리된 경우 세션 삭제
+            deleteSession(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.CD_DTL_COMPONENT_ID_SRC, prjId));
+            deleteSession(CommonFunction.makeSessionKey(loginUserName(), CoConstDef.SESSION_KEY_UPLOAD_REPORT_PROJECT_SRC, prjId));
+        }
+
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 
     @SuppressWarnings("unchecked")
@@ -315,28 +303,23 @@ public class ApiSelfCheckV2Controller extends CoTopComponent {
             @ApiParam(value = "Project id", required = true) @PathVariable(name = "id", required = true) String prjId,
             @ApiParam(value = "Format", allowableValues = "Spreadsheet")
             @ValuesAllowed(propName = "format", values = { "Spreadsheet"}) @RequestParam String format
-    ) {
+    ) throws Exception {
         String downloadId = "";
         T2File fileInfo = new T2File();
 
-        try {
-            T2Users userInfo = userService.checkApiUserAuth(authorization);
-            Map<String, Object> paramMap = new HashMap<>();
-            paramMap.put("userId", userInfo.getUserId());
-            paramMap.put("userRole", userRole(userInfo));
-            paramMap.put("prjId", prjId);
-            boolean searchFlag = apiSelfCheckService.existProjectCnt(paramMap); // 조회가 안된다면 권한이 없는 project id를 입력함.
-            if (searchFlag) {
-                downloadId = ExcelDownLoadUtil.getExcelDownloadId("selfReport", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
-                fileInfo = fileService.selectFileInfo(downloadId);
+        T2Users userInfo = userService.checkApiUserAuth(authorization);
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put("userId", userInfo.getUserId());
+        paramMap.put("userRole", userRole(userInfo));
+        paramMap.put("prjId", prjId);
+        boolean searchFlag = apiSelfCheckService.existProjectCnt(paramMap); // 조회가 안된다면 권한이 없는 project id를 입력함.
+        if (searchFlag) {
+            downloadId = ExcelDownLoadUtil.getExcelDownloadId("selfReport", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
+            fileInfo = fileService.selectFileInfo(downloadId);
 
-                return excelToResponseEntity(fileInfo.getLogiPath() + fileInfo.getLogiNm(), fileInfo.getOrigNm());
-            } else {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-            }
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return ResponseEntity.internalServerError().build();
+            return excelToResponseEntity(fileInfo.getLogiPath() + fileInfo.getLogiNm(), fileInfo.getOrigNm());
+        } else {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
     }
 
@@ -350,46 +333,41 @@ public class ApiSelfCheckV2Controller extends CoTopComponent {
         Map<String, Object> resultMap = new HashMap<>();
         String errorCode = CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE; // Default error message
 
-        try {
-            T2Users userInfo = userService.checkApiUserAuth(authorization);
-            Map<String, Object> paramMap = new HashMap<>();
-            paramMap.put("userId", userInfo.getUserId());
-            paramMap.put("userRole", userRole(userInfo));
-            paramMap.put("prjId", prjId);
+        T2Users userInfo = userService.checkApiUserAuth(authorization);
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put("userId", userInfo.getUserId());
+        paramMap.put("userRole", userRole(userInfo));
+        paramMap.put("prjId", prjId);
 
-            boolean searchFlag = apiSelfCheckService.existProjectCnt(paramMap);
-            if (!searchFlag) {
-                return responseService.errorResponse(HttpStatus.FORBIDDEN, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
+        boolean searchFlag = apiSelfCheckService.existProjectCnt(paramMap);
+        if (!searchFlag) {
+            return responseService.errorResponse(HttpStatus.FORBIDDEN, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
+        }
+        if (emailList == null) {
+            return responseService.errorResponse(HttpStatus.BAD_REQUEST, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+        }
+
+        for (String email : emailList) {
+            boolean ldapCheck = true;
+            if (CoConstDef.FLAG_YES.equals(avoidNull(CommonFunction.getProperty("ldap.check.flag")))) {
+                ldapCheck = apiProjectService.existLdapUserToEmail(email);
             }
-            if (emailList == null) {
+            if (!ldapCheck) {
+                return responseService.errorResponse(HttpStatus.NOT_FOUND, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_USER_NOTFOUND_MESSAGE));
+            }
+            boolean watcherFlag = apiSelfCheckService.existsWatcherByEmail(prjId, email);
+            if (!watcherFlag) {
                 return responseService.errorResponse(HttpStatus.BAD_REQUEST, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
             }
-
-            for (String email : emailList) {
-                boolean ldapCheck = true;
-                if (CoConstDef.FLAG_YES.equals(avoidNull(CommonFunction.getProperty("ldap.check.flag")))) {
-                    ldapCheck = apiProjectService.existLdapUserToEmail(email);
-                }
-                if (!ldapCheck) {
-                    return responseService.errorResponse(HttpStatus.NOT_FOUND, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_USER_NOTFOUND_MESSAGE));
-                }
-                boolean watcherFlag = apiSelfCheckService.existsWatcherByEmail(prjId, email);
-                if (!watcherFlag) {
-                    return responseService.errorResponse(HttpStatus.BAD_REQUEST, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
-                }
-                Map<String, Object> param = new HashMap<>();
-                param.put("prjId", prjId);
-                param.put("division", "");
-                param.put("userId", "");
-                param.put("email", email);
-                apiSelfCheckService.insertWatcher(param);
-            }
-
-            return ResponseEntity.ok(resultMap);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.BAD_REQUEST,
-                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+            Map<String, Object> param = new HashMap<>();
+            param.put("prjId", prjId);
+            param.put("division", "");
+            param.put("userId", "");
+            param.put("email", email);
+            apiSelfCheckService.insertWatcher(param);
         }
+
+        return ResponseEntity.ok(resultMap);
     }
 
     @ApiOperation(value = "SelfCheck Get", notes = "SelfCheck Get")
@@ -400,23 +378,18 @@ public class ApiSelfCheckV2Controller extends CoTopComponent {
 
         Map<String, Object> resultMap = new HashMap<>();
 
-        try {
-            T2Users userInfo = userService.checkApiUserAuth(authorization);
-            Map<String, Object> paramMap = new HashMap<>();
-            paramMap.put("userId", userInfo.getUserId());
-            paramMap.put("userRole", userRole(userInfo));
-            paramMap.put("prjId", prjId);
+        T2Users userInfo = userService.checkApiUserAuth(authorization);
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put("userId", userInfo.getUserId());
+        paramMap.put("userRole", userRole(userInfo));
+        paramMap.put("prjId", prjId);
 
-            boolean searchFlag = apiSelfCheckService.existProjectCnt(paramMap);
-            if (!searchFlag) {
-                return responseService.errorResponse(HttpStatus.FORBIDDEN, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
-            }
-            var selfCheck = apiSelfCheckService.selectProjectMaster(prjId);
-            resultMap.put("content", selfCheck);
-            return ResponseEntity.ok(resultMap);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.BAD_REQUEST,
-                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PARAMETER_ERROR_MESSAGE));
+        boolean searchFlag = apiSelfCheckService.existProjectCnt(paramMap);
+        if (!searchFlag) {
+            return responseService.errorResponse(HttpStatus.FORBIDDEN, CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_PERMISSION_ERROR_MESSAGE));
         }
+        var selfCheck = apiSelfCheckService.selectProjectMaster(prjId);
+        resultMap.put("content", selfCheck);
+        return ResponseEntity.ok(resultMap);
     }
 }

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiSelfCheckV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiSelfCheckV2Controller.java
@@ -317,6 +317,10 @@ public class ApiSelfCheckV2Controller extends CoTopComponent {
             downloadId = ExcelDownLoadUtil.getExcelDownloadId("selfReport", prjId, RESOURCE_PUBLIC_DOWNLOAD_EXCEL_PATH_PREFIX);
             fileInfo = fileService.selectFileInfo(downloadId);
 
+            if (fileInfo == null) {
+                return responseService.errorResponse(HttpStatus.NOT_FOUND, "File not found.");
+            }
+
             return excelToResponseEntity(fileInfo.getLogiPath() + fileInfo.getLogiNm(), fileInfo.getOrigNm());
         } else {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiVulnerabilityV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiVulnerabilityV2Controller.java
@@ -56,27 +56,22 @@ public class ApiVulnerabilityV2Controller extends CoTopComponent {
         userService.checkApiUserAuth(authorization);
         Map<String, Object> resultMap = new HashMap<String, Object>();
 
-        try {
-            // ossName과 cveId 둘 다 입력하지 않을 경우 에러 처리
-            if (isEmpty(ossName) && isEmpty(cveId)) {
-                return responseService.errorResponse(HttpStatus.BAD_REQUEST, "Either ossName or cveId is required");
-            }
-
-            if (isEmpty(ossVersion)) { // ossVersion을 입력하지 않을 경우 전체 검색으로 처리함.
-                ossVersion = "-";
-            }
-
-            List<Map<String, Object>> content = apiVulnerabilityService.selectNvdList(ossName, ossVersion, cveId);
-
-            if (content.size() > 0) {
-                resultMap.put("content", content);
-            }
-
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
-                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE));
+        // ossName과 cveId 둘 다 입력하지 않을 경우 에러 처리
+        if (isEmpty(ossName) && isEmpty(cveId)) {
+            return responseService.errorResponse(HttpStatus.BAD_REQUEST, "Either ossName or cveId is required");
         }
+
+        if (isEmpty(ossVersion)) { // ossVersion을 입력하지 않을 경우 전체 검색으로 처리함.
+            ossVersion = "-";
+        }
+
+        List<Map<String, Object>> content = apiVulnerabilityService.selectNvdList(ossName, ossVersion, cveId);
+
+        if (content.size() > 0) {
+            resultMap.put("content", content);
+        }
+
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 
     @ApiOperation(value = "Search Vulnerability Max Score Info", notes = "Search NVD Max Score Data")
@@ -90,21 +85,17 @@ public class ApiVulnerabilityV2Controller extends CoTopComponent {
         userService.checkApiUserAuth(authorization);
         Map<String, Object> resultMap = new HashMap<String, Object>();
 
-        try {
-            if (isEmpty(ossVersion)) { // ossVersion을 입력하지 않을 경우 전체 검색으로 처리함.
-                ossVersion = "-";
-            }
-
-            List<Map<String, Object>> content = apiVulnerabilityService.selectMaxScoreNvdInfo(ossName, ossVersion);
-
-            if (content.size() > 0) {
-                resultMap.put("content", content);
-            }
-
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR);
+        if (isEmpty(ossVersion)) { // ossVersion을 입력하지 않을 경우 전체 검색으로 처리함.
+            ossVersion = "-";
         }
+
+        List<Map<String, Object>> content = apiVulnerabilityService.selectMaxScoreNvdInfo(ossName, ossVersion);
+
+        if (content.size() > 0) {
+            resultMap.put("content", content);
+        }
+
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 
     @ApiOperation(value = "Search CVE IDs by Email Send Date", notes = "Get CVE IDs from discovered OSS vulnerability notification emails")
@@ -119,27 +110,22 @@ public class ApiVulnerabilityV2Controller extends CoTopComponent {
         Map<String, Object> resultMap = new HashMap<String, Object>();
 
         try {
-            try {
-                LocalDate.parse(sendDate);
-            } catch (DateTimeParseException e) {
-                return responseService.errorResponse(HttpStatus.BAD_REQUEST,
-                        "Invalid sendDate format. Expected YYYY-MM-DD (e.g. 2024-01-31).");
-            }
-
-            Map<String, List<Map<String, String>>> cveOssMap = apiVulnerabilityService.selectCveIdsBySendDate(sendDate, isAfterDate);
-            List<Map<String, List<Map<String, String>>>> cveOssList = new ArrayList<>();
-            if (!cveOssMap.isEmpty()) {
-                cveOssList.add(cveOssMap);
-            }
-
-            resultMap.put("success", true);
-            resultMap.put("count", cveOssMap.size());
-            resultMap.put("list", cveOssList);
-
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            return responseService.errorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
-                    CoCodeManager.getCodeString(CoConstDef.CD_OPEN_API_MESSAGE, CoConstDef.CD_OPEN_API_UNKNOWN_ERROR_MESSAGE));
+            LocalDate.parse(sendDate);
+        } catch (DateTimeParseException e) {
+            return responseService.errorResponse(HttpStatus.BAD_REQUEST,
+                    "Invalid sendDate format. Expected YYYY-MM-DD (e.g. 2024-01-31).");
         }
+
+        Map<String, List<Map<String, String>>> cveOssMap = apiVulnerabilityService.selectCveIdsBySendDate(sendDate, isAfterDate);
+        List<Map<String, List<Map<String, String>>>> cveOssList = new ArrayList<>();
+        if (!cveOssMap.isEmpty()) {
+            cveOssList.add(cveOssMap);
+        }
+
+        resultMap.put("success", true);
+        resultMap.put("count", cveOssMap.size());
+        resultMap.put("list", cveOssList);
+
+        return new ResponseEntity<>(resultMap, HttpStatus.OK);
     }
 }

--- a/src/main/java/oss/fosslight/config/SwaggerConfig.java
+++ b/src/main/java/oss/fosslight/config/SwaggerConfig.java
@@ -7,9 +7,19 @@ package oss.fosslight.config;
 
 import java.util.*;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -20,27 +30,87 @@ import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger.web.InMemorySwaggerResourcesProvider;
 import springfox.documentation.swagger.web.SwaggerResource;
 import springfox.documentation.swagger.web.SwaggerResourcesProvider;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+@Slf4j
 @Configuration
 @EnableSwagger2
-public class SwaggerConfig {
-	private static final Set<String> DEFAULT_PRODUCES_AND_CONSUMES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("application/json")));
+@RequiredArgsConstructor
+public class SwaggerConfig implements WebMvcConfigurer {
+    private static final Set<String> DEFAULT_PRODUCES_AND_CONSUMES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("application/json")));
     private static final String REFERENCE = "authorization header value";
 
+    /** Swagger group name exposed to every user (external + internal). */
+    private static final String GROUP_V2 = "v2";
+    /** Swagger group name exposed only to authenticated ROLE_ADMIN users. */
+    private static final String GROUP_V2_INTERNAL = "v2-internal";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final SwaggerInternalGroupInterceptor swaggerInternalGroupInterceptor;
+
+    /**
+     * Public API group. Excludes any endpoint/controller annotated with
+     * {@link oss.fosslight.api.annotation.InternalApi @InternalApi} so that internal-only
+     * APIs are hidden from external users.
+     */
     @Bean
     Docket swaggerApiV2() {
         return new Docket(DocumentationType.SWAGGER_2).apiInfo(swaggerInfo())
                 .consumes(DEFAULT_PRODUCES_AND_CONSUMES).produces(DEFAULT_PRODUCES_AND_CONSUMES).select()
-                .apis(RequestHandlerSelectors.basePackage(AppConstBean.APP_COMPONENT_SCAN_PACKAGE+".api.controller"))
+                .apis(RequestHandlerSelectors.basePackage(AppConstBean.APP_COMPONENT_SCAN_PACKAGE + ".api.controller")
+                        .and(notInternalApi()))
                 .paths(PathSelectors.ant("/api/v2/**"))
                 .build()
-                .groupName("v2")
+                .groupName(GROUP_V2)
                 .securityContexts(List.of(securityContext()))
                 .securitySchemes(List.of(securityScheme()));
+    }
+
+    /**
+     * Internal API group. Includes only endpoints/controllers annotated with
+     * {@link oss.fosslight.api.annotation.InternalApi @InternalApi}. The group itself is
+     * only listed in {@code /swagger-resources} when the caller is an authenticated admin
+     * (see {@link #swaggerResourcesProvider()}), and the underlying {@code /v2/api-docs}
+     * document is additionally protected by {@link SwaggerInternalGroupInterceptor}.
+     */
+    @Bean
+    Docket swaggerApiV2Internal() {
+        return new Docket(DocumentationType.SWAGGER_2).apiInfo(swaggerInfo())
+                .consumes(DEFAULT_PRODUCES_AND_CONSUMES).produces(DEFAULT_PRODUCES_AND_CONSUMES).select()
+                .apis(RequestHandlerSelectors.basePackage(AppConstBean.APP_COMPONENT_SCAN_PACKAGE + ".api.controller")
+                        .and(internalApi()))
+                .paths(PathSelectors.ant("/api/v2/**"))
+                .build()
+                .groupName(GROUP_V2_INTERNAL)
+                .securityContexts(List.of(securityContext()))
+                .securitySchemes(List.of(securityScheme()));
+    }
+
+    /**
+     * Predicate that matches handlers whose declaring class or method is annotated
+     * with {@link oss.fosslight.api.annotation.InternalApi @InternalApi}.
+     */
+    @SuppressWarnings("deprecation") // declaringClass() is deprecated in Springfox 3.0 but still the cleanest API for class-level lookup
+    private static java.util.function.Predicate<springfox.documentation.RequestHandler> internalApi() {
+        return handler -> {
+            if (handler == null) {
+                return false;
+            }
+            // method-level annotation
+            if (handler.isAnnotatedWith(oss.fosslight.api.annotation.InternalApi.class)) {
+                return true;
+            }
+            // class-level annotation (fall back)
+            return handler.declaringClass() != null
+                    && handler.declaringClass().isAnnotationPresent(oss.fosslight.api.annotation.InternalApi.class);
+        };
+    }
+
+    /** Predicate that is the negation of {@link #internalApi()}. */
+    private static java.util.function.Predicate<springfox.documentation.RequestHandler> notInternalApi() {
+        return internalApi().negate();
     }
 
     private SecurityContext securityContext() {
@@ -68,5 +138,79 @@ public class SwaggerConfig {
                 .description("") // 시스템설졍이 필요한 경우 기입
                 .version("1")
                 .build();
+    }
+
+    /**
+     * Dynamically controls which Swagger groups are listed in {@code /swagger-resources}.
+     *
+     * <p>The public {@code v2} group is always listed. The {@code v2-internal} group is
+     * listed only when the current request carries a valid web-session JWT cookie
+     * ({@code X-FOSS-AUTH-TOKEN}) whose authority is {@code ROLE_ADMIN}.
+     *
+     * <p>This relies on the <em>web login session</em> (cookie), not the API token sent
+     * via the {@code Authorization} header, because Swagger UI itself is served from the
+     * browser and the cookie is sent automatically on every request to the hub.
+     */
+    @Bean
+    @Primary
+    SwaggerResourcesProvider swaggerResourcesProvider() {
+        return () -> {
+            List<SwaggerResource> resources = new ArrayList<>();
+            resources.add(swaggerResource(GROUP_V2, "/v2/api-docs?group=" + GROUP_V2));
+
+            if (isCurrentUserAdmin()) {
+                resources.add(swaggerResource(GROUP_V2_INTERNAL, "/v2/api-docs?group=" + GROUP_V2_INTERNAL));
+            }
+            return resources;
+        };
+    }
+
+    private SwaggerResource swaggerResource(String name, String location) {
+        SwaggerResource resource = new SwaggerResource();
+        resource.setName(name);
+        resource.setLocation(location);
+        resource.setSwaggerVersion("2.0");
+        return resource;
+    }
+
+    /**
+     * Returns {@code true} when the current HTTP request has a valid web-session JWT
+     * cookie whose authority is {@code ROLE_ADMIN}.
+     */
+    private boolean isCurrentUserAdmin() {
+        try {
+            HttpServletRequest req = currentRequest();
+            if (req == null) {
+                return false;
+            }
+            String token = jwtTokenProvider.resolveToken(req);
+            if (!jwtTokenProvider.validateToken(token)) {
+                return false;
+            }
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            if (auth == null) {
+                return false;
+            }
+            return auth.getAuthorities().stream()
+                    .anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority()));
+        } catch (Exception e) {
+            log.debug("Failed to resolve admin role for swagger resources", e);
+            return false;
+        }
+    }
+
+    private static HttpServletRequest currentRequest() {
+        ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        return attrs != null ? attrs.getRequest() : null;
+    }
+
+    /**
+     * Registers the interceptor that blocks direct access to the {@code v2-internal}
+     * api-docs document for non-admin users (prevents URL-guessing bypass).
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(swaggerInternalGroupInterceptor)
+                .addPathPatterns("/v2/api-docs");
     }
 }

--- a/src/main/java/oss/fosslight/config/SwaggerInternalGroupInterceptor.java
+++ b/src/main/java/oss/fosslight/config/SwaggerInternalGroupInterceptor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package oss.fosslight.config;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Blocks direct access to the {@code v2-internal} Swagger document.
+ *
+ * <p>The {@code /swagger-resources} endpoint only lists the {@code v2-internal} group for
+ * authenticated admins (see {@link SwaggerConfig#swaggerResourcesProvider()}), but a user
+ * who knows the URL could still request {@code /v2/api-docs?group=v2-internal} directly.
+ * This interceptor rejects such requests with HTTP 403 unless the caller is an
+ * authenticated {@code ROLE_ADMIN} user (verified via the web-session JWT cookie).
+ *
+ * <p>Only requests whose {@code group} parameter equals {@code v2-internal} are inspected;
+ * all other {@code /v2/api-docs} requests pass through unchanged.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SwaggerInternalGroupInterceptor implements HandlerInterceptor {
+
+    private static final String INTERNAL_GROUP = "v2-internal";
+    private static final String ADMIN_AUTHORITY = "ROLE_ADMIN";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+
+        if (!INTERNAL_GROUP.equals(request.getParameter("group"))) {
+            return true;
+        }
+
+        String token = jwtTokenProvider.resolveToken(request);
+        if (!jwtTokenProvider.validateToken(token)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        Authentication auth = jwtTokenProvider.getAuthentication(token);
+        boolean isAdmin = auth != null && auth.getAuthorities().stream()
+                .anyMatch(a -> ADMIN_AUTHORITY.equals(a.getAuthority()));
+
+        if (!isAdmin) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/oss/fosslight/controller/ProjectController.java
+++ b/src/main/java/oss/fosslight/controller/ProjectController.java
@@ -52,6 +52,8 @@ import com.google.gson.reflect.TypeToken;
 
 import lombok.extern.slf4j.Slf4j;
 import oss.fosslight.CoTopComponent;
+import oss.fosslight.api.advice.CProjectNotFoundException;
+import oss.fosslight.api.advice.CSupplementNoticeGenerationException;
 import oss.fosslight.api.service.ResponseService;
 import oss.fosslight.common.CoCodeManager;
 import oss.fosslight.common.CoConstDef;
@@ -4650,6 +4652,9 @@ public class ProjectController extends CoTopComponent {
 			String localizedMessage = getMessage(messageCode);
 			log.error("Validation failed for supplement notice: {}", messageCode);
 			return makeJsonResponseHeader(false, localizedMessage);
+		} catch (CProjectNotFoundException | CSupplementNoticeGenerationException e) {
+			log.error(e.getMessage(), e);
+			return makeJsonResponseHeader(false, e.getMessage());
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 			return makeJsonResponseHeader(false, e.getMessage());

--- a/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/ProjectServiceImpl.java
@@ -71,6 +71,8 @@ import org.springframework.web.util.HtmlUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import oss.fosslight.CoTopComponent;
+import oss.fosslight.api.advice.CProjectNotFoundException;
+import oss.fosslight.api.advice.CSupplementNoticeGenerationException;
 import oss.fosslight.util.OssComponentUtil;
 import oss.fosslight.common.CoCodeManager;
 import oss.fosslight.common.CoConstDef;
@@ -7028,7 +7030,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 
 		Project projectDetail = getProjectDetail(project);
 		if (projectDetail == null) {
-			throw new IllegalStateException("Project not found.");
+			throw new CProjectNotFoundException("Project not found.");
 		}
 
 		ProjectIdentification identification = new ProjectIdentification();
@@ -7052,7 +7054,7 @@ public class ProjectServiceImpl extends CoTopComponent implements ProjectService
 		}
 
 		if (isEmpty(fileId)) {
-			throw new IllegalStateException("Failed to generate supplement notice file. Please verify that the project contains valid binary components.");
+			throw new CSupplementNoticeGenerationException("Failed to generate supplement notice file. Please verify that the project contains valid binary components.");
 		}
 
 		return fileId;


### PR DESCRIPTION


## Description

Remove the global try-catch(Exception) blocks that were scattered across API v2 endpoints and consolidate exception handling into ApiV2ExceptionAdvice so that all API controllers return a consistent error response.

- Add CProjectNotFoundException (404) for non-existent project lookups
- Add CSupplementNoticeGenerationException (422) for supplement notice generation failures (e.g. no valid binary components)
- Add corresponding @ExceptionHandler entries in ApiV2ExceptionAdvice
- Replace IllegalStateException in ProjectServiceImpl.getSupplementNoticeFileId with the new semantically-typed exceptions
- Clean up try-catch blocks in v2 controllers (ApiCode/Oss/Partner/Project/ SelfCheck/Vulnerability) and ProjectController to let exceptions propagate to the advice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for missing projects and supplement notice generation failures, including actionable messages.
  * Added separate public and administrator-only API documentation with restricted access to internal endpoints.
  * Marked selected administrative endpoints as internal.

* **Bug Fixes**
  * Standardized missing-project responses to HTTP 404 and supplement notice failures to HTTP 422.
  * Improved error logging with request method and URI details.
  * Prevented unexpected failures from being misreported as generic client or server errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->