### PR TITLE
bugfix: Add securityComments field to SecurityExportItemDto

### DIFF
--- a/src/main/java/oss/fosslight/api/dto/SecurityExportItemDto.java
+++ b/src/main/java/oss/fosslight/api/dto/SecurityExportItemDto.java
@@ -18,6 +18,7 @@ public class SecurityExportItemDto {
     private String vulnerabilityLink;
     private String officialPatchLink;
     private String securityPatchLink;
+    private String securityComments;
     private String cpeName;
     private String verStartEndRange;
     private String gridId;
@@ -35,6 +36,7 @@ public class SecurityExportItemDto {
                 .vulnerabilityLink(toEmpty(item.getVulnerabilityLink()))
                 .officialPatchLink(toEmpty(item.getOfficialPatchLink()))
                 .securityPatchLink(toEmpty(item.getSecurityPatchLink()))
+                .securityComments(toEmpty(item.getSecurityComments()))
                 .cpeName(toEmpty(item.getCpeName()))
                 .verStartEndRange(toEmpty(item.getVerStartEndRange()))
                 .gridId(toEmpty(item.getGridId()))


### PR DESCRIPTION
## Description
securityComments field was missing.
Add comment filed to response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security export data now includes security comments when available.
  * Missing security comments are represented as blank values for consistent exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->