### PR TITLE
 Improve Swagger response example readability by extracting long examples

### DIFF
--- a/src/main/java/oss/fosslight/api/controller/v2/ApiBatV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiBatV2Controller.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import oss.fosslight.CoTopComponent;
 import oss.fosslight.api.annotation.ApiCommonResponses;
+import oss.fosslight.api.doc.example.BatApiExampleConstants;
 import oss.fosslight.api.entity.CommonResult;
 import oss.fosslight.api.service.ResponseService;
 import oss.fosslight.api.service.RestResponseService;
@@ -47,7 +48,7 @@ public class ApiBatV2Controller extends CoTopComponent {
                     message = "성공",
                     response = Map.class,
                     examples = @Example(value = @ExampleProperty(mediaType = "application/json",
-                            value = "{\"content\":[{\"binaryFileName\":\"bash\",\"path\":\"/bin/bash\",\"ossName\":\"bash\",\"ossVersion\":\"5.2.21\",\"license\":\"GPL-3.0-or-later\",\"projectName\":\"sample-platform\",\"checksum\":\"a1b2c3d4e5f6\",\"tlsh\":\"T1A2B3C4D5E6F\",\"updateDate\":\"2026-08-20\",\"downloadlocation\":\"https://ftp.gnu.org/gnu/bash/bash-5.2.21.tar.gz\"}]}"))
+                            value = BatApiExampleConstants.BINARY_INFO_SEARCH_SUCCESS_EXAMPLE))
             ),
             @ApiResponse(
                     code = 400,

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiOssV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiOssV2Controller.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import oss.fosslight.CoTopComponent;
 import oss.fosslight.api.annotation.ApiCommonResponses;
 import oss.fosslight.api.annotation.InternalApi;
+import oss.fosslight.api.doc.example.OssApiExampleConstants;
 import oss.fosslight.api.dto.ListLicenseDto;
 import oss.fosslight.api.dto.ListOssDto;
 import oss.fosslight.api.service.RestResponseService;
@@ -65,7 +66,7 @@ public class ApiOssV2Controller extends CoTopComponent {
                     message = "성공",
                     response = ListOssDto.Result.class,
                     examples = @Example(value = @ExampleProperty(mediaType = "application/json",
-                            value = "{\"list\":[{\"ossId\":\"1\",\"ossType\":\"100\",\"ossTypeMap\":{\"Multi\":\"Y\",\"Dual\":\"N\",\"V-Diff\":\"N\"},\"ossName\":\"sample-oss\",\"ossVersion\":\"1.0.0\",\"licenseName\":\"Apache-2.0\",\"licenseType\":\"PMS\",\"downloadUrl\":\"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\",\"downloadUrls\":[\"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\"],\"homepageUrl\":\"https://example.org/sample-oss\",\"description\":\"Sample open source component\",\"cveId\":\"CVE-2026-1234\",\"cvssScore\":\"7.5\",\"creator\":\"user01\",\"created\":\"2026-08-01 09:00:00\",\"modifier\":\"user02\",\"modified\":\"2026-08-20 14:30:00\",\"obligations\":[\"Y\",\"N\"],\"obligationTypeMap\":{\"Notice\":\"Y\",\"Source\":\"N\"},\"copyright\":\"Copyright 2026 Example Authors\",\"nicknames\":\"sample|sample-lib\",\"nicknameList\":[\"sample\",\"sample-lib\"],\"attribution\":\"This product includes sample-oss.\",\"exclude\":false}],\"totalCount\":1}"))
+                            value = OssApiExampleConstants.OSS_LIST_SEARCH_SUCCESS_EXAMPLE))
             ),
             @ApiResponse(
                     code = 400,
@@ -117,7 +118,7 @@ public class ApiOssV2Controller extends CoTopComponent {
                     message = "성공",
                     response = ListLicenseDto.Result.class,
                     examples = @Example(value = @ExampleProperty(mediaType = "application/json",
-                            value = "{\"list\":[{\"licenseId\":\"1\",\"licenseName\":\"Apache License 2.0\",\"licenseType\":\"Permissive\",\"licenseText\":\"Apache License Version 2.0, January 2004\",\"licenseIdentifier\":\"Apache-2.0\",\"homepageUrl\":\"https://www.apache.org/licenses/LICENSE-2.0\",\"description\":\"A permissive open source license.\",\"creator\":\"admin\",\"modifier\":\"admin\",\"created\":\"2026-08-01 09:00:00\",\"modified\":\"2026-08-20 14:30:00\",\"restrictions\":[\"Include License\",\"Notice\"],\"licenseNickname\":\"Apache 2.0\",\"obligations\":[\"Y\",\"N\"],\"attribution\":\"Licensed under the Apache License, Version 2.0.\"}],\"totalCount\":1}"))
+                            value = OssApiExampleConstants.LICENSE_LIST_SEARCH_SUCCESS_EXAMPLE))
             ),
             @ApiResponse(
                     code = 400,
@@ -250,7 +251,7 @@ public class ApiOssV2Controller extends CoTopComponent {
                     code = 200,
                     message = "성공",
                     response = Map.class,
-                    examples = @Example(value = @ExampleProperty(mediaType = "application/json", value = "{\"UPDATE-DOWNLOAD-LOCATION-FORMAT\":{\"reFineTotalCnt\":1,\"reFineItems\":{\"sample-oss_1.0.0\":[\"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\"]}}}"))
+                    examples = @Example(value = @ExampleProperty(mediaType = "application/json", value = OssApiExampleConstants.OSS_DOWNLOAD_LOCATION_REFINE_SUCCESS_EXAMPLE))
             ),
             @ApiResponse(code = 400, message = "필수 doUpdateFlag 또는 refineType 누락", examples = @Example(value = @ExampleProperty(mediaType = "application/json", value = "{\"error\":\"Bad Request\",\"message\":\"'refineType' parameter is missing or misspelled\"}"))),
             @ApiResponse(

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiPartnerV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiPartnerV2Controller.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import oss.fosslight.CoTopComponent;
 import oss.fosslight.api.advice.CProjectNotAvailableException;
 import oss.fosslight.api.annotation.ApiCommonResponses;
+import oss.fosslight.api.doc.example.PartnerApiExampleConstants;
 import oss.fosslight.api.service.RestResponseService;
 import oss.fosslight.common.CoCodeManager;
 import oss.fosslight.common.CoConstDef;
@@ -65,7 +66,7 @@ public class ApiPartnerV2Controller extends CoTopComponent {
                     message = "성공",
                     response = Map.class,
                     examples = @Example(value = @ExampleProperty(mediaType = "application/json",
-                            value = "{\"list\":[{\"partnerId\":\"1\",\"partnerName\":\"Example Supplier\",\"softwareName\":\"Example SDK\",\"softwareVersion\":\"2.5.0\",\"status\":\"Confirm\",\"modifiedDate\":\"2026-08-20\",\"createdDate\":\"2026-08-01\",\"deliveryForm\":\"Source Code\",\"description\":\"SDK supplied for the TV project\",\"creator\":\"user01\",\"reviewer\":\"reviewer01\",\"division\":\"Division\",\"prjId\":\"6304,6305\"}],\"totalCount\":1}"))
+                            value = PartnerApiExampleConstants.PARTNER_LIST_SEARCH_SUCCESS_EXAMPLE))
             ),
             @ApiResponse(
                     code = 400,
@@ -243,7 +244,7 @@ public class ApiPartnerV2Controller extends CoTopComponent {
                     message = "성공",
                     response = Map.class,
                     examples = @Example(value = @ExampleProperty(mediaType = "application/json",
-                            value = "{\"sample-oss\":[{\"version\":\"1.0.0\",\"license\":[\"Apache-2.0\"],\"download location\":\"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\",\"homepage\":\"https://example.org/sample-oss\",\"copyright text\":[\"Copyright 2026 Example Authors\"],\"exclude\":false,\"comment\":\"Used by Example SDK\",\"Vulnerability\":\"7.5\"}]}"))
+                            value = PartnerApiExampleConstants.PARTNER_SBOM_JSON_SUCCESS_EXAMPLE))
             ),
            
             @ApiResponse(
@@ -261,7 +262,7 @@ public class ApiPartnerV2Controller extends CoTopComponent {
 
     @ApiOperation(value = "3rd Party SBOM JSON 조회 (Deprecated)", notes = "이전 경로입니다. /partners/{id}/sbom/json-data 사용을 권장합니다.", hidden = true)
     @ApiResponses({
-            @ApiResponse(code = 200, message = "조회 성공", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"sample-oss\":[{\"version\":\"1.0.0\",\"license\":[\"Apache-2.0\"],\"download location\":\"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\",\"homepage\":\"https://example.org/sample-oss\",\"copyright text\":[\"Copyright 2026 Example Authors\"],\"exclude\":false,\"comment\":\"Used by Example SDK\",\"Vulnerability\":\"7.5\"}]}"))),
+            @ApiResponse(code = 200, message = "조회 성공", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = PartnerApiExampleConstants.PARTNER_SBOM_JSON_SUCCESS_EXAMPLE))),
             @ApiResponse(code = 403, message = "3rd Party 수정 권한 없음", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"The user does not have edit permissions for Project 123\"}"))),
             
     })

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiProjectV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiProjectV2Controller.java
@@ -13,6 +13,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.tools.ant.taskdefs.condition.Http;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
@@ -26,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 import oss.fosslight.CoTopComponent;
 import oss.fosslight.api.advice.CProjectNotAvailableException;
 import oss.fosslight.api.annotation.ApiCommonResponses;
+import oss.fosslight.api.doc.example.ProjectApiExampleConstants;
 import oss.fosslight.api.service.RestResponseService;
 import oss.fosslight.common.CoCodeManager;
 import oss.fosslight.common.CoConstDef;
@@ -99,7 +101,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
     @ApiOperation(value = "프로젝트 목록 조회", notes = "조회 권한이 있는 프로젝트를 조건과 페이지 정보로 검색합니다. 조회 결과가 없으면 빈 list와 totalCount 0을 반환합니다.")
     @ApiResponses({
             @ApiResponse(code = 200, message = "조회 성공", response = Map.class,
-                    examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"list\":[{\"prjId\":\"6304\",\"prjName\":\"FOSSLight TV Platform\",\"prjVersion\":\"2026.08\",\"updateDate\":\"2026-08-20\",\"createDate\":\"2026-08-01\",\"identificationStatus\":\"Confirm\",\"verificationStatus\":\"Confirm\",\"distributionStatus\":\"Distributed\",\"distributionType\":\"General\",\"networkService\":\"NO\",\"notice\":\"General\",\"noticePlatform\":\"\",\"priority\":\"High\",\"status\":\"Complete\",\"identificationCsvFileId\":\"10001\",\"publicYn\":\"Y\",\"secperson\":\"security01\",\"secmailYn\":\"Y\",\"editors\":\"user01,user02\",\"statusRequestYn\":\"N\",\"cvssScoreMax\":\"7.5\",\"vulnerabilityScore\":\"7.5\"}],\"totalCount\":1}"))),
+                    examples = @Example(@ExampleProperty(mediaType = "application/json", value = ProjectApiExampleConstants.PROJECT_LIST_SEARCH_SUCCESS_EXAMPLE))),
             @ApiResponse(code = 400, message = "잘못된 요청 - page 또는 countPerPage가 1 미만", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"Input value=0. page must be larger than 1\"}")))
     })
     @GetMapping(value = {APIV2.FOSSLIGHT_API_PROJECT_SEARCH})
@@ -157,7 +159,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
 
     @ApiOperation(value = "프로젝트 모델 목록 조회", notes = "prjIdList에 지정한 프로젝트별 모델 목록과 배포명을 조회합니다.")
     @ApiResponses({
-            @ApiResponse(code = 200, message = "조회 성공", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"records\":1,\"contents\":[{\"modelList\":[{\"category\":\"Appliances > Air Conditioner\",\"modelName\":\"AIRCON\",\"releaseDate\":\"20260831\",\"distributeName\":\"FOSSLight 2026\"}],\"prjId\":\"6304\",\"distributionName\":null}]}"))),
+            @ApiResponse(code = 200, message = "조회 성공", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = ProjectApiExampleConstants.PROJECT_MODEL_LIST_SEARCH_SUCCESS_EXAMPLE))),
             @ApiResponse(code = 400, message = "잘못된 요청 - prjIdList 누락", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"error\":\"Bad Request\",\"message\":\"'prjIdList' parameter is missing or misspelled\"}")))
     })
     @GetMapping(value = {APIV2.FOSSLIGHT_API_MODEL_SEARCH})
@@ -518,7 +520,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
 
     @ApiOperation(value = "프로젝트 SBOM JSON 조회", notes = "프로젝트 BOM을 OSS 이름별 JSON으로 반환합니다. saveFlag가 Y이면 생성 결과를 프로젝트에 저장합니다.")
     @ApiResponses({
-            @ApiResponse(code = 200, message = "조회 성공. 프로젝트가 조회되지 않으면 빈 객체 반환", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"sample-oss\":[{\"version\":\"1.0.0\",\"license\":[\"Apache-2.0\"],\"download location\":\"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\",\"homepage\":\"https://example.org/sample-oss\",\"copyright text\":[\"Copyright 2026 Example Authors\"],\"exclude\":false,\"comment\":\"Used by the TV platform\",\"Vulnerability\":\"7.5\"}]}"))),
+            @ApiResponse(code = 200, message = "조회 성공. 프로젝트가 조회되지 않으면 빈 객체 반환", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = ProjectApiExampleConstants.PROJECT_SBOM_JSON_SUCCESS_EXAMPLE))),
             @ApiResponse(code = 400, message = "잘못된 요청 - saveFlag 허용값 오류", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"getPrjBomAsJson.saveFlag: Input value='X'. 'saveFlag' field value should be from list of [Y, N]\"}"))),
             @ApiResponse(code = 403, message = "프로젝트 수정 권한 없음", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"The user does not have edit permissions for Project 123\"}"))),
             
@@ -534,7 +536,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
 
     @ApiOperation(value = "프로젝트 BOM JSON 조회 (Deprecated)", notes = "이전 경로입니다. /projects/{id}/sbom/json-data 사용을 권장합니다.", hidden = true)
     @ApiResponses({
-            @ApiResponse(code = 200, message = "조회 성공", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"sample-oss\":[{\"version\":\"1.0.0\",\"license\":[\"Apache-2.0\"],\"download location\":\"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\",\"homepage\":\"https://example.org/sample-oss\",\"copyright text\":[\"Copyright 2026 Example Authors\"],\"exclude\":false,\"comment\":\"Used by the TV platform\",\"Vulnerability\":\"7.5\"}]}"))),
+            @ApiResponse(code = 200, message = "조회 성공", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = ProjectApiExampleConstants.PROJECT_SBOM_JSON_SUCCESS_EXAMPLE))),
             @ApiResponse(code = 400, message = "잘못된 요청", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"The parameter is invalid.\"}"))),
             @ApiResponse(code = 403, message = "프로젝트 수정 권한 없음", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"The user does not have edit permissions for Project 123\"}"))),
             
@@ -579,7 +581,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
 
     @ApiOperation(value = "프로젝트 SBOM 비교", notes = "두 프로젝트의 BOM을 비교하여 추가·삭제·변경 항목을 contents에 반환합니다.")
     @ApiResponses({
-            @ApiResponse(code = 200, message = "비교 성공. 같은 프로젝트이면 status가 same", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"contents\":{\"add\":[{\"name\":\"new-oss\",\"version\":\"2.0.0\",\"license\":[\"MIT\"]}],\"delete\":[{\"name\":\"old-oss\",\"version\":\"1.0.0\",\"license\":[\"BSD-3-Clause\"]}],\"change\":[{\"name\":\"sample-oss\",\"prev\":[{\"version\":\"1.0.0\",\"license\":[\"Apache-2.0\"]}],\"now\":[{\"version\":\"1.1.0\",\"license\":[\"Apache-2.0\"]}]}]}}"))),
+            @ApiResponse(code = 200, message = "비교 성공. 같은 프로젝트이면 status가 same", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = ProjectApiExampleConstants.PROJECT_SBOM_COMPARE_SUCCESS_EXAMPLE))),
             @ApiResponse(code = 400, message = "비교할 BOM 데이터 없음", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"The parameter is invalid.\"}"))),
             
     })
@@ -593,7 +595,7 @@ public class ApiProjectV2Controller extends CoTopComponent {
 
     @ApiOperation(value = "프로젝트 BOM 비교 (Deprecated)", notes = "이전 경로입니다. /projects/{id}/sbom/compare-with/{compareId} 사용을 권장합니다.", hidden = true)
     @ApiResponses({
-            @ApiResponse(code = 200, message = "비교 성공", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"contents\":{\"add\":[{\"name\":\"new-oss\",\"version\":\"2.0.0\",\"license\":[\"MIT\"]}],\"delete\":[{\"name\":\"old-oss\",\"version\":\"1.0.0\",\"license\":[\"BSD-3-Clause\"]}],\"change\":[{\"name\":\"sample-oss\",\"prev\":[{\"version\":\"1.0.0\",\"license\":[\"Apache-2.0\"]}],\"now\":[{\"version\":\"1.1.0\",\"license\":[\"Apache-2.0\"]}]}]}}"))),
+            @ApiResponse(code = 200, message = "비교 성공", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = ProjectApiExampleConstants.PROJECT_SBOM_COMPARE_SUCCESS_EXAMPLE))),
             @ApiResponse(code = 400, message = "비교할 BOM 데이터 없음", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"The parameter is invalid.\"}")))
     })
     @GetMapping(value = {"/projects/{id}/bom/compare-with/{compareId}"})
@@ -1422,7 +1424,8 @@ public class ApiProjectV2Controller extends CoTopComponent {
             uploadFlag = true;
         } else {
             if (!CoConstDef.FLAG_YES.equals(useYn)) {
-                errorMsg = "delete project"; // 삭제된 project
+                errorMsg = String.format("Project not found. Project ID: %s", prjId); // 삭제된 project
+                return responseService.errorResponse(HttpStatus.BAD_REQUEST, errorMsg);
             }
         }
 

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiProjectV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiProjectV2Controller.java
@@ -1639,7 +1639,8 @@ public class ApiProjectV2Controller extends CoTopComponent {
 
     @ApiOperation(value = "Security Mail 설정", notes = "프로젝트 Security Mail 사용 여부를 설정합니다. N인 경우 secMailDesc가 필수입니다.")
     @ApiResponses({
-            @ApiResponse(code = 200, message = "설정 성공", response = Map.class, examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"Security enable setting updated successfully\",\"secMailYn\":\"Y\",\"secMailDesc\":\"Enable\"}"))),
+            @ApiResponse(code = 200, message = "설정 성공 (주의: secMailYn 값 및 상태에 따라 secMailDesc 반환 형태가 달라질 수 있습니다)\n* `secMailYN:N` 인 경우, secMailDesc가 프로젝트에 설정된 값으로 리턴됩니다", response = Map.class,
+                    examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"Security enable setting updated successfully\",\"secMailYn\":\"Y\",\"secMailDesc\":\"Enable\"}"))),
             @ApiResponse(code = 400, message = "Security Mail 파라미터 오류\n\n* `Security Enable (secMailYn) is required.`\n* `Security Enable (secMailYn) must be Y or N.`\n* `Security Description (secMailDesc) is required when Security Enable is N.`", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"Security Enable (secMailYn) must be Y or N.\"}"))),
             @ApiResponse(code = 403, message = "프로젝트 수정 권한 없음", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"The user does not have edit permissions for Project 123. Check Permission or Project Status\"}"))),
             @ApiResponse(code = 404, message = "프로젝트 없음", examples = @Example(@ExampleProperty(mediaType = "application/json", value = "{\"message\":\"Project not found. Project ID: 123\"}")))

--- a/src/main/java/oss/fosslight/api/controller/v2/ApiSelfCheckV2Controller.java
+++ b/src/main/java/oss/fosslight/api/controller/v2/ApiSelfCheckV2Controller.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import oss.fosslight.CoTopComponent;
 import oss.fosslight.api.annotation.ApiCommonResponses;
+import oss.fosslight.api.doc.example.SelfCheckApiExampleConstants;
 import oss.fosslight.api.entity.CommonResult;
 import oss.fosslight.api.service.ResponseService;
 import oss.fosslight.api.service.RestResponseService;
@@ -472,7 +473,7 @@ public class ApiSelfCheckV2Controller extends CoTopComponent {
                     message = "성공",
                     response = Map.class,
                     examples = @Example(value = @ExampleProperty(mediaType = "application/json",
-                            value = "{\"content\":{\"prjId\":\"123\",\"prjName\":\"Sample Self Check\",\"prjVersion\":\"1.0\",\"comment\":\"Initial self-check\",\"commentIdx\":\"501\",\"useYn\":\"Y\",\"srcCsvFileId\":\"10001\",\"creator\":\"user01\",\"createdDate\":\"2026-08-01 09:00:00\",\"modifier\":\"user02\",\"modifiedDate\":\"2026-08-20 14:30:00\",\"prjUserName\":\"홍길동\",\"prjDivisionName\":\"HE Division\"}}"))
+                            value = SelfCheckApiExampleConstants.SELF_CHECK_DETAIL_SUCCESS_EXAMPLE))
             ),
            
             @ApiResponse(

--- a/src/main/java/oss/fosslight/api/doc/example/BatApiExampleConstants.java
+++ b/src/main/java/oss/fosslight/api/doc/example/BatApiExampleConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package oss.fosslight.api.doc.example;
+
+public final class BatApiExampleConstants {
+    private BatApiExampleConstants() {
+    }
+
+    public static final String BINARY_INFO_SEARCH_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"content\": [\n"
+                    + "    {\n"
+                    + "      \"binaryFileName\": \"bash\",\n"
+                    + "      \"path\": \"/bin/bash\",\n"
+                    + "      \"ossName\": \"bash\",\n"
+                    + "      \"ossVersion\": \"5.2.21\",\n"
+                    + "      \"license\": \"GPL-3.0-or-later\",\n"
+                    + "      \"checksum\": \"a1b2c3d4e5f6\",\n"
+                    + "      \"sourceCodePath\": \"/usr/src/bash\",\n"
+                    + "      \"platformName\": \"Linux\",\n"
+                    + "      \"platformVersion\": \"6.1\"\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}";
+}

--- a/src/main/java/oss/fosslight/api/doc/example/OssApiExampleConstants.java
+++ b/src/main/java/oss/fosslight/api/doc/example/OssApiExampleConstants.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package oss.fosslight.api.doc.example;
+
+public final class OssApiExampleConstants {
+    private OssApiExampleConstants() {
+    }
+
+    public static final String OSS_LIST_SEARCH_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"list\": [\n"
+                    + "    {\n"
+                    + "      \"ossId\": \"1\",\n"
+                    + "      \"ossType\": \"100\",\n"
+                    + "      \"ossTypeMap\": {\n"
+                    + "        \"Multi\": \"Y\",\n"
+                    + "        \"Dual\": \"N\",\n"
+                    + "        \"V-Diff\": \"N\"\n"
+                    + "      },\n"
+                    + "      \"ossName\": \"sample-oss\",\n"
+                    + "      \"ossVersion\": \"1.0.0\",\n"
+                    + "      \"licenseName\": \"Apache-2.0\",\n"
+                    + "      \"licenseType\": \"PMS\",\n"
+                    + "      \"downloadUrl\": \"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\",\n"
+                    + "      \"downloadUrls\": [\"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\"],\n"
+                    + "      \"homepageUrl\": \"https://example.org/sample-oss\",\n"
+                    + "      \"description\": \"Sample open source component\",\n"
+                    + "      \"cveId\": \"CVE-2026-1234\",\n"
+                    + "      \"cvssScore\": \"7.5\",\n"
+                    + "      \"creator\": \"user01\",\n"
+                    + "      \"created\": \"2026-08-01 09:00:00\",\n"
+                    + "      \"modifier\": \"user02\",\n"
+                    + "      \"modified\": \"2026-08-20 14:30:00\",\n"
+                    + "      \"obligations\": [\"Y\", \"N\"],\n"
+                    + "      \"obligationTypeMap\": {\n"
+                    + "        \"Notice\": \"Y\",\n"
+                    + "        \"Source\": \"N\"\n"
+                    + "      },\n"
+                    + "      \"copyright\": \"Copyright 2026 Example Authors\",\n"
+                    + "      \"nicknames\": \"sample|sample-lib\",\n"
+                    + "      \"nicknameList\": [\"sample\", \"sample-lib\"],\n"
+                    + "      \"attribution\": \"This product includes sample-oss.\",\n"
+                    + "      \"exclude\": false\n"
+                    + "    }\n"
+                    + "  ],\n"
+                    + "  \"totalCount\": 1\n"
+                    + "}";
+
+    public static final String LICENSE_LIST_SEARCH_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"list\": [\n"
+                    + "    {\n"
+                    + "      \"licenseId\": \"1\",\n"
+                    + "      \"licenseName\": \"Apache License 2.0\",\n"
+                    + "      \"licenseType\": \"PMS\",\n"
+                    + "      \"ossId\": \"1\",\n"
+                    + "      \"licenseText\": \"Apache License Version 2.0\",\n"
+                    + "      \"licenseIdentifier\": \"Apache-2.0\",\n"
+                    + "      \"homepageUrl\": \"https://www.apache.org/licenses/LICENSE-2.0\",\n"
+                    + "      \"description\": \"Apache License, Version 2.0\",\n"
+                    + "      \"creator\": \"user01\",\n"
+                    + "      \"modifier\": \"user02\",\n"
+                    + "      \"created\": \"2026-08-01 09:00:00\",\n"
+                    + "      \"modified\": \"2026-08-20 14:30:00\",\n"
+                    + "      \"restrictions\": [\"Patent Grant\"],\n"
+                    + "      \"obligations\": [\"Y\", \"N\"],\n"
+                    + "      \"attribution\": \"This product includes Apache License 2.0.\"\n"
+                    + "    }\n"
+                    + "  ],\n"
+                    + "  \"totalCount\": 1\n"
+                    + "}";
+
+    public static final String OSS_DOWNLOAD_LOCATION_REFINE_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"UPDATE-DOWNLOAD-LOCATION-FORMAT\": {\n"
+                    + "    \"reFineTotalCnt\": 1,\n"
+                    + "    \"reFineItems\": {\n"
+                    + "      \"sample-oss_1.0.0\": [\n"
+                    + "        \"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\"\n"
+                    + "      ]\n"
+                    + "    }\n"
+                    + "  }\n"
+                    + "}";
+}

--- a/src/main/java/oss/fosslight/api/doc/example/PartnerApiExampleConstants.java
+++ b/src/main/java/oss/fosslight/api/doc/example/PartnerApiExampleConstants.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package oss.fosslight.api.doc.example;
+
+public final class PartnerApiExampleConstants {
+    private PartnerApiExampleConstants() {
+    }
+
+    public static final String PARTNER_LIST_SEARCH_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"list\": [\n"
+                    + "    {\n"
+                    + "      \"partnerId\": \"1\",\n"
+                    + "      \"partnerName\": \"Example Supplier\",\n"
+                    + "      \"softwareName\": \"Example SDK\",\n"
+                    + "      \"softwareVersion\": \"2.5.0\",\n"
+                    + "      \"status\": \"Confirm\",\n"
+                    + "      \"division\": \"HE Division\",\n"
+                    + "      \"creator\": \"user01\",\n"
+                    + "      \"created\": \"2026-08-01 09:00:00\",\n"
+                    + "      \"modifier\": \"user02\",\n"
+                    + "      \"modified\": \"2026-08-20 14:30:00\"\n"
+                    + "    }\n"
+                    + "  ],\n"
+                    + "  \"totalCount\": 1\n"
+                    + "}";
+
+    public static final String PARTNER_SBOM_JSON_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"contents\": [\n"
+                    + "    {\n"
+                    + "      \"ossName\": \"sample-oss\",\n"
+                    + "      \"ossVersion\": \"1.0.0\",\n"
+                    + "      \"license\": [\"Apache-2.0\"],\n"
+                    + "      \"download location\": \"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\",\n"
+                    + "      \"homepage\": \"https://example.org/sample-oss\",\n"
+                    + "      \"Vulnerability\": \"7.5\",\n"
+                    + "      \"source\": \"NVD\",\n"
+                    + "      \"licenseType\": \"Permissive\"\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}";
+}

--- a/src/main/java/oss/fosslight/api/doc/example/ProjectApiExampleConstants.java
+++ b/src/main/java/oss/fosslight/api/doc/example/ProjectApiExampleConstants.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package oss.fosslight.api.doc.example;
+
+public final class ProjectApiExampleConstants {
+    private ProjectApiExampleConstants() {
+    }
+
+    public static final String PROJECT_LIST_SEARCH_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"list\": [\n"
+                    + "    {\n"
+                    + "      \"prjId\": \"6304\",\n"
+                    + "      \"prjName\": \"FOSSLight TV Platform\",\n"
+                    + "      \"prjVersion\": \"2026.08\",\n"
+                    + "      \"status\": \"Complete\",\n"
+                    + "      \"identificationStatus\": \"Confirm\",\n"
+                    + "      \"verificationStatus\": \"Confirm\",\n"
+                    + "      \"division\": \"LGE\",\n"
+                    + "      \"creator\": \"user01\",\n"
+                    + "      \"created\": \"2026-08-01 09:00:00\",\n"
+                    + "      \"modifier\": \"user02\",\n"
+                    + "      \"modified\": \"2026-08-25 10:30:00\"\n"
+                    + "    }\n"
+                    + "  ],\n"
+                    + "  \"totalCount\": 1\n"
+                    + "}";
+
+    public static final String PROJECT_MODEL_LIST_SEARCH_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"records\": 1,\n"
+                    + "  \"contents\": [\n"
+                    + "    {\n"
+                    + "      \"prjId\": \"6304\",\n"
+                    + "      \"distributionName\": \"FOSSLight 2026\",\n"
+                    + "      \"modelList\": [\n"
+                    + "        {\n"
+                    + "          \"modelName\": \"AIRCON\",\n"
+                    + "          \"category\": \"Appliances > Air Conditioner\",\n"
+                    + "          \"releaseDate\": \"20260831\",\n"
+                    + "          \"status\": \"Complete\"\n"
+                    + "        }\n"
+                    + "      ]\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}";
+
+    public static final String PROJECT_SBOM_JSON_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"contents\": [\n"
+                    + "    {\n"
+                    + "      \"ossName\": \"sample-oss\",\n"
+                    + "      \"ossVersion\": \"1.0.0\",\n"
+                    + "      \"license\": [\"Apache-2.0\"],\n"
+                    + "      \"download location\": \"https://github.com/example/sample-oss/archive/v1.0.0.tar.gz\",\n"
+                    + "      \"homepage\": \"https://example.org/sample-oss\",\n"
+                    + "      \"Vulnerability\": \"7.5\",\n"
+                    + "      \"source\": \"NVD\",\n"
+                    + "      \"licenseType\": \"Permissive\"\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}";
+
+    public static final String PROJECT_SBOM_COMPARE_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"contents\": {\n"
+                    + "    \"add\": [\n"
+                    + "      {\n"
+                    + "        \"name\": \"new-oss\",\n"
+                    + "        \"version\": \"2.0.0\"\n"
+                    + "      }\n"
+                    + "    ],\n"
+                    + "    \"delete\": [\n"
+                    + "      {\n"
+                    + "        \"name\": \"old-oss\",\n"
+                    + "        \"version\": \"1.0.0\"\n"
+                    + "      }\n"
+                    + "    ],\n"
+                    + "    \"change\": [\n"
+                    + "      {\n"
+                    + "        \"name\": \"sample-oss\",\n"
+                    + "        \"prev\": [\n"
+                    + "          {\n"
+                    + "            \"version\": \"1.0.0\"\n"
+                    + "          }\n"
+                    + "        ],\n"
+                    + "        \"now\": [\n"
+                    + "          {\n"
+                    + "            \"version\": \"1.1.0\"\n"
+                    + "          }\n"
+                    + "        ]\n"
+                    + "      }\n"
+                    + "    ]\n"
+                    + "  }\n"
+                    + "}";
+}

--- a/src/main/java/oss/fosslight/api/doc/example/SelfCheckApiExampleConstants.java
+++ b/src/main/java/oss/fosslight/api/doc/example/SelfCheckApiExampleConstants.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 LG Electronics Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package oss.fosslight.api.doc.example;
+
+public final class SelfCheckApiExampleConstants {
+    private SelfCheckApiExampleConstants() {
+    }
+
+    public static final String SELF_CHECK_DETAIL_SUCCESS_EXAMPLE =
+            "{\n"
+                    + "  \"content\": {\n"
+                    + "    \"prjId\": \"123\",\n"
+                    + "    \"prjName\": \"Sample Self Check\",\n"
+                    + "    \"prjVersion\": \"1.0\",\n"
+                    + "    \"comment\": \"Initial self-check\",\n"
+                    + "    \"creator\": \"user01\",\n"
+                    + "    \"createdDate\": \"2026-08-01 09:00:00\",\n"
+                    + "    \"modifier\": \"user02\",\n"
+                    + "    \"modifiedDate\": \"2026-08-10 11:20:00\"\n"
+                    + "  }\n"
+                    + "}";
+}

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -2451,6 +2451,10 @@ public class ExcelUtil extends CoTopComponent {
 					sheet = wb.getSheetAt(StringUtil.string2integer(sheetIdx));
 				} catch (Exception e) {
 					sheetSeq = wb.getSheetIndex(readType);
+					if(sheetSeq == -1){
+						errMsgList.add("Cannot find sheet name : " + readType);
+						return false;
+					}
 					sheet = wb.getSheetAt(sheetSeq);
 				}
 				


### PR DESCRIPTION
## Summary
- Improved Swagger UI readability for long API response examples that were previously rendered as a single dense line.
- Kept short and simple examples inline near the API method, while moving long or deeply nested examples into shared Example Constants.
- Preserved response field names in all examples so consumers can still inspect the actual JSON structure.

## Changes
- Split project-related example payloads into category-based Example Constants for Project, OSS, Partner, SelfCheck, and Bat APIs.
- Reformatted long JSON examples into pretty-printed structures so they are easier to read in Swagger UI.
- Updated `@ApiResponse` annotations to reference shared examples instead of embedding long inline payloads.
- Limited the change to Swagger example readability work only and excluded `hub_lge` property file updates.

## Why
- Endpoint-level examples are valuable because they help developers understand the API quickly at the method level.
- Long examples are harder to scan when they are rendered as a single line, so extracting them improves readability without losing context.
- This approach balances maintainability and discoverability, while keeping examples understandable for API consumers.

## Notes
- This change is focused on improving Swagger example readability.
- No environment or property file changes were included.