### PR TITLE
align SPDX/CycloneDX upload and load handling with spec

### DIFF
--- a/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
@@ -1206,7 +1206,7 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 
 	        int rowIdx = 1;
 	        Map<String, String> externalRefsMap = new HashMap<>();
-	        Map<String, Object> relationshipsMap = new HashMap<>();
+	        Map<String, String> bomRefToSpdxIdMap = new HashMap<>();
 	        List<String> packageInfoidentifierList = new ArrayList<>();
 	        
 	        if (bom.getComponents() != null) {
@@ -1309,8 +1309,10 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 	                row.createCell(21).setCellValue("FALSE");
 	                
 	                packageInfoidentifierList.add(spdxId);
+	                if (!isEmpty(c.getBomRef())) {
+	                	bomRefToSpdxIdMap.put(c.getBomRef(), spdxId);
+	                }
 	                if (!isEmpty(c.getPurl())) {
-	                	relationshipsMap.put(c.getPurl(), spdxId);
 	                	externalRefsMap.put(spdxId, c.getPurl());
 	                }
 	            }
@@ -1385,12 +1387,12 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 	        	
 				for (org.cyclonedx.model.Dependency dep : bom.getDependencies()) {
 					String key = dep.getRef();
-					if (relationshipsMap.containsKey(key) && CollectionUtils.isNotEmpty(dep.getDependencies())) {
-						String spdxElementId = (String) relationshipsMap.get(key);
+					if (bomRefToSpdxIdMap.containsKey(key) && CollectionUtils.isNotEmpty(dep.getDependencies())) {
+						String spdxElementId = bomRefToSpdxIdMap.get(key);
 						for (org.cyclonedx.model.Dependency dependency : dep.getDependencies()) {
 							String relatedSpdxElementKey = dependency.getRef();
-							if (relationshipsMap.containsKey(relatedSpdxElementKey)) {
-								String relatedSpdxElement = String.valueOf(relationshipsMap.getOrDefault(relatedSpdxElementKey, ""));
+							if (bomRefToSpdxIdMap.containsKey(relatedSpdxElementKey)) {
+								String relatedSpdxElement = String.valueOf(bomRefToSpdxIdMap.getOrDefault(relatedSpdxElementKey, ""));
 								int cellIdx = 0;
 
 								Row row = sheetRelationships.getRow(rowIdx);

--- a/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
@@ -841,24 +841,68 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 	            root = (ObjectNode) rootNode;
 	        }
 		    
-		    String[] globalFieldsToRemove = {"relationships", "snippets", "annotations", "externalDocumentRefs", "hasExtractedLicensingInfos", "reviewers"};
+		    String[] globalFieldsToRemove = {"snippets", "annotations", "externalDocumentRefs", "hasExtractedLicensingInfos", "reviewers"};
 		    for (String field : globalFieldsToRemove) {
 		    	root.remove(field);
 	    		log.info("Field '{}' removed to optimize Excel conversion and prevent row limits.", field);
 		    }
-		    
+		
+		    Set<String> validIds = new HashSet<>();
+		    if (root.has("SPDXID")) {
+		        validIds.add(root.path("SPDXID").asText());
+		    }
 		    if (root.has("packages") && root.get("packages").isArray()) {
-		        ArrayNode packages = (ArrayNode) root.get("packages");
-		        for (JsonNode pkgNode : packages) {
+		        for (JsonNode pkgNode : root.get("packages")) {
 		            if (pkgNode.isObject()) {
-		                ObjectNode pkg = (ObjectNode) pkgNode;
-		                
-		                pkg.remove("relationships");
-		                pkg.remove("annotations");
-		                pkg.remove("attributionText");
+		                JsonNode spdxIdNode = pkgNode.get("SPDXID");
+		                if (spdxIdNode != null && !spdxIdNode.isNull()) {
+		                    validIds.add(spdxIdNode.asText());
+		                }
+		                ((ObjectNode) pkgNode).remove("relationships");
+		                ((ObjectNode) pkgNode).remove("annotations");
+		                ((ObjectNode) pkgNode).remove("attributionText");
 		            }
 		        }
 		    }
+		    if (root.has("files") && root.get("files").isArray()) {
+		        for (JsonNode fileNode : root.get("files")) {
+		            if (fileNode.isObject()) {
+		            	JsonNode spdxIdNode = fileNode.get("SPDXID");
+		            	if (spdxIdNode != null && !spdxIdNode.isNull()) {
+		            		validIds.add(spdxIdNode.asText());
+		            	}
+		        }
+		    }
+		    }
+		    if (root.has("snippets") && root.get("snippets").isArray()) {
+		        for (JsonNode snippetNode : root.get("snippets")) {
+		            if (snippetNode.isObject()) {
+		            	JsonNode spdxIdNode = snippetNode.get("SPDXID");
+		            	if (spdxIdNode != null && !spdxIdNode.isNull()) {
+		            		validIds.add(spdxIdNode.asText());
+		            	}
+		        }
+		    }
+		    }
+		    if (root.has("relationships") && root.get("relationships").isArray()) {
+		        ArrayNode relationships = (ArrayNode) root.get("relationships");
+		        for (int i = relationships.size() - 1; i >= 0; i--) {
+		            JsonNode rel = relationships.get(i);
+		            String spdxElementId = rel.path("spdxElementId").asText();
+		            String relatedSpdxElement = rel.path("relatedSpdxElement").asText();
+		            boolean valid = validIds.contains(spdxElementId)
+		                    || "NONE".equalsIgnoreCase(spdxElementId)
+		                    || "NOASSERTION".equalsIgnoreCase(spdxElementId)
+		                    || spdxElementId.startsWith("DocumentRef-");
+		            valid = valid && (validIds.contains(relatedSpdxElement)
+		                    || "NONE".equalsIgnoreCase(relatedSpdxElement)
+		                    || "NOASSERTION".equalsIgnoreCase(relatedSpdxElement)
+		                    || relatedSpdxElement.startsWith("DocumentRef-"));
+		            if (!valid) {
+		            	relationships.remove(i);
+		            }
+		        }
+		}
 		    
 //		    Set<String> validIds = new HashSet<>();
 //		    

--- a/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
@@ -864,26 +864,6 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		            }
 		        }
 		    }
-		    if (root.has("files") && root.get("files").isArray()) {
-		        for (JsonNode fileNode : root.get("files")) {
-		            if (fileNode.isObject()) {
-		            	JsonNode spdxIdNode = fileNode.get("SPDXID");
-		            	if (spdxIdNode != null && !spdxIdNode.isNull()) {
-		            		validIds.add(spdxIdNode.asText());
-		            	}
-		        }
-		    }
-		    }
-		    if (root.has("snippets") && root.get("snippets").isArray()) {
-		        for (JsonNode snippetNode : root.get("snippets")) {
-		            if (snippetNode.isObject()) {
-		            	JsonNode spdxIdNode = snippetNode.get("SPDXID");
-		            	if (spdxIdNode != null && !spdxIdNode.isNull()) {
-		            		validIds.add(spdxIdNode.asText());
-		            	}
-		        }
-		    }
-		    }
 		    if (root.has("relationships") && root.get("relationships").isArray()) {
 		        ArrayNode relationships = (ArrayNode) root.get("relationships");
 		        for (int i = relationships.size() - 1; i >= 0; i--) {

--- a/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
+++ b/src/main/java/oss/fosslight/service/impl/FileServiceImpl.java
@@ -853,11 +853,6 @@ public class FileServiceImpl extends CoTopComponent implements FileService {
 		            if (pkgNode.isObject()) {
 		                ObjectNode pkg = (ObjectNode) pkgNode;
 		                
-		                if (pkg.has("externalRefs")) {
-		                    pkg.remove("externalRefs");
-		                    log.debug("ExternalRefs removed from package: {}", pkg.path("name").asText());
-		                }
-
 		                pkg.remove("relationships");
 		                pkg.remove("annotations");
 		                pkg.remove("attributionText");

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -1240,6 +1240,7 @@ public class ExcelUtil extends CoTopComponent {
 			String lastBinaryName = "";
 			String lastExcludeYn = "";
 			Map<String, String> spdxPurlMap = getSpdxExternalRefPurlMap(sheet, workbook);
+			Map<String, Set<String>> spdxDependsOnMap = getSpdxDependsOnMap(sheet, workbook, spdxPurlMap);
 
 			List<String> duplicateCheckList = new ArrayList<>();
 			List<String> errRow = new ArrayList<>();
@@ -1456,9 +1457,16 @@ public class ExcelUtil extends CoTopComponent {
     				// default
     				bean.setExcludeYn(avoidNull(bean.getExcludeYn(), CoConstDef.FLAG_NO));
     
-    				if (dependenciesCol > -1) {
-						bean.setDependencies(dependenciesCol < 0 ? "" : avoidNull(getCellData(row.getCell(dependenciesCol))).trim().replaceAll("\t", ""));
+					String dependencies = "";
+					if (!isSPDXSpreadsheet(sheet)) {
+    					dependencies = dependenciesCol < 0 ? "" : avoidNull(getCellData(row.getCell(dependenciesCol))).trim().replaceAll("\t", "");
+					} else {
+    					Set<String> dependsOnUrls = spdxDependsOnMap.get(bean.getSpdxIdentifier());
+    					if (dependsOnUrls != null && !dependsOnUrls.isEmpty()) {
+    						dependencies = StringUtil.join(new ArrayList<>(dependsOnUrls), ",");
+    					}
 					}
+					bean.setDependencies(dependencies);
     				
     				if (tlshCol > -1) {
 						bean.setTlsh(tlshCol < 0 ? "" : avoidNull(getCellData(row.getCell(tlshCol))).trim().replaceAll("\t", ""));
@@ -1633,6 +1641,77 @@ public class ExcelUtil extends CoTopComponent {
 		return normalized.isEmpty() || "NONE".equalsIgnoreCase(normalized) || "NOASSERTION".equalsIgnoreCase(normalized);
 	}
 
+	private static Map<String, Set<String>> getSpdxDependsOnMap(Sheet sheet, Workbook workbook, Map<String, String> spdxPurlMap) {
+		Map<String, Set<String>> dependsOnBySpdxId = new LinkedHashMap<>();
+		if (!isSPDXSpreadsheet(sheet) || workbook == null || spdxPurlMap == null || spdxPurlMap.isEmpty()) {
+			return dependsOnBySpdxId;
+		}
+
+		Sheet relationshipsSheet = workbook.getSheet("Relationships");
+		if (relationshipsSheet == null) {
+			return dependsOnBySpdxId;
+		}
+
+		int headerRowIndex = findSpdxRelationshipsHeaderRowIndex(relationshipsSheet);
+		if (headerRowIndex < 0) {
+			return dependsOnBySpdxId;
+		}
+
+		Row headerRow = relationshipsSheet.getRow(headerRowIndex);
+		if (headerRow == null) {
+			return dependsOnBySpdxId;
+		}
+
+		int spdxIdACol = -1;
+		int relationshipCol = -1;
+		int spdxIdBCol = -1;
+		Iterator<Cell> iter = headerRow.cellIterator();
+		while (iter.hasNext()) {
+			Cell cell = iter.next();
+			String value = avoidNull(getCellData(cell)).toUpperCase().trim();
+			switch (value) {
+				case "SPDX IDENTIFIER A":
+					spdxIdACol = cell.getColumnIndex();
+					break;
+				case "RELATIONSHIP":
+					relationshipCol = cell.getColumnIndex();
+					break;
+				case "SPDX IDENTIFIER B":
+					spdxIdBCol = cell.getColumnIndex();
+					break;
+				default:
+					break;
+			}
+		}
+
+		if (spdxIdACol < 0 || relationshipCol < 0 || spdxIdBCol < 0) {
+			return dependsOnBySpdxId;
+		}
+
+		for (int rowIdx = headerRowIndex + 1; rowIdx < relationshipsSheet.getPhysicalNumberOfRows(); rowIdx++) {
+			Row row = relationshipsSheet.getRow(rowIdx);
+			if (row == null) {
+				continue;
+			}
+
+			String spdxIdA = normalizeSpdxValue(getCellData(row.getCell(spdxIdACol)));
+			String relation = normalizeSpdxValue(getCellData(row.getCell(relationshipCol)));
+			String spdxIdB = normalizeSpdxValue(getCellData(row.getCell(spdxIdBCol)));
+			if (isSpdxEmptyValue(spdxIdA) || isSpdxEmptyValue(spdxIdB) || !"DEPENDS_ON".equalsIgnoreCase(relation)) {
+				continue;
+			}
+
+			String dependencyPurl = normalizeSpdxValue(spdxPurlMap.get(spdxIdB));
+			if (isSpdxEmptyValue(dependencyPurl)) {
+				continue;
+			}
+
+			dependsOnBySpdxId.computeIfAbsent(spdxIdA, k -> new LinkedHashSet<>()).add(dependencyPurl);
+		}
+
+		return dependsOnBySpdxId;
+	}
+
 	private static int findSpdxExternalRefsHeaderRowIndex(Sheet sheet) {
 		if (sheet == null) {
 			return -1;
@@ -1671,6 +1750,47 @@ public class ExcelUtil extends CoTopComponent {
 			}
 
 			if (hasPackageId && hasCategory && hasType && hasLocator) {
+				return rowIdx;
+			}
+		}
+
+		return -1;
+	}
+
+	private static int findSpdxRelationshipsHeaderRowIndex(Sheet sheet) {
+		if (sheet == null) {
+			return -1;
+		}
+
+		int maxRow = Math.min(sheet.getLastRowNum(), 20);
+		for (int rowIdx = 0; rowIdx <= maxRow; rowIdx++) {
+			Row row = sheet.getRow(rowIdx);
+			if (row == null) {
+				continue;
+			}
+
+			boolean hasSpdxIdA = false;
+			boolean hasRelationship = false;
+			boolean hasSpdxIdB = false;
+
+			for (Cell cell : row) {
+				String value = avoidNull(getCellData(cell)).trim().toUpperCase();
+				switch (value) {
+					case "SPDX IDENTIFIER A":
+						hasSpdxIdA = true;
+						break;
+					case "RELATIONSHIP":
+						hasRelationship = true;
+						break;
+					case "SPDX IDENTIFIER B":
+						hasSpdxIdB = true;
+						break;
+					default:
+						break;
+				}
+			}
+
+			if (hasSpdxIdA && hasRelationship && hasSpdxIdB) {
 				return rowIdx;
 			}
 		}

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -18,8 +18,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -592,7 +595,7 @@ public class ExcelUtil extends CoTopComponent {
 				// 1. final list sheet data 취득
 				Sheet sheet = wb.getSheet("Final List");
 				Map<String, String> finalListErrMsg = new HashMap<>();
-				finalListErrMsg = readSheet(sheet, list, true, readType, errMsgList);
+				finalListErrMsg = readSheet(sheet, list, true, readType, errMsgList, wb);
 				if (!finalListErrMsg.isEmpty()) {
 					errList.add(finalListErrMsg);
 				}
@@ -608,7 +611,7 @@ public class ExcelUtil extends CoTopComponent {
 						}
 						List<OssComponents> _list = new ArrayList<>();
 						Map<String, String> errMsg = new HashMap<>();
-						errMsg = readSheet(_sheet, _list, true, readType, errMsgList);
+						errMsg = readSheet(_sheet, _list, true, readType, errMsgList, wb);
 						if (!errMsg.isEmpty()) {
 							errList.add(errMsg);
 						}
@@ -665,7 +668,7 @@ public class ExcelUtil extends CoTopComponent {
 					// get target sheet
 					Sheet sheet = wb.getSheetAt(StringUtil.string2integer(sheetIdx));
 					Map<String, String> errMsg = new HashMap<>();
-					errMsg = readSheet(sheet, list, false, readType, errMsgList);
+					errMsg = readSheet(sheet, list, false, readType, errMsgList, wb);
 					if (!errMsg.isEmpty()) {
 						errList.add(errMsg);
 					}
@@ -774,6 +777,10 @@ public class ExcelUtil extends CoTopComponent {
 	}
 
 	public static Map<String, String> readSheet(Sheet sheet, List<OssComponents> list, boolean readNoCol, String readType, List<String> errMsgList) {
+		return readSheet(sheet, list, readNoCol, readType, errMsgList, sheet != null ? sheet.getWorkbook() : null);
+	}
+
+	public static Map<String, String> readSheet(Sheet sheet, List<OssComponents> list, boolean readNoCol, String readType, List<String> errMsgList, Workbook workbook) {
 		int DefaultHeaderRowIndex = 2; // header index
 		
 		int ossNameCol = -1;
@@ -822,6 +829,7 @@ public class ExcelUtil extends CoTopComponent {
 		Map<String, String> errMsg = new HashMap<>();
 		
 		DefaultHeaderRowIndex = findHeaderRowIndex(sheet);
+		Row headerRow = DefaultHeaderRowIndex >= 0 ? sheet.getRow(DefaultHeaderRowIndex) : null;
 		
 		if (DefaultHeaderRowIndex < 0) {
 			if (!readNoCol) {
@@ -830,7 +838,6 @@ public class ExcelUtil extends CoTopComponent {
 			}
 		} else {
 			// set column index
-			Row headerRow = sheet.getRow(DefaultHeaderRowIndex);
 			Iterator<Cell> iter = headerRow.cellIterator();
 			int colIdx = 0;
 			List<String> dupColList = new ArrayList<>();
@@ -1232,6 +1239,7 @@ public class ExcelUtil extends CoTopComponent {
 			String lastFilePath = "";
 			String lastBinaryName = "";
 			String lastExcludeYn = "";
+			Map<String, String> spdxPurlMap = getSpdxExternalRefPurlMap(sheet, workbook);
 
 			List<String> duplicateCheckList = new ArrayList<>();
 			List<String> errRow = new ArrayList<>();
@@ -1305,22 +1313,23 @@ public class ExcelUtil extends CoTopComponent {
     						bean.setDownloadLocation("");
     					} else {
     						String downloadLocation = avoidNull(getCellData(row.getCell(downloadLocationCol))).trim().replaceAll("\\s", "");
-    						if (downloadLocation.equals("NONE") || downloadLocation.equals("NOASSERTION")) {
+    						if (isSpdxEmptyValue(downloadLocation)) {
     							bean.setDownloadLocation("");
         					} else {
         						bean.setDownloadLocation(downloadLocation);
         					}
     					}
     					
-    					bean.setHomepage(homepageCol < 0 ? "" : avoidNull(getCellData(row.getCell(homepageCol))).trim().replaceAll("\\s", ""));
+    					String homepage = homepageCol < 0 ? "" : avoidNull(getCellData(row.getCell(homepageCol))).trim().replaceAll("\\s", "");
+    					bean.setHomepage(isSpdxEmptyValue(homepage) ? "" : homepage);
     					bean.setFilePath(pathOrFileCol < 0 ? "" : avoidNull(getCellData(row.getCell(pathOrFileCol))).trim().replaceAll("\t", ""));
     					bean.setBinaryName(binaryNameCol < 0 ? "" : avoidNull(getCellData(row.getCell(binaryNameCol))).trim().replaceAll("\t", ""));
-    
+     
     					if (downloadLocationCol < 0) {
     						bean.setCopyrightText("");
     					} else {
     						String copyrightText = getCellData(row.getCell(copyrightTextCol));
-        					if (copyrightText.equals("NONE") || copyrightText.equals("NOASSERTION")) {
+        					if (isSpdxEmptyValue(copyrightText)) {
         						bean.setCopyrightText("");
         					} else {
         						bean.setCopyrightText(copyrightText);
@@ -1342,8 +1351,13 @@ public class ExcelUtil extends CoTopComponent {
     					bean.setReportKey(getCellData(row.getCell(noCol)));
     				}
 
+    				String licenseValue = "";
     				if (licenseCol > 0) {
-    					String licenseConcluded = getCellData(row.getCell(licenseCol));
+    					String licenseConcluded = normalizeSpdxValue(getCellData(row.getCell(licenseCol)));
+    					if (isSPDXSpreadsheet(sheet) && isSpdxEmptyValue(licenseConcluded)) {
+    						licenseConcluded = getSpdxDeclaredLicenseValue(headerRow, row);
+    					}
+    					licenseValue = licenseConcluded;
         				if (isSPDXSpreadsheet(sheet) && (licenseConcluded.contains("AND") || licenseConcluded.contains("OR"))) {
         					String licenseComment = getCellData(row.getCell(commentCol));
         					String comment = "";
@@ -1369,7 +1383,7 @@ public class ExcelUtil extends CoTopComponent {
     				// oss Name을 입력하지 않거나, 이전 row와 oss name, oss version이 동일한 경우, 멀티라이선스로 판단
     				OssComponentsLicense subBean = new OssComponentsLicense();
     				if (licenseCol > 0) {
-    					String licenseName = getCellData(row.getCell(licenseCol));
+    					String licenseName = licenseValue;
         				if (isSPDXSpreadsheet(sheet)){
         					licenseName = StringUtil.join(Arrays.asList(licenseName.split("\\(|\\)| ")).stream().filter(l -> !isEmpty(l) && !l.equals("AND") && !l.equals("OR")).collect(Collectors.toList()), ",");
         				} else if (licenseName.contains(",")) {
@@ -1420,7 +1434,11 @@ public class ExcelUtil extends CoTopComponent {
     					bean.setFilePath(_replaceFilePath);
     				}
     				
-    				bean.setPackageUrl(packageUrlCol < 0 ? "" : getCellData(row.getCell(packageUrlCol)));
+    				String packageUrl = normalizeSpdxValue(packageUrlCol < 0 ? "" : getCellData(row.getCell(packageUrlCol)));
+    				if (isSPDXSpreadsheet(sheet) && isSpdxEmptyValue(packageUrl)) {
+    					packageUrl = normalizeSpdxValue(spdxPurlMap.get(bean.getSpdxIdentifier()));
+    				}
+    				bean.setPackageUrl(packageUrl);
     				
     				// empty row check
     				if (isEmpty(bean.getOssName()) && isEmpty(bean.getOssVersion()) && isEmpty(subBean.getLicenseName()) && isEmpty(bean.getBinaryName()) && isEmpty(bean.getFilePath())
@@ -1514,6 +1532,150 @@ public class ExcelUtil extends CoTopComponent {
 
 	private static boolean isSPDXSpreadsheet(Sheet sheet) {
 		return sheet.getSheetName().equals("Package Info") || sheet.getSheetName().equals("Per File Info");
+	}
+
+	private static String getSpdxDeclaredLicenseValue(Row headerRow, Row row) {
+		if (headerRow == null || row == null) {
+			return "";
+		}
+
+		Iterator<Cell> iter = headerRow.cellIterator();
+		while (iter.hasNext()) {
+			Cell cell = iter.next();
+			String value = avoidNull(getCellData(cell)).toUpperCase().trim();
+			if ("LICENSE DECLARED".equals(value)) {
+				return normalizeSpdxValue(getCellData(row.getCell(cell.getColumnIndex())));
+			}
+		}
+
+		return "";
+	}
+
+	private static Map<String, String> getSpdxExternalRefPurlMap(Sheet sheet, Workbook workbook) {
+		Map<String, String> purlByPackageId = new HashMap<>();
+		if (!isSPDXSpreadsheet(sheet) || workbook == null) {
+			return purlByPackageId;
+		}
+
+		Sheet externalRefsSheet = workbook.getSheet("External Refs");
+		if (externalRefsSheet == null) {
+			return purlByPackageId;
+		}
+
+		int headerRowIndex = findSpdxExternalRefsHeaderRowIndex(externalRefsSheet);
+		if (headerRowIndex < 0) {
+			return purlByPackageId;
+		}
+
+		Row headerRow = externalRefsSheet.getRow(headerRowIndex);
+		if (headerRow == null) {
+			return purlByPackageId;
+		}
+
+		int packageIdCol = -1;
+		int categoryCol = -1;
+		int typeCol = -1;
+		int locatorCol = -1;
+		Iterator<Cell> iter = headerRow.cellIterator();
+		while (iter.hasNext()) {
+			Cell cell = iter.next();
+			String value = avoidNull(getCellData(cell)).toUpperCase().trim();
+			switch (value) {
+				case "PACKAGE ID":
+					packageIdCol = cell.getColumnIndex();
+					break;
+				case "CATEGORY":
+					categoryCol = cell.getColumnIndex();
+					break;
+				case "TYPE":
+					typeCol = cell.getColumnIndex();
+					break;
+				case "LOCATOR":
+					locatorCol = cell.getColumnIndex();
+					break;
+				default:
+					break;
+			}
+		}
+
+		if (packageIdCol < 0 || categoryCol < 0 || typeCol < 0 || locatorCol < 0) {
+			return purlByPackageId;
+		}
+
+		for (int rowIdx = headerRowIndex + 1; rowIdx < externalRefsSheet.getPhysicalNumberOfRows(); rowIdx++) {
+			Row row = externalRefsSheet.getRow(rowIdx);
+			if (row == null) {
+				continue;
+			}
+
+			String packageId = normalizeSpdxValue(getCellData(row.getCell(packageIdCol)));
+			String category = normalizeSpdxValue(getCellData(row.getCell(categoryCol)));
+			String type = normalizeSpdxValue(getCellData(row.getCell(typeCol)));
+			String locator = normalizeSpdxValue(getCellData(row.getCell(locatorCol)));
+			if (isSpdxEmptyValue(packageId) || isSpdxEmptyValue(locator)) {
+				continue;
+			}
+			if ("PACKAGE_MANAGER".equalsIgnoreCase(category) && "purl".equalsIgnoreCase(type)) {
+				purlByPackageId.put(packageId, locator);
+			}
+		}
+
+		return purlByPackageId;
+	}
+
+	private static String normalizeSpdxValue(String value) {
+		String normalized = avoidNull(value).trim();
+		return isSpdxEmptyValue(normalized) ? "" : normalized;
+	}
+
+	private static boolean isSpdxEmptyValue(String value) {
+		String normalized = avoidNull(value).trim();
+		return normalized.isEmpty() || "NONE".equalsIgnoreCase(normalized) || "NOASSERTION".equalsIgnoreCase(normalized);
+	}
+
+	private static int findSpdxExternalRefsHeaderRowIndex(Sheet sheet) {
+		if (sheet == null) {
+			return -1;
+		}
+
+		int maxRow = Math.min(sheet.getLastRowNum(), 20);
+		for (int rowIdx = 0; rowIdx <= maxRow; rowIdx++) {
+			Row row = sheet.getRow(rowIdx);
+			if (row == null) {
+				continue;
+			}
+
+			boolean hasPackageId = false;
+			boolean hasCategory = false;
+			boolean hasType = false;
+			boolean hasLocator = false;
+
+			for (Cell cell : row) {
+				String value = avoidNull(getCellData(cell)).trim().toUpperCase();
+				switch (value) {
+					case "PACKAGE ID":
+						hasPackageId = true;
+						break;
+					case "CATEGORY":
+						hasCategory = true;
+						break;
+					case "TYPE":
+						hasType = true;
+						break;
+					case "LOCATOR":
+						hasLocator = true;
+						break;
+					default:
+						break;
+				}
+			}
+
+			if (hasPackageId && hasCategory && hasType && hasLocator) {
+				return rowIdx;
+			}
+		}
+
+		return -1;
 	}
 
 	private static boolean hasSameLicense(OssComponents ossComponents, OssComponentsLicense subBean) {

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -11,6 +11,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -52,6 +53,7 @@ import org.springframework.context.annotation.PropertySources;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
+import com.github.packageurl.PackageURL;
 import com.opencsv.CSVParser;
 import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
@@ -1239,6 +1241,7 @@ public class ExcelUtil extends CoTopComponent {
 			String lastFilePath = "";
 			String lastBinaryName = "";
 			String lastExcludeYn = "";
+			boolean isSpdxSpreadsheet = isSPDXSpreadsheet(sheet);
 			Map<String, String> spdxPurlMap = getSpdxExternalRefPurlMap(sheet, workbook);
 			Map<String, Set<String>> spdxDependsOnMap = getSpdxDependsOnMap(sheet, workbook, spdxPurlMap);
 
@@ -1309,36 +1312,48 @@ public class ExcelUtil extends CoTopComponent {
     							bean.setOssVersion("");
     						}
     					}
+
+						bean.setOssNickName(nickNameCol < 0 ? "" : getCellData(row.getCell(nickNameCol)));
+						bean.setSpdxIdentifier(spdxIdentifierCol < 0 ? "" : getCellData(row.getCell(spdxIdentifierCol)));
     					
+    					String packageUrl = normalizeSpdxValue(packageUrlCol < 0 ? "" : getCellData(row.getCell(packageUrlCol)));
+    					if (isSpdxSpreadsheet && isSbomEmptyValue(packageUrl)) {
+    						packageUrl = normalizeSpdxValue(spdxPurlMap.get(bean.getSpdxIdentifier()));
+    					}
+    					bean.setPackageUrl(packageUrl);
+					
     					if (downloadLocationCol < 0) {
     						bean.setDownloadLocation("");
     					} else {
     						String downloadLocation = avoidNull(getCellData(row.getCell(downloadLocationCol))).trim().replaceAll("\\s", "");
-    						if (isSpdxEmptyValue(downloadLocation)) {
+    						if (isSbomEmptyValue(downloadLocation)) {
     							bean.setDownloadLocation("");
         					} else {
         						bean.setDownloadLocation(downloadLocation);
         					}
     					}
-    					
+    					if (isSpdxSpreadsheet && isSbomEmptyValue(bean.getDownloadLocation()) && !isSbomEmptyValue(bean.getPackageUrl())) {
+    						String generatedDownloadLocation = generateDownloadLocationFromPurl(bean.getPackageUrl());
+    						if (!isSbomEmptyValue(generatedDownloadLocation)) {
+    							bean.setDownloadLocation(generatedDownloadLocation);
+    						}
+    					}
+					
     					String homepage = homepageCol < 0 ? "" : avoidNull(getCellData(row.getCell(homepageCol))).trim().replaceAll("\\s", "");
-    					bean.setHomepage(isSpdxEmptyValue(homepage) ? "" : homepage);
+    					bean.setHomepage(isSbomEmptyValue(homepage) ? "" : homepage);
     					bean.setFilePath(pathOrFileCol < 0 ? "" : avoidNull(getCellData(row.getCell(pathOrFileCol))).trim().replaceAll("\t", ""));
     					bean.setBinaryName(binaryNameCol < 0 ? "" : avoidNull(getCellData(row.getCell(binaryNameCol))).trim().replaceAll("\t", ""));
-     
+					
     					if (downloadLocationCol < 0) {
     						bean.setCopyrightText("");
     					} else {
     						String copyrightText = getCellData(row.getCell(copyrightTextCol));
-        					if (isSpdxEmptyValue(copyrightText)) {
+        					if (isSbomEmptyValue(copyrightText)) {
         						bean.setCopyrightText("");
         					} else {
         						bean.setCopyrightText(copyrightText);
         					}
     					}
-    					
-    					bean.setOssNickName(nickNameCol < 0 ? "" : getCellData(row.getCell(nickNameCol)));
-    					bean.setSpdxIdentifier(spdxIdentifierCol < 0 ? "" : getCellData(row.getCell(spdxIdentifierCol)));
     				}
     				
     				duplicateCheckList.add(avoidNull(bean.getOssName()) + "-" + avoidNull(bean.getOssVersion()) + "-" + avoidNull(bean.getLicenseName()));
@@ -1355,11 +1370,11 @@ public class ExcelUtil extends CoTopComponent {
     				String licenseValue = "";
     				if (licenseCol > 0) {
     					String licenseConcluded = normalizeSpdxValue(getCellData(row.getCell(licenseCol)));
-    					if (isSPDXSpreadsheet(sheet) && isSpdxEmptyValue(licenseConcluded)) {
+    					if (isSpdxSpreadsheet && isSbomEmptyValue(licenseConcluded)) {
     						licenseConcluded = getSpdxDeclaredLicenseValue(headerRow, row);
     					}
     					licenseValue = licenseConcluded;
-        				if (isSPDXSpreadsheet(sheet) && (licenseConcluded.contains("AND") || licenseConcluded.contains("OR"))) {
+        				if (isSpdxSpreadsheet && (licenseConcluded.contains("AND") || licenseConcluded.contains("OR"))) {
         					String licenseComment = getCellData(row.getCell(commentCol));
         					String comment = "";
 
@@ -1385,7 +1400,7 @@ public class ExcelUtil extends CoTopComponent {
     				OssComponentsLicense subBean = new OssComponentsLicense();
     				if (licenseCol > 0) {
     					String licenseName = licenseValue;
-        				if (isSPDXSpreadsheet(sheet)){
+        				if (isSpdxSpreadsheet){
         					licenseName = StringUtil.join(Arrays.asList(licenseName.split("\\(|\\)| ")).stream().filter(l -> !isEmpty(l) && !l.equals("AND") && !l.equals("OR")).collect(Collectors.toList()), ",");
         				} else if (licenseName.contains(",")) {
         					licenseName = StringUtil.join(Arrays.asList(licenseName.split(",")).stream().filter(l -> !isEmpty(l)).collect(Collectors.toList()), ",");
@@ -1435,12 +1450,6 @@ public class ExcelUtil extends CoTopComponent {
     					bean.setFilePath(_replaceFilePath);
     				}
     				
-    				String packageUrl = normalizeSpdxValue(packageUrlCol < 0 ? "" : getCellData(row.getCell(packageUrlCol)));
-    				if (isSPDXSpreadsheet(sheet) && isSpdxEmptyValue(packageUrl)) {
-    					packageUrl = normalizeSpdxValue(spdxPurlMap.get(bean.getSpdxIdentifier()));
-    				}
-    				bean.setPackageUrl(packageUrl);
-    				
     				// empty row check
     				if (isEmpty(bean.getOssName()) && isEmpty(bean.getOssVersion()) && isEmpty(subBean.getLicenseName()) && isEmpty(bean.getBinaryName()) && isEmpty(bean.getFilePath())
     						&& isEmpty(bean.getDownloadLocation()) && isEmpty(bean.getHomepage()) && isEmpty(bean.getCopyrightText())) {
@@ -1458,7 +1467,7 @@ public class ExcelUtil extends CoTopComponent {
     				bean.setExcludeYn(avoidNull(bean.getExcludeYn(), CoConstDef.FLAG_NO));
     
 					String dependencies = "";
-					if (!isSPDXSpreadsheet(sheet)) {
+					if (!isSpdxSpreadsheet) {
     					dependencies = dependenciesCol < 0 ? "" : avoidNull(getCellData(row.getCell(dependenciesCol))).trim().replaceAll("\t", "");
 					} else {
     					Set<String> dependsOnUrls = spdxDependsOnMap.get(bean.getSpdxIdentifier());
@@ -1620,7 +1629,7 @@ public class ExcelUtil extends CoTopComponent {
 			String category = normalizeSpdxValue(getCellData(row.getCell(categoryCol)));
 			String type = normalizeSpdxValue(getCellData(row.getCell(typeCol)));
 			String locator = normalizeSpdxValue(getCellData(row.getCell(locatorCol)));
-			if (isSpdxEmptyValue(packageId) || isSpdxEmptyValue(locator)) {
+			if (isSbomEmptyValue(packageId) || isSbomEmptyValue(locator)) {
 				continue;
 			}
 			if ("PACKAGE_MANAGER".equalsIgnoreCase(category) && "purl".equalsIgnoreCase(type)) {
@@ -1633,12 +1642,101 @@ public class ExcelUtil extends CoTopComponent {
 
 	private static String normalizeSpdxValue(String value) {
 		String normalized = avoidNull(value).trim();
-		return isSpdxEmptyValue(normalized) ? "" : normalized;
+		return isSbomEmptyValue(normalized) ? "" : normalized;
 	}
 
-	private static boolean isSpdxEmptyValue(String value) {
+	private static boolean isSbomEmptyValue(String value) {
 		String normalized = avoidNull(value).trim();
 		return normalized.isEmpty() || "NONE".equalsIgnoreCase(normalized) || "NOASSERTION".equalsIgnoreCase(normalized);
+	}
+
+	private static String generateDownloadLocationFromPurl(String purlValue) {
+		if (StringUtils.isBlank(purlValue)) {
+			return "";
+		}
+
+		try {
+			PackageURL purl = new PackageURL(purlValue);
+			String type = purl.getType();
+			String namespace = purl.getNamespace();
+			String name = purl.getName();
+			if (StringUtils.isBlank(type) || StringUtils.isBlank(name)) {
+				return "";
+			}
+
+			Map<String, String> qualifiers = purl.getQualifiers();
+			String downloadUrl = qualifiers != null ? qualifiers.get("download_url") : null;
+			if (StringUtils.isNotBlank(downloadUrl)) {
+				return decodePurlValue(downloadUrl);
+			}
+
+			String repositoryUrl = qualifiers != null ? qualifiers.get("repository_url") : null;
+			String resolvedRepositoryUrl = StringUtils.isNotBlank(repositoryUrl) ? decodePurlValue(repositoryUrl) : "";
+			String normalizedRepositoryUrl = StringUtils.removeEnd(resolvedRepositoryUrl.trim(), "/");
+
+			switch (type) {
+				case "github":
+					return "https://github.com/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+				case "npm":
+					if (StringUtils.startsWith(namespace, "@")) {
+						return "https://www.npmjs.com/package/" + namespace + "/" + name;
+					}
+					return "https://www.npmjs.com/package/" + name;
+				case "pypi":
+					return "https://pypi.org/project/" + name;
+				case "maven":
+						if (StringUtils.isNotBlank(normalizedRepositoryUrl)) {
+							return normalizedRepositoryUrl;
+						}
+						if (StringUtils.isNotBlank(namespace)) {
+							return "https://mvnrepository.com/artifact/" + namespace + "/" + name;
+						}
+						return "https://mvnrepository.com/artifact/" + name;
+				case "cocoapods":
+					return "https://cocoapods.org/pods/" + name;
+				case "gem":
+					return "https://rubygems.org/gems/" + name;
+				case "golang":
+					return "https://pkg.go.dev/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+				case "cargo":
+					return "https://crates.io/crates/" + name;
+				case "nuget":
+					return "https://nuget.org/packages/" + name;
+				case "bitbucket":
+					return "https://bitbucket.org/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+				case "composer":
+					return "https://packagist.org/packages/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+				case "cran":
+					return "https://cran.r-project.org/web/packages/" + name + "/index.html";
+				case "hackage":
+					return "https://hackage.haskell.org/package/" + name;
+				case "huggingface":
+					return "https://huggingface.co/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+				case "git":
+					return "https://" + StringUtils.trimToEmpty(namespace) + "/" + name;
+				case "cpan":
+				case "docker":
+				case "yocto":
+				case "generic":
+				default:
+					return "";
+			}
+		} catch (Exception e) {
+			log.debug("Failed to generate download location from purl: {}", purlValue, e);
+			return "";
+		}
+	}
+
+	private static String decodePurlValue(String value) {
+		if (StringUtils.isBlank(value)) {
+			return "";
+		}
+
+		try {
+			return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+		} catch (Exception e) {
+			return value;
+		}
 	}
 
 	private static Map<String, Set<String>> getSpdxDependsOnMap(Sheet sheet, Workbook workbook, Map<String, String> spdxPurlMap) {
@@ -1697,12 +1795,12 @@ public class ExcelUtil extends CoTopComponent {
 			String spdxIdA = normalizeSpdxValue(getCellData(row.getCell(spdxIdACol)));
 			String relation = normalizeSpdxValue(getCellData(row.getCell(relationshipCol)));
 			String spdxIdB = normalizeSpdxValue(getCellData(row.getCell(spdxIdBCol)));
-			if (isSpdxEmptyValue(spdxIdA) || isSpdxEmptyValue(spdxIdB) || !"DEPENDS_ON".equalsIgnoreCase(relation)) {
+			if (isSbomEmptyValue(spdxIdA) || isSbomEmptyValue(spdxIdB) || !"DEPENDS_ON".equalsIgnoreCase(relation)) {
 				continue;
 			}
 
 			String dependencyPurl = normalizeSpdxValue(spdxPurlMap.get(spdxIdB));
-			if (isSpdxEmptyValue(dependencyPurl)) {
+			if (isSbomEmptyValue(dependencyPurl)) {
 				continue;
 			}
 

--- a/src/main/java/oss/fosslight/util/ExcelUtil.java
+++ b/src/main/java/oss/fosslight/util/ExcelUtil.java
@@ -1676,14 +1676,17 @@ public class ExcelUtil extends CoTopComponent {
 
 			switch (type) {
 				case "github":
-					return "https://github.com/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+						if (StringUtils.isBlank(namespace)) {
+							return "";
+						}
+						return "https://github.com/" + namespace + "/" + name;
 				case "npm":
-					if (StringUtils.startsWith(namespace, "@")) {
-						return "https://www.npmjs.com/package/" + namespace + "/" + name;
-					}
-					return "https://www.npmjs.com/package/" + name;
+						if (StringUtils.startsWith(namespace, "@")) {
+							return "https://www.npmjs.com/package/" + namespace + "/" + name;
+						}
+						return "https://www.npmjs.com/package/" + name;
 				case "pypi":
-					return "https://pypi.org/project/" + name;
+						return "https://pypi.org/project/" + name;
 				case "maven":
 						if (StringUtils.isNotBlank(normalizedRepositoryUrl)) {
 							return normalizedRepositoryUrl;
@@ -1693,27 +1696,42 @@ public class ExcelUtil extends CoTopComponent {
 						}
 						return "https://mvnrepository.com/artifact/" + name;
 				case "cocoapods":
-					return "https://cocoapods.org/pods/" + name;
+						return "https://cocoapods.org/pods/" + name;
 				case "gem":
-					return "https://rubygems.org/gems/" + name;
+						return "https://rubygems.org/gems/" + name;
 				case "golang":
-					return "https://pkg.go.dev/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+						if (StringUtils.isBlank(namespace)) {
+							return "";
+						}
+						return "https://pkg.go.dev/" + namespace + "/" + name;
 				case "cargo":
-					return "https://crates.io/crates/" + name;
+						return "https://crates.io/crates/" + name;
 				case "nuget":
-					return "https://nuget.org/packages/" + name;
+						return "https://nuget.org/packages/" + name;
 				case "bitbucket":
-					return "https://bitbucket.org/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+						if (StringUtils.isBlank(namespace)) {
+							return "";
+						}
+						return "https://bitbucket.org/" + namespace + "/" + name;
 				case "composer":
-					return "https://packagist.org/packages/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+						if (StringUtils.isBlank(namespace)) {
+							return "";
+						}
+						return "https://packagist.org/packages/" + namespace + "/" + name;
 				case "cran":
-					return "https://cran.r-project.org/web/packages/" + name + "/index.html";
+						return "https://cran.r-project.org/web/packages/" + name + "/index.html";
 				case "hackage":
-					return "https://hackage.haskell.org/package/" + name;
+						return "https://hackage.haskell.org/package/" + name;
 				case "huggingface":
-					return "https://huggingface.co/" + StringUtils.trimToEmpty(namespace) + "/" + name;
+						if (StringUtils.isBlank(namespace)) {
+							return "";
+						}
+						return "https://huggingface.co/" + namespace + "/" + name;
 				case "git":
-					return "https://" + StringUtils.trimToEmpty(namespace) + "/" + name;
+						if (StringUtils.isBlank(namespace)) {
+							return "";
+						}
+						return "https://" + namespace + "/" + name;
 				case "cpan":
 				case "docker":
 				case "yocto":

--- a/src/main/resources/templates/project/common-script.html
+++ b/src/main/resources/templates/project/common-script.html
@@ -3689,19 +3689,25 @@ var com_fn = {
   									if (checkFlag) {
   										checkFlag = false;
  										sheetTr += '<td><input type="checkbox" class="sheetRowCheckBox mr-2" name="sheetCheck">' + sheetName + '</td>';
+ 										var defaultTabNm = "SRC";
+ 										if (!isExcel && (sheetName.indexOf("PACKAGE INFO") > -1 || sheetName.indexOf("PER FILE INFO") > -1)) {
+ 											defaultTabNm = "DEP";
+ 										}
+										
  										for (var j = 0; j < checkTabNms.length; j++) {
+ 											var radioId = "sheet" + result[1][i].no + "_" + checkTabNms[j];
  											if (isExcel) {
  												if (sheetName.indexOf(checkTabNms[j]) > -1) {
  	 												checkFlag = true;
- 													sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="sheet' + result[1][i].no + '" style="margin-left: -0.5rem !important;" class="form-check-input" checked></td>';
- 	 											} else {
- 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="sheet' + result[1][i].no + '" style="margin-left: -0.5rem !important;" class="form-check-input"></td>';
- 	 											}
- 											} else {
- 												if ("SRC" == checkTabNms[j]) {
- 													sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="sheet' + result[1][i].no + '" style="margin-left: -0.5rem !important;" class="form-check-input" checked></td>';
+ 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="' + radioId + '" style="margin-left: -0.5rem !important;" class="form-check-input" checked></td>';
  												} else {
- 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="sheet' + result[1][i].no + '" style="margin-left: -0.5rem !important;" class="form-check-input"></td>';
+ 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="' + radioId + '" style="margin-left: -0.5rem !important;" class="form-check-input"></td>';
+ 												}
+ 											} else {
+ 												if (defaultTabNm == checkTabNms[j]) {
+ 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="' + radioId + '" style="margin-left: -0.5rem !important;" class="form-check-input" checked></td>';
+ 												} else {
+ 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="' + radioId + '" style="margin-left: -0.5rem !important;" class="form-check-input"></td>';
  												}
  											}
 										}

--- a/src/main/resources/templates/project/common-script.html
+++ b/src/main/resources/templates/project/common-script.html
@@ -3690,24 +3690,23 @@ var com_fn = {
   										checkFlag = false;
  										sheetTr += '<td><input type="checkbox" class="sheetRowCheckBox mr-2" name="sheetCheck">' + sheetName + '</td>';
  										var defaultTabNm = "SRC";
- 										if (!isExcel && (sheetName.indexOf("PACKAGE INFO") > -1 || sheetName.indexOf("PER FILE INFO") > -1)) {
+ 										if (sheetName.indexOf("PACKAGE INFO") > -1 || sheetName.indexOf("PER FILE INFO") > -1) {
  											defaultTabNm = "DEP";
  										}
 										
  										for (var j = 0; j < checkTabNms.length; j++) {
- 											var radioId = "sheet" + result[1][i].no + "_" + checkTabNms[j];
  											if (isExcel) {
  												if (sheetName.indexOf(checkTabNms[j]) > -1) {
  	 												checkFlag = true;
- 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="' + radioId + '" style="margin-left: -0.5rem !important;" class="form-check-input" checked></td>';
+ 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="sheet' + result[1][i].no + '" style="margin-left: -0.5rem !important;" class="form-check-input" checked></td>';
  												} else {
- 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="' + radioId + '" style="margin-left: -0.5rem !important;" class="form-check-input"></td>';
+ 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="sheet' + result[1][i].no + '" style="margin-left: -0.5rem !important;" class="form-check-input"></td>';
  												}
  											} else {
  												if (defaultTabNm == checkTabNms[j]) {
- 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="' + radioId + '" style="margin-left: -0.5rem !important;" class="form-check-input" checked></td>';
+ 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="sheet' + result[1][i].no + '" style="margin-left: -0.5rem !important;" class="form-check-input" checked></td>';
  												} else {
- 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="' + radioId + '" style="margin-left: -0.5rem !important;" class="form-check-input"></td>';
+ 	 												sheetTr += '<td class="text-center"><input type="radio" name="sheetNameSelect' + result[1][i].no + '" value="' + result[1][i].no + '_' + checkTabNms[j] + '" id="sheet' + result[1][i].no + '" style="margin-left: -0.5rem !important;" class="form-check-input"></td>';
  												}
  											}
 										}

--- a/src/test/java/oss/fosslight/controller/ProjectSpdxJsonUploadIntegrationTest.java
+++ b/src/test/java/oss/fosslight/controller/ProjectSpdxJsonUploadIntegrationTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -19,7 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.file.Files;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 class ProjectSpdxJsonUploadIntegrationTest {
     private static final String USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.107 Safari/537.36";
-    private static final String SPDX_JSON_PATH = "/Users/hyeinlee/Documents/_WORK/FOSSLight_Hub_2.0_For_Dev/6. spdx_cyclonedx/short_17932_SPDXRdf-ThinQ2.0_Server-1.8.23.json";
+    private static final String SPDX_JSON_RESOURCE = "fixtures/spdx/short-SPDXRdf-FOSSLightHub.json";
 
     @Autowired
     private MockMvc mockMvc;
@@ -46,12 +46,15 @@ class ProjectSpdxJsonUploadIntegrationTest {
     void spdxJsonUploadAndReadDepData() throws Exception {
         String prjId = createProject();
 
-        byte[] jsonBytes = Files.readAllBytes(new FileSystemResource(SPDX_JSON_PATH).getFile().toPath());
+        byte[] jsonBytes;
+        try (InputStream inputStream = new ClassPathResource(SPDX_JSON_RESOURCE).getInputStream()) {
+            jsonBytes = inputStream.readAllBytes();
+        }
 
         MockHttpServletResponse uploadResponse = mockMvc.perform(
                         multipart("/project/csvFile")
                                 .file("myfile", jsonBytes)
-                                .param("registFileId", "85853")
+                                .param("registFileId", "")
                                 .header("user-agent", USER_AGENT)
                                 .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isOk())

--- a/src/test/java/oss/fosslight/controller/ProjectSpdxJsonUploadIntegrationTest.java
+++ b/src/test/java/oss/fosslight/controller/ProjectSpdxJsonUploadIntegrationTest.java
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2026
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package oss.fosslight.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc(addFilters = false)
+@SpringBootTest
+@WithMockUser(username = "user", roles = {"USER"})
+@Transactional
+class ProjectSpdxJsonUploadIntegrationTest {
+    private static final String USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.107 Safari/537.36";
+    private static final String SPDX_JSON_PATH = "/Users/hyeinlee/Documents/_WORK/FOSSLight_Hub_2.0_For_Dev/6. spdx_cyclonedx/short_17932_SPDXRdf-ThinQ2.0_Server-1.8.23.json";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("SPDX json upload should load DEP data with purl and declared-license fallback")
+    void spdxJsonUploadAndReadDepData() throws Exception {
+        String prjId = createProject();
+
+        byte[] jsonBytes = Files.readAllBytes(new FileSystemResource(SPDX_JSON_PATH).getFile().toPath());
+
+        MockHttpServletResponse uploadResponse = mockMvc.perform(
+                        multipart("/project/csvFile")
+                                .file("myfile", jsonBytes)
+                                .param("registFileId", "85853")
+                                .header("user-agent", USER_AGENT)
+                                .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse();
+
+        List<Object> uploadResult = new ObjectMapper().readValue(uploadResponse.getContentAsString(), List.class);
+        List<Map<String, Object>> uploadFiles = (List<Map<String, Object>>) uploadResult.get(0);
+        String fileSeq = String.valueOf(uploadFiles.get(0).get("fileSeq"));
+
+        HashMap<String, Object> request = new HashMap<>();
+        request.put("readType", "13");
+        request.put("prjId", prjId);
+        request.put("sheetNums", List.of("1_DEP", "4_DEP"));
+        request.put("fileSeq", fileSeq);
+        request.put("depMainData", "[]");
+        request.put("srcMainData", "[]");
+        request.put("binMainData", "[]");
+
+        MockHttpServletResponse sheetResponse = mockMvc.perform(
+                        post("/project/getIdentificationSheetData")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(new ObjectMapper().writeValueAsString(request))
+                                .header("user-agent", USER_AGENT))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse();
+
+        Map<String, Object> wrapper = new ObjectMapper().readValue(sheetResponse.getContentAsString(), Map.class);
+        Map<String, Object> resultData = (Map<String, Object>) wrapper.get("resultData");
+        List<Map<String, Object>> rows = (List<Map<String, Object>>) resultData.get("rows");
+
+        assertThat(rows).isNotEmpty();
+        assertThat(rows.stream().map(r -> String.valueOf(r.getOrDefault("purl", ""))).anyMatch(v -> !v.isBlank())).isTrue();
+        assertThat(rows.stream().anyMatch(r -> {
+            String licenseName = String.valueOf(r.getOrDefault("licenseName", ""));
+            return !licenseName.isBlank() && !"NOASSERTION".equalsIgnoreCase(licenseName);
+        })).isTrue();
+    }
+
+    private String createProject() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(post("/project/saveAjax")
+                        .param("copy", "false")
+                        .param("prjName", UUID.randomUUID().toString())
+                        .param("prjVersion", "v1")
+                        .param("noticeType", "10")
+                        .param("distributionType", "10")
+                        .param("comment", "<p>test</p>")
+                        .param("osType", "100")
+                        .param("priority", "30")
+                        .param("statusRequestYn", "")
+                        .param("listId", "")
+                        .param("publicYn", "Y")
+                        .param("secMailYn", "Y")
+                        .param("networkServerType", "N")
+                        .param("prjDivision", "")
+                        .param("prjUserId", "user")
+                        .param("prjId", "")
+                        .param("prjDivision", "")
+                        .param("distributeTarget", "NA")
+                        .param("prjModelJson", "[]")
+                        .header("user-agent", USER_AGENT)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse();
+
+        Map<String, Map<String, String>> responseMap = new ObjectMapper().readValue(response.getContentAsString(), Map.class);
+        return responseMap.get("resultData").get("prjId");
+    }
+}

--- a/src/test/resources/fixtures/spdx/short-SPDXRdf-FOSSLightHub.json
+++ b/src/test/resources/fixtures/spdx/short-SPDXRdf-FOSSLightHub.json
@@ -192,13 +192,29 @@
       "versionInfo": ""
     },
     {
-      "SPDXID": "SPDXRef-Package-MultiLicense",
-      "name": "dual-licensed-lib",
-      "downloadLocation": "https://github.com/example/dual-licensed-lib",
+      "SPDXID": "SPDXRef-Package-173827644",
+      "copyrightText": "Copyright (C) 1999- Shigeru Chiba.",
+      "downloadLocation": "https://github.com/jboss-javassist/javassist",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org.javassist/javassist@3.20.0-GA",
+          "referenceType": "purl"
+        }
+      ],
       "filesAnalyzed": false,
-      "licenseConcluded": "MIT AND Apache-2.0",
-      "licenseDeclared": "MIT AND Apache-2.0",
-      "copyrightText": "Copyright (c) 2024 Example Contributors"
+      "homepage": "http://www.javassist.org",
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "(LGPL-2.1 OR MPL-1.1 OR Apache-2.0)",
+      "licenseInfoFromFiles": [
+        "LGPL-2.1",
+        "MPL-1.1",
+        "Apache-2.0"
+      ],
+      "name": "javassist",
+      "originator": "Organization: \"\"",
+      "supplier": "Person: \"\"",
+      "versionInfo": ""
     }
   ],
   "relationships": [

--- a/src/test/resources/fixtures/spdx/short-SPDXRdf-FOSSLightHub.json
+++ b/src/test/resources/fixtures/spdx/short-SPDXRdf-FOSSLightHub.json
@@ -1,0 +1,261 @@
+{
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "FOSSLight Hub (Enterprise)",
+  "documentNamespace": "http://osc.lge.com/SPDXRef-FOSSLightHub(Enterprise)-202609090244",
+  "documentDescribes": [],
+  "creationInfo": {
+    "created": "2026-09-09T14:44:34Z",
+    "creators": [
+      "Person: kyungsun.min (kyungsun.min@lge.com)",
+      "Organization: LG Electronics (opensource@lge.com)",
+      "Tool: SPDXTools-2.2.2"
+    ],
+    "licenseListVersion": "3.10"
+  },
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-173827726",
+      "copyrightText": "Copyright 2011-2016 the original author or authors",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org.springframework.security/spring-security-crypto@5.7.11",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": "https://spring.io/spring-security",
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "licenseInfoFromFiles": [
+        "Apache-2.0"
+      ],
+      "name": "spring-security-crypto",
+      "originator": "Organization: \"\"",
+      "supplier": "Person: \"\"",
+      "versionInfo": ""
+    },
+    {
+      "SPDXID": "SPDXRef-Package-173827683",
+      "copyrightText": "Copyright (c) 1998-2004, Drew Davidson and Luke Blanshard",
+      "downloadLocation": "https://github.com/jkuhnert/ognl",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/ognl/ognl@3.1.26",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": "http://mvnrepository.com/artifact/ognl/ognl",
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "licenseInfoFromFiles": [
+        "BSD-3-Clause"
+      ],
+      "name": "ognl",
+      "originator": "Organization: \"\"",
+      "supplier": "Person: \"\"",
+      "versionInfo": ""
+    },
+    {
+      "SPDXID": "SPDXRef-Package-173827549",
+      "copyrightText": "Copyright (c) 2005, 2009, 2012, 2018 Oracle and/or its affiliates. ",
+      "downloadLocation": "https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": "https://projects.eclipse.org/projects/ee4j.ca",
+      "licenseConcluded": "EPL-2.0",
+      "licenseDeclared": "(GPL-2.0-with-classpath-exception OR EPL-2.0)",
+      "licenseInfoFromFiles": [
+        "GPL-2.0-with-classpath-exception",
+        "EPL-2.0"
+      ],
+      "name": "Jakarta Annotations API",
+      "originator": "Organization: \"\"",
+      "supplier": "Person: \"\"",
+      "versionInfo": ""
+    },
+    {
+      "SPDXID": "SPDXRef-Package-173827624",
+      "copyrightText": "Copyright (c) 2008-2020 Oracle and/or its affiliates",
+      "downloadLocation": "https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org.hibernate/hibernate-core@5.6.15.Final",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": "https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core",
+      "licenseConcluded": "LGPL-2.1",
+      "licenseDeclared": "LGPL-2.1",
+      "licenseInfoFromFiles": [
+        "LGPL-2.1"
+      ],
+      "name": "hibernate-core",
+      "originator": "Organization: \"\"",
+      "supplier": "Person: \"\"",
+      "versionInfo": ""
+    },
+    {
+      "SPDXID": "SPDXRef-Package-173827698",
+      "copyrightText": "Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)",
+      "downloadLocation": "https://mvnrepository.com/artifact/org.slf4j/jul-to-slf4j",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": "http://www.slf4j.org",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "licenseInfoFromFiles": [
+        "MIT"
+      ],
+      "name": "slf4J",
+      "originator": "Organization: \"\"",
+      "supplier": "Person: \"\"",
+      "versionInfo": ""
+    },
+    {
+      "SPDXID": "SPDXRef-File-173827750",
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "licenseConcluded": "LicenseRef-LGE-Proprietary-License",
+      "licenseDeclared": "LicenseRef-LGE-Proprietary-License",
+      "licenseInfoFromFiles": [
+        "LGE-Proprietary-License"
+      ],
+      "name": "-",
+      "originator": "Organization: \"\"",
+      "supplier": "Person: \"\"",
+      "versionInfo": ""
+    },
+    {
+      "SPDXID": "SPDXRef-Package-173827687",
+      "copyrightText": "Copyright (c) 2010 the V8 project authors\nCopyright (c) 1997, 1998 Sun Microsystems, Inc.",
+      "downloadLocation": "https://mvnrepository.com/artifact/org.mozilla/rhino",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org.mozilla/rhino@1.7.7.2",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": "https://mvnrepository.com/artifact/org.mozilla/rhino",
+      "licenseConcluded": "MPL-2.0",
+      "licenseDeclared": "MPL-2.0",
+      "licenseInfoFromFiles": [
+        "MPL-2.0"
+      ],
+      "name": "org.mozilla:rhino",
+      "originator": "Organization: \"\"",
+      "supplier": "Person: \"\"",
+      "versionInfo": ""
+    },
+    {
+      "SPDXID": "SPDXRef-Package-173827599",
+      "copyrightText": "Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors",
+      "downloadLocation": "https://mvnrepository.com/artifact/com.itextpdf/io",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/com.itextpdf/io@7.2.3",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": "https://mvnrepository.com/artifact/com.itextpdf/io",
+      "licenseConcluded": "AGPL-3.0",
+      "licenseDeclared": "AGPL-3.0",
+      "licenseInfoFromFiles": [
+        "AGPL-3.0"
+      ],
+      "name": "com.itextpdf:io",
+      "originator": "Organization: \"\"",
+      "supplier": "Person: \"\"",
+      "versionInfo": ""
+    },
+    {
+      "SPDXID": "SPDXRef-Package-MultiLicense",
+      "name": "dual-licensed-lib",
+      "downloadLocation": "https://github.com/example/dual-licensed-lib",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT AND Apache-2.0",
+      "licenseDeclared": "MIT AND Apache-2.0",
+      "copyrightText": "Copyright (c) 2024 Example Contributors"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-173827687"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-File-173827750"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-173827549"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-173827624"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-173827683"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-173827698"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-173827599"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-173827726"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-173827683",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-File-173827750"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-173827549",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-173827683"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-MultiLicense"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR updates the SPDX/CycloneDX upload and load flow to match the project specification and improve handling of report files.

The change aligns the implementation with the documented rules for SPDX and CycloneDX loading, including license fallback behavior when `licenseConcluded` is empty and validation for uploaded report files.

## Changes

- Updated SPDX/CycloneDX upload validation logic
- Adjusted project script handling to validate report files more consistently
- Aligned behavior with the documented load spec for SPDX and CycloneDX inputs
- Added/updated project load documentation for SPDX/CycloneDX and YAML-based metadata
- Clarified SPDX fallback behavior when the concluded license is empty

## Why

The project’s spec defines expected behavior for SPDX and CycloneDX file loading, but the implementation and validation flow needed to be aligned with those requirements. This change brings the code in line with the documented specification and reduces mismatches during file upload and processing.

## Notes

This PR is focused on matching the specification and tightening report validation rather than introducing unrelated functional changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing SPDX spreadsheets with package, file, license, external reference, and dependency information.
  - SPDX spreadsheet upload sheets now select the appropriate package or file view by default.
  - Dependency relationships are resolved more accurately using component references.

- **Bug Fixes**
  - Improved SPDX JSON relationship handling by retaining valid package and document relationships while filtering unknown references.
  - Prevented malformed download links when package namespace information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->